### PR TITLE
extend terminology search query to organization label

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/TerminologyQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/TerminologyQueryFactory.java
@@ -94,7 +94,9 @@ public class TerminologyQueryFactory {
         if (!query.isEmpty()) {
             var labelQuery = ElasticRequestUtils
                     .buildPrefixSuffixQuery(query)
-                    .field("properties.prefLabel.value");
+                    .fields(Map.of(
+                            "properties.prefLabel.value", 1.0f,
+                            "references.contributor.properties.prefLabel.value", 2.0f));
             mustQueries.add(labelQuery);
         }
 


### PR DESCRIPTION
Query string will now apply to organization label as well, in addition to the terminology label.

Search by organization IDs was added in #27, but it was then determined that the preferred approach would be to search the organization name instead. The previous implementation is left as-is, although it might no be used.

Example search with curl:

```sh
curl 'http://localhost:3000/terminology-api/api/v1/frontend/searchTerminology' \
    -H 'Cache-Control: no-cache' \
    -H 'Content-Type: application/json' \
    -H 'Accept: */*' \
    -d @- << EOF
{
  "query": "Testiorganisaatio",
  "searchConcepts": false,
  "prefLang": "fi",
  "pageSize": 10,
  "pageFrom": 0
}
EOF
```

Which will add the following kind of filter to the ES query:

```json
"query_string": {
  "query": "Testiorganisaatio Testiorganisaatio* *Testiorganisaatio",
  "fields": [
    "properties.prefLabel.value^1.0",
    "references.contributor.properties.prefLabel.value^2.0"
  ]
}
```

YTI-1582