### PR TITLE
YTI-1582 extend terminology search with new options

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/TerminologyQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/TerminologyQueryFactory.java
@@ -1,14 +1,12 @@
 package fi.vm.yti.terminology.api.frontend.elasticqueries;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
+import fi.vm.yti.terminology.api.exception.InvalidQueryException;
+import org.apache.lucene.queryparser.flexible.core.QueryNodeException;
+import org.apache.lucene.queryparser.flexible.standard.StandardQueryParser;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.index.query.BoolQueryBuilder;
@@ -48,17 +46,31 @@ public class TerminologyQueryFactory {
     public SearchRequest createQuery(TerminologySearchRequest request,
                                      boolean superUser,
                                      Set<String> privilegedOrganizations) {
-        return createQuery(request.getQuery(), Collections.emptySet(), pageSize(request), pageFrom(request), superUser, privilegedOrganizations);
+        return createQuery(
+                request.getQuery(),
+                request.getStatuses(),
+                Collections.emptySet(),
+                pageSize(request),
+                pageFrom(request),
+                superUser,
+                privilegedOrganizations);
     }
 
     public SearchRequest createQuery(TerminologySearchRequest request,
                                      Collection<String> additionalTerminologyIds,
                                      boolean superUser,
                                      Set<String> privilegedOrganizations) {
-        return createQuery(request.getQuery(), additionalTerminologyIds, pageSize(request), pageFrom(request), superUser, privilegedOrganizations);
+        return createQuery(
+                request.getQuery(),
+                request.getStatuses(),
+                additionalTerminologyIds,
+                pageSize(request),
+                pageFrom(request),
+                superUser, privilegedOrganizations);
     }
 
     private SearchRequest createQuery(String query,
+                                      String[] statuses,
                                       Collection<String> additionalTerminologyIds,
                                       int pageSize,
                                       int pageFrom,
@@ -70,32 +82,60 @@ public class TerminologyQueryFactory {
 
         QueryBuilder incompleteQuery = statusAndContributorQuery(privilegedOrganizations);
 
-        QueryBuilder labelQuery = null;
+        // collect all queries in these, and later create a bool query if
+        // there are more than one
+        var mustQueries = new ArrayList<QueryBuilder>();
+        var shouldQueries = new ArrayList<QueryBuilder>();
+
         if (!query.isEmpty()) {
-            labelQuery = ElasticRequestUtils.buildPrefixSuffixQuery(query).field("properties.prefLabel.value");
+            var labelQuery = ElasticRequestUtils
+                    .buildPrefixSuffixQuery(query)
+                    .field("properties.prefLabel.value");
+            mustQueries.add(labelQuery);
         }
 
-        TermsQueryBuilder idQuery = null;
+        if (statuses != null && statuses.length > 0) {
+            mustQueries.add(ElasticRequestUtils.buildStatusQuery(
+                    statuses, "properties.status.value"));
+        }
+
+        // if the search was also done to concepts, we may have
+        // extra terminologies here
         if (additionalTerminologyIds != null && !additionalTerminologyIds.isEmpty()) {
-            idQuery = QueryBuilders.termsQuery("type.graph.id.keyword", additionalTerminologyIds);
+            var idQuery = QueryBuilders.termsQuery(
+                    "type.graph.id.keyword",
+                    additionalTerminologyIds);
+            shouldQueries.add(idQuery);
         }
 
-        if (idQuery != null && labelQuery != null) {
-            sourceBuilder.query(combineIncompleteQuery(QueryBuilders.boolQuery()
-                .should(labelQuery)
-                .should(idQuery)
-                .minimumShouldMatch(1), incompleteQuery, superUser));
-        } else if (idQuery != null) {
-            sourceBuilder.query(combineIncompleteQuery(idQuery, incompleteQuery, superUser));
-        } else if (labelQuery != null) {
-            sourceBuilder.query(combineIncompleteQuery(labelQuery, incompleteQuery, superUser));
-        } else {
-            if (superUser) {
-                sourceBuilder.query(QueryBuilders.matchAllQuery());
-            } else {
-                sourceBuilder.query(incompleteQuery);
+        QueryBuilder mustQuery = null;
+        if (mustQueries.size() > 1) {
+            // several queries, collect them into a bool query
+            mustQuery = QueryBuilders.boolQuery();
+            for (var boolableQuery : mustQueries) {
+                mustQuery = ((BoolQueryBuilder) mustQuery).must(boolableQuery);
             }
+        } else if (mustQueries.size() == 1) {
+            mustQuery = mustQueries.get(0);
+        } else {
+            // no specific queries, search all
+            mustQuery = QueryBuilders.matchAllQuery();
         }
+        mustQuery = combineIncompleteQuery(mustQuery, incompleteQuery, superUser);
+
+        // now we've created the must (AND) query, need to wrap it in another
+        // boolean OR if we have been provided with terminologyIds
+        QueryBuilder shouldQuery = null;
+        if (!shouldQueries.isEmpty()) {
+            shouldQueries.add(mustQuery);
+            shouldQuery = QueryBuilders.boolQuery();
+            for (var boolableQuery : shouldQueries) {
+                shouldQuery = ((BoolQueryBuilder) shouldQuery).should(boolableQuery);
+            }
+            ((BoolQueryBuilder) shouldQuery).minimumShouldMatch(1);
+        }
+
+        sourceBuilder.query(shouldQuery != null ? shouldQuery : mustQuery);
 
         SearchRequest sr = new SearchRequest("vocabularies")
             .source(sourceBuilder);
@@ -128,6 +168,7 @@ public class TerminologyQueryFactory {
                 .size(1000)
                 .query(finalQuery));
         //.fetchSource(false));
+        //log.debug("createMatchingTerminologiesQuery Query request: " + sr.toString());
         return sr;
     }
 

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/TerminologySearchRequest.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/TerminologySearchRequest.java
@@ -8,6 +8,8 @@ public class TerminologySearchRequest {
 
     private String[] statuses;
 
+    private String[] groups;
+
     private String prefLang;
 
     private Integer pageSize;
@@ -35,6 +37,14 @@ public class TerminologySearchRequest {
 
     public void setStatuses(String[] statuses) {
         this.statuses = statuses;
+    }
+
+    public String[] getGroups() {
+        return groups;
+    }
+
+    public void setGroups(String[] groups) {
+        this.groups = groups;
     }
 
     public String getPrefLang() {

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/TerminologySearchRequest.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/TerminologySearchRequest.java
@@ -10,6 +10,8 @@ public class TerminologySearchRequest {
 
     private String[] groups;
 
+    private String[] types;
+
     private String prefLang;
 
     private Integer pageSize;
@@ -45,6 +47,14 @@ public class TerminologySearchRequest {
 
     public void setGroups(String[] groups) {
         this.groups = groups;
+    }
+
+    public String[] getTypes() {
+        return types;
+    }
+
+    public void setTypes(String[] types) {
+        this.types = types;
     }
 
     public String getPrefLang() {

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/TerminologySearchRequest.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/TerminologySearchRequest.java
@@ -3,8 +3,13 @@ package fi.vm.yti.terminology.api.frontend.searchdto;
 public class TerminologySearchRequest {
 
     private String query;
+
     private boolean searchConcepts;
+
+    private String[] statuses;
+
     private String prefLang;
+
     private Integer pageSize;
     private Integer pageFrom;
 
@@ -22,6 +27,14 @@ public class TerminologySearchRequest {
 
     public void setSearchConcepts(final boolean searchConcepts) {
         this.searchConcepts = searchConcepts;
+    }
+
+    public String[] getStatuses() {
+        return statuses;
+    }
+
+    public void setStatuses(String[] statuses) {
+        this.statuses = statuses;
     }
 
     public String getPrefLang() {

--- a/src/main/resources/create_vocabulary_mappings.json
+++ b/src/main/resources/create_vocabulary_mappings.json
@@ -74,6 +74,9 @@
     "uri": {
       "type": "keyword"
     },
+    "type.id": {
+      "type": "keyword"
+    },
     "references.contributor.id": {
       "type": "keyword"
     },

--- a/src/main/resources/create_vocabulary_mappings.json
+++ b/src/main/resources/create_vocabulary_mappings.json
@@ -77,6 +77,9 @@
     "references.contributor.id": {
       "type": "keyword"
     },
+    "references.inGroup.id": {
+      "type": "keyword"
+    },
     "vocabulary": {
       "properties": {
         "id": {


### PR DESCRIPTION
This PR adds more search filters to the terminology/vocabulary search.

* status (Text array)
* groups (UUID array)
* terminology types (Text array)

A terminology search actually performs three consecutive searches, if a deep concept search is requested.

1. terminologies matching organization to show "INCOMPLETE" items for those with access
2. concepts with the same text search, their terminologies added to the end result
3. terminologies (vocabularies)

If deep search was not requested, the first two queries are not executed.

One of the new search options is "status", and this is added to both concept and vocabulary query. Group and type filters are only added to the terminology query.

A couple new mappings have been added to `create_vocabulary_mappings.json`.

* `type.id`
* `references.inGroup.id`


Example using curl:

```sh
curl 'http://localhost:3000/terminology-api/api/v1/frontend/searchTerminology' \
    -H 'Cache-Control: no-cache' \
    -H 'Content-Type: application/json' \
    -H 'Accept: */*' \
    -d @- << EOF
{
  "query": "test",
  "types": [
    "TerminologicalVocabulary"
  ],
  "statuses": [
    "DRAFT"
  ],
  "groups": [
    "9ba19f8d-d688-39cc-b620-ebb7875e6e9b"
  ],
  "searchConcepts": true,
  "prefLang": "fi",
  "pageSize": 10,
  "pageFrom": 0
}
EOF
```

A roughly drawn picture to make the ES query changes clearer (may have some errors, but should help with explaining):

![terminology-search-changes](https://user-images.githubusercontent.com/25614946/144461508-e9fd4434-de78-4f29-88d8-2fb9d6182d40.png)


