### PR TITLE
add /counts endpoint

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+import fi.vm.yti.terminology.api.frontend.searchdto.*;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,10 +23,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import fi.vm.yti.security.AuthenticatedUserProvider;
 import fi.vm.yti.security.YtiUser;
-import fi.vm.yti.terminology.api.frontend.searchdto.ConceptSearchRequest;
-import fi.vm.yti.terminology.api.frontend.searchdto.ConceptSearchResponse;
-import fi.vm.yti.terminology.api.frontend.searchdto.TerminologySearchRequest;
-import fi.vm.yti.terminology.api.frontend.searchdto.TerminologySearchResponse;
 import fi.vm.yti.terminology.api.model.termed.GenericDeleteAndSave;
 import fi.vm.yti.terminology.api.model.termed.GenericNode;
 import fi.vm.yti.terminology.api.model.termed.GenericNodeInlined;
@@ -313,5 +310,14 @@ public class FrontendController {
     TerminologySearchResponse searchTerminology(@RequestBody TerminologySearchRequest request) {
         logger.info("POST /searchTerminology requested with query: " + request.toString());
         return elasticSearchService.searchTerminology(request);
+    }
+
+    @Operation(summary = "Get counts", description = "List counts of concepts and vocabularies grouped by different search results")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "List counts of concepts and vocabularies grouped by different search results")
+    @ApiResponse(responseCode = "200", description = "Counts response container object as JSON")
+    @RequestMapping(value = "/counts", method = GET, produces = APPLICATION_JSON_VALUE)
+    CountSearchResponse getCounts() {
+        logger.info("GET /counts requested");
+        return elasticSearchService.getCounts();
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendElasticSearchService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendElasticSearchService.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import fi.vm.yti.terminology.api.frontend.elasticqueries.CountQueryFactory;
+import fi.vm.yti.terminology.api.frontend.searchdto.*;
 import org.apache.http.HttpHost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
@@ -31,11 +33,6 @@ import fi.vm.yti.security.AuthenticatedUserProvider;
 import fi.vm.yti.terminology.api.frontend.elasticqueries.ConceptQueryFactory;
 import fi.vm.yti.terminology.api.frontend.elasticqueries.DeepConceptQueryFactory;
 import fi.vm.yti.terminology.api.frontend.elasticqueries.TerminologyQueryFactory;
-import fi.vm.yti.terminology.api.frontend.searchdto.ConceptSearchRequest;
-import fi.vm.yti.terminology.api.frontend.searchdto.ConceptSearchResponse;
-import fi.vm.yti.terminology.api.frontend.searchdto.DeepSearchHitListDTO;
-import fi.vm.yti.terminology.api.frontend.searchdto.TerminologySearchRequest;
-import fi.vm.yti.terminology.api.frontend.searchdto.TerminologySearchResponse;
 import fi.vm.yti.terminology.api.util.Parameters;
 import static fi.vm.yti.terminology.api.util.ElasticRequestUtils.responseContentAsString;
 
@@ -53,6 +50,7 @@ public class FrontendElasticSearchService {
     private final AuthenticatedUserProvider userProvider;
     private final TerminologyQueryFactory terminologyQueryFactory;
     private final DeepConceptQueryFactory deepConceptQueryFactory;
+    private final CountQueryFactory countQueryFactory;
     private final ConceptQueryFactory conceptQueryFactory;
 
     @Autowired
@@ -73,6 +71,7 @@ public class FrontendElasticSearchService {
         this.terminologyQueryFactory = new TerminologyQueryFactory(objectMapper);
         this.deepConceptQueryFactory = new DeepConceptQueryFactory(objectMapper);
         this.conceptQueryFactory = new ConceptQueryFactory(objectMapper, namespaceRoot);
+        this.countQueryFactory = new CountQueryFactory(objectMapper);
     }
 
     ConceptSearchResponse searchConcept(ConceptSearchRequest request) {
@@ -118,6 +117,17 @@ public class FrontendElasticSearchService {
             }
             SearchResponse response = esRestClient.search(finalQuery, RequestOptions.DEFAULT);
             return terminologyQueryFactory.parseResponse(response, request, deepSearchHits);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    CountSearchResponse getCounts() {
+        SearchRequest query = countQueryFactory.createQuery();
+        try {
+            SearchResponse response = esRestClient.search(query, RequestOptions.DEFAULT);
+            logger.debug(response.toString());
+            return countQueryFactory.parseResponse(response);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/CountQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/CountQueryFactory.java
@@ -1,0 +1,125 @@
+package fi.vm.yti.terminology.api.frontend.elasticqueries;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.vm.yti.terminology.api.frontend.searchdto.CountDTO;
+import fi.vm.yti.terminology.api.frontend.searchdto.CountSearchResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class CountQueryFactory {
+    private static final Logger log = LoggerFactory.getLogger(CountQueryFactory.class);
+
+    private final ObjectMapper objectMapper;
+
+    public CountQueryFactory(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public SearchRequest createQuery() {
+        QueryBuilder withIncompleteHandling = QueryBuilders.boolQuery()
+                .mustNot(QueryBuilders.matchQuery("properties.status.value", "INCOMPLETE"));
+
+        SearchRequest sr = new SearchRequest("concepts,vocabularies")
+                .source(new SearchSourceBuilder()
+                        .size(0)
+                        .query(withIncompleteHandling)
+                        .aggregation(this.createStatusAggregation())
+                        .aggregation(this.createGroupAggregation())
+                        .aggregation(this.createIndexAggregation()));
+
+        log.debug("Count request: " + sr.toString());
+        return sr;
+    }
+
+    private TermsAggregationBuilder createStatusAggregation() {
+        String scriptSource = "doc.containsKey('status') ? doc.status : params._source.properties.status[0].value";
+        Map<String, Object> params = new HashMap<>(16);
+        Script script = new Script(
+                Script.DEFAULT_SCRIPT_TYPE,
+                "painless",
+                scriptSource,
+                params);
+
+        return AggregationBuilders
+                .terms("statusagg")
+                .size(300)
+                .script(script);
+    }
+
+    private TermsAggregationBuilder createIndexAggregation() {
+        return AggregationBuilders
+                .terms("indexagg")
+                .size(300)
+                .field("_index");
+    }
+
+    private TermsAggregationBuilder createGroupAggregation() {
+        String scriptSource = String.join("\n",
+                "if (!params._source.containsKey('references')) {",
+                "    return null;",
+                "}",
+                "   return params._source.references.inGroup",
+                "       .stream()",
+                "       .map(x -> x.id)",
+                "       .collect(Collectors.toList())");
+
+        Map<String, Object> params = new HashMap<>(16);
+        Script script = new Script(
+                Script.DEFAULT_SCRIPT_TYPE,
+                "painless",
+                scriptSource,
+                params);
+
+        return AggregationBuilders
+                .terms("groupagg")
+                .size(300)
+                .script(script);
+    }
+
+    public CountSearchResponse parseResponse(SearchResponse response) {
+        CountSearchResponse ret = new CountSearchResponse();
+        ret.setTotalHitCount(response.getHits().getTotalHits());
+
+        Terms indexAgg = response.getAggregations().get("indexagg");
+        var indices = indexAgg
+                .getBuckets()
+                .stream()
+                .collect(Collectors.toMap(
+                        MultiBucketsAggregation.Bucket::getKeyAsString,
+                        MultiBucketsAggregation.Bucket::getDocCount));
+
+        Terms statusAgg = response.getAggregations().get("statusagg");
+        var statuses = statusAgg
+                .getBuckets()
+                .stream()
+                .collect(Collectors.toMap(
+                        MultiBucketsAggregation.Bucket::getKeyAsString,
+                        MultiBucketsAggregation.Bucket::getDocCount));
+
+        Terms groupAgg = response.getAggregations().get("groupagg");
+        var groups = groupAgg
+                .getBuckets()
+                .stream()
+                .collect(Collectors.toMap(
+                        MultiBucketsAggregation.Bucket::getKeyAsString,
+                        MultiBucketsAggregation.Bucket::getDocCount));
+
+        ret.setCounts(new CountDTO(indices, statuses, groups));
+
+        return ret;
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/CountDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/CountDTO.java
@@ -5,22 +5,74 @@ import java.util.Map;
 
 public class CountDTO {
 
-    private Map<String, Long> indices;
+    public CategoriesCountDTO getCategories() {
+        return categories;
+    }
+
+    public void setCategories(CategoriesCountDTO categories) {
+        this.categories = categories;
+    }
+
+    class CategoriesCountDTO {
+        private long terminologicalVocabulary;
+        private long otherVocabulary;
+        private long concept;
+
+        public CategoriesCountDTO() {
+            this.terminologicalVocabulary = 0;
+            this.otherVocabulary = 0;
+            this.concept = 0;
+        }
+
+        public CategoriesCountDTO(Map<String, Long> categories) {
+            this.terminologicalVocabulary = categories.getOrDefault(
+                    "TerminologicalVocabulary", 0L);
+            this.otherVocabulary = categories.getOrDefault(
+                    "OtherVocabulary", 0L);
+            this.concept = categories.getOrDefault(
+                    "Concept", 0L);
+        }
+
+        public long getTerminologicalVocabulary() {
+            return terminologicalVocabulary;
+        }
+
+        public void setTerminologicalVocabulary(int terminologicalVocabulary) {
+            this.terminologicalVocabulary = terminologicalVocabulary;
+        }
+
+        public long getOtherVocabulary() {
+            return otherVocabulary;
+        }
+
+        public void setOtherVocabulary(int otherVocabulary) {
+            this.otherVocabulary = otherVocabulary;
+        }
+
+        public long getConcept() {
+            return concept;
+        }
+
+        public void setConcept(int concept) {
+            this.concept = concept;
+        }
+    }
+
+    private CategoriesCountDTO categories;
     private Map<String, Long> statuses;
     private Map<String, Long> groups;
 
-
     public CountDTO() {
-        this.indices = Collections.emptyMap();
+        this.categories = new CategoriesCountDTO();
         this.statuses = Collections.emptyMap();
         this.groups = Collections.emptyMap();
     }
 
     public CountDTO(
-            final Map<String, Long> indices,
+            final Map<String, Long> categories,
             final Map<String, Long> statuses,
             final Map<String, Long> groups) {
-        this.indices = indices;
+        this.categories = new CategoriesCountDTO(categories);
         this.statuses = statuses;
         this.groups = groups;
     }
@@ -39,13 +91,5 @@ public class CountDTO {
 
     public void setGroups(Map<String, Long> groups) {
         this.groups = groups;
-    }
-
-    public Map<String, Long> getIndices() {
-        return indices;
-    }
-
-    public void setIndices(Map<String, Long> indices) {
-        this.indices = indices;
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/CountDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/CountDTO.java
@@ -1,0 +1,51 @@
+package fi.vm.yti.terminology.api.frontend.searchdto;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class CountDTO {
+
+    private Map<String, Long> indices;
+    private Map<String, Long> statuses;
+    private Map<String, Long> groups;
+
+
+    public CountDTO() {
+        this.indices = Collections.emptyMap();
+        this.statuses = Collections.emptyMap();
+        this.groups = Collections.emptyMap();
+    }
+
+    public CountDTO(
+            final Map<String, Long> indices,
+            final Map<String, Long> statuses,
+            final Map<String, Long> groups) {
+        this.indices = indices;
+        this.statuses = statuses;
+        this.groups = groups;
+    }
+
+    public Map<String, Long> getStatuses() {
+        return statuses;
+    }
+
+    public void setStatuses(Map<String, Long> statuses) {
+        this.statuses = statuses;
+    }
+
+    public Map<String, Long> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(Map<String, Long> groups) {
+        this.groups = groups;
+    }
+
+    public Map<String, Long> getIndices() {
+        return indices;
+    }
+
+    public void setIndices(Map<String, Long> indices) {
+        this.indices = indices;
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/CountSearchResponse.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/CountSearchResponse.java
@@ -1,0 +1,31 @@
+package fi.vm.yti.terminology.api.frontend.searchdto;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class CountSearchResponse {
+
+    private long totalHitCount;
+    private CountDTO counts;
+
+    public CountSearchResponse() {
+        this.totalHitCount = 0;
+        this.counts = new CountDTO();
+    }
+
+    public long getTotalHitCount() {
+        return totalHitCount;
+    }
+
+    public void setTotalHitCount(long totalHitCount) {
+        this.totalHitCount = totalHitCount;
+    }
+
+    public CountDTO getCounts() {
+        return counts;
+    }
+
+    public void setCounts(CountDTO counts) {
+        this.counts = counts;
+    }
+}


### PR DESCRIPTION
Add /counts endpoint, which lists the number of documents in vocabularies and concepts grouped by index, status and group.

The implementation is done as a single elasticsearch query utilizing aggregations.

YTI-1583

Example response:

```json
{
  "totalHitCount": 18892,
  "counts": {
    "indices": {
      "vocabularies": 69,
      "concepts": 18823
    },
    "statuses": {
      "DRAFT": 18158,
      "SUPERSEDED": 7,
      "VALID": 573,
      "RETIRED": 51,
      "INCOMPLETE": 11,
      "SUGGESTED": 88,
      "INVALID": 4
    },
    "groups": {
      "b4dc527b-5465-3b82-871a-2a982e23554b": 4,
      "11b4cac3-e350-4de1-8886-baadd5ed2e83": 12,
      "1143c41d-10ec-4b13-a97a-7d28328070af": 5
    }
  }
}
```