### PR TITLE
YTI-1582 add organization filter to terminology search

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/TerminologyQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/TerminologyQueryFactory.java
@@ -62,6 +62,7 @@ public class TerminologyQueryFactory {
                 request.getStatuses(),
                 request.getGroups(),
                 request.getTypes(),
+                request.getOrganizations(),
                 additionalTerminologyIds,
                 pageSize(request),
                 pageFrom(request),
@@ -73,6 +74,7 @@ public class TerminologyQueryFactory {
                                       String[] statuses,
                                       String[] groupIds,
                                       String[] types,
+                                      String[] organizationIds,
                                       Collection<String> additionalTerminologyIds,
                                       int pageSize,
                                       int pageFrom,
@@ -111,6 +113,18 @@ public class TerminologyQueryFactory {
 
             mustQueries.add(QueryBuilders.termsQuery(
                     "references.inGroup.id", groupIds));
+        }
+
+        if (organizationIds != null && organizationIds.length > 0)  {
+            try {
+                Arrays.stream(organizationIds).forEach(x -> UUID.fromString(x));
+            } catch (IllegalArgumentException exception){
+                log.error("One or more organization IDs were invalid");
+                throw new InvalidQueryException("One or organization IDs were invalid");
+            }
+
+            mustQueries.add(QueryBuilders.termsQuery(
+                    "references.contributor.id", organizationIds));
         }
 
         QueryBuilder typeQuery = null;

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/TerminologySearchRequest.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/TerminologySearchRequest.java
@@ -12,6 +12,8 @@ public class TerminologySearchRequest {
 
     private String[] types;
 
+    private String[] organizations;
+
     private String prefLang;
 
     private Integer pageSize;
@@ -55,6 +57,14 @@ public class TerminologySearchRequest {
 
     public void setTypes(String[] types) {
         this.types = types;
+    }
+
+    public String[] getOrganizations() {
+        return organizations;
+    }
+
+    public void setOrganizations(String[] organizations) {
+        this.organizations = organizations;
     }
 
     public String getPrefLang() {


### PR DESCRIPTION
This PR adds one more search filter to the terminology/vocabulary search. The implementation is exactly the same as when groupIds were added in #25

Example search with curl:

```sh
curl 'http://localhost:3000/terminology-api/api/v1/frontend/searchTerminology' \
    -H 'Cache-Control: no-cache' \
    -H 'Content-Type: application/json' \
    -H 'Accept: */*' \
    -d @- << EOF
{
  "organizations": [
    "d9c76d52-03d3-4480-8c2c-b66e6d9c57f2"
  ],
  "searchConcepts": false,
  "prefLang": "fi",
  "pageSize": 10,
  "pageFrom": 0
}
EOF
```
