### PR TITLE
YTI-1351: Fix adding links to notes

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/importapi/NtrfMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/importapi/NtrfMapper.java
@@ -1869,8 +1869,10 @@ public class NtrfMapper {
                     if (linkRef.startsWith("href:")) {
                         linkRef = linkRef.substring(5);
                     }
-                    noteString = noteString.trim().concat("<a href='" + linkRef + "' data-type='external'>"
-                            + escapeStringContent(lc.getContent().get(0).toString().trim()) + "</a>");
+
+                    noteString = noteString.concat("<a href='" + linkRef + "' data-type='external'>"
+                            + escapeStringContent(lc.getContent().get(0).toString().trim() + "</a>"));
+
                     logger.info("Add LINK:" + linkRef);
                 }
             } else if (de instanceof JAXBElement) {


### PR DESCRIPTION
Remove trim() from note string when adding link to the text.