### PR TITLE
YTI-448 add jaxb runtime dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     implementation 'com.google.guava:guava:30.1.1-jre'
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.1'
     implementation 'com.sun.xml.bind:jaxb-impl:3.0.2'
-    implementation 'com.sun.xml.bind:jaxb-core:2.3.0'
+    implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.2'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
     implementation 'jakarta.activation:jakarta.activation-api:2.0.1'
 


### PR DESCRIPTION
Replace jaxb core with jaxb runtime dependency. Xml import didn't work with the first one