### PR TITLE
YTI-1151 Escape xml characters

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/importapi/NtrfMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/importapi/NtrfMapper.java
@@ -2166,6 +2166,7 @@ public class NtrfMapper {
         Escaper escaper = Escapers.builder()
                 .addEscape('&', "&amp;")
                 .addEscape('\"', "&quot;")
+                .addEscape('\'', "&apos;")
                 .addEscape('<', "&lt;")
                 .addEscape('>', "&gt;")
                 .build();


### PR DESCRIPTION
While unmarshalling from xml to java classes the characters will get unescaped (e.g. `&amp;` -> &). These are re-escaped in the ntrf mapper, because in the frontend content is interpreted as xml.