### PR TITLE
YTI-1711 Add multiple roles for user

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
@@ -134,7 +134,7 @@ public class FrontendController {
     @PostMapping(path = "/request", produces = APPLICATION_JSON_VALUE)
     void sendRequest(
             @Parameter(description = "UUID for the organization") @RequestParam UUID organizationId,
-            @Parameter(description = "Comma separated list of roles for organisation") @RequestParam String roles) {
+            @Parameter(description = "Comma separated list of roles for organisation") @RequestParam(required = false) String[] roles) {
         logger.info("POST /request requested with organizationID: " + organizationId.toString());
         groupManagementService.sendRequest(organizationId, roles);
     }

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
@@ -132,9 +132,11 @@ public class FrontendController {
     @ApiResponse(responseCode = "200", description = "Request submitted successfully")
     @ApiResponse(responseCode = "401", description = "If the caller is not not authenticated user")
     @PostMapping(path = "/request", produces = APPLICATION_JSON_VALUE)
-    void sendRequest(@Parameter(description = "UUID for the organization") @RequestParam UUID organizationId) {
+    void sendRequest(
+            @Parameter(description = "UUID for the organization") @RequestParam UUID organizationId,
+            @Parameter(description = "Comma separated list of roles for organisation") @RequestParam String roles) {
         logger.info("POST /request requested with organizationID: " + organizationId.toString());
-        groupManagementService.sendRequest(organizationId);
+        groupManagementService.sendRequest(organizationId, roles);
     }
 
     @Operation(summary = "Get terminology basic info as JSON")

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendGroupManagementService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendGroupManagementService.java
@@ -59,7 +59,7 @@ public class FrontendGroupManagementService {
         return restTemplate.exchange(url, GET, null, new ParameterizedTypeReference<List<GroupManagementUserRequest>>() {}).getBody();
     }
 
-    void sendRequest(final UUID organizationId) {
+    public void sendRequest(final UUID organizationId, final String roles) {
 
         YtiUser user = userProvider.getUser();
 
@@ -69,7 +69,8 @@ public class FrontendGroupManagementService {
 
         Parameters parameters = new Parameters();
         parameters.add("userId", user.getId().toString());
-        parameters.add("role", Role.TERMINOLOGY_EDITOR.toString());
+        // If no roles specified, add TERMINOLOGY_EDITOR role (backwards compatibility)
+        parameters.add("role", roles != null ? roles : Role.TERMINOLOGY_EDITOR.toString());
         parameters.add("organizationId", organizationId.toString());
 
         String url = groupManagementUrl + "/private-api/request" + parameters;

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendGroupManagementService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendGroupManagementService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
@@ -59,7 +60,7 @@ public class FrontendGroupManagementService {
         return restTemplate.exchange(url, GET, null, new ParameterizedTypeReference<List<GroupManagementUserRequest>>() {}).getBody();
     }
 
-    public void sendRequest(final UUID organizationId, final String roles) {
+    public void sendRequest(final UUID organizationId, final String[] roles) {
 
         YtiUser user = userProvider.getUser();
 
@@ -69,8 +70,14 @@ public class FrontendGroupManagementService {
 
         Parameters parameters = new Parameters();
         parameters.add("userId", user.getId().toString());
+
         // If no roles specified, add TERMINOLOGY_EDITOR role (backwards compatibility)
-        parameters.add("role", roles != null ? roles : Role.TERMINOLOGY_EDITOR.toString());
+        if (roles == null) {
+            parameters.add("role", Role.TERMINOLOGY_EDITOR.toString());
+        } else {
+            Arrays.stream(roles).forEach(r -> parameters.add("role", r));
+        }
+
         parameters.add("organizationId", organizationId.toString());
 
         String url = groupManagementUrl + "/private-api/request" + parameters;

--- a/src/test/java/fi/vm/yti/terminology/service/FrontendGroupmanagementServiceTest.java
+++ b/src/test/java/fi/vm/yti/terminology/service/FrontendGroupmanagementServiceTest.java
@@ -89,12 +89,16 @@ public class FrontendGroupmanagementServiceTest {
     public void testAddMultipleRoles() throws Exception {
         var orgId = UUID.randomUUID();
 
-        service.sendRequest(orgId, Role.CODE_LIST_EDITOR + "," + Role.TERMINOLOGY_EDITOR);
+        service.sendRequest(orgId, new String[] {
+                Role.CODE_LIST_EDITOR.toString(),
+                Role.TERMINOLOGY_EDITOR.toString()
+        });
 
         verify(restTemplate).exchange(urlCaptor.capture(), eq(HttpMethod.POST), eq(null), eq(String.class));
 
         URL url = new URL(urlCaptor.getValue());
 
-        assertTrue(url.getQuery().contains("role=" + Role.CODE_LIST_EDITOR + "," + Role.TERMINOLOGY_EDITOR.toString()));
+        assertTrue(url.getQuery().contains("role=" + Role.CODE_LIST_EDITOR.toString()));
+        assertTrue(url.getQuery().contains("role=" + Role.TERMINOLOGY_EDITOR.toString()));
     }
 }

--- a/src/test/java/fi/vm/yti/terminology/service/FrontendGroupmanagementServiceTest.java
+++ b/src/test/java/fi/vm/yti/terminology/service/FrontendGroupmanagementServiceTest.java
@@ -1,0 +1,100 @@
+package fi.vm.yti.terminology.service;
+
+import fi.vm.yti.security.AuthenticatedUserProvider;
+import fi.vm.yti.security.Role;
+import fi.vm.yti.security.YtiUser;
+import fi.vm.yti.terminology.api.frontend.FrontendGroupManagementService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@Import({
+        FrontendGroupManagementService.class,
+})
+@TestPropertySource(properties = {
+        "groupmanagement.url=http://local.invalid"
+})
+public class FrontendGroupmanagementServiceTest {
+
+    @MockBean
+    AuthenticatedUserProvider userProvider;
+
+    @MockBean
+    RestTemplate restTemplate;
+
+    @Autowired
+    FrontendGroupManagementService service;
+
+    @Captor
+    ArgumentCaptor<String> urlCaptor;
+
+    YtiUser mockUser = new YtiUser(
+            "test@test.invalid",
+            "firstname",
+            "lastname",
+            UUID.fromString("384c982c-7254-43df-ab7c-5037b6fb71c0"),
+            false,
+            false,
+            LocalDateTime.of(2005, 4, 2, 1, 10),
+            LocalDateTime.of(2006, 4, 2, 1, 10),
+            Collections.emptyMap(),
+            "",
+            "");
+
+    @BeforeEach
+    public void setUp() {
+        when(userProvider.getUser()).thenReturn(mockUser);
+
+        when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(), any(Class.class)))
+            .thenReturn(new ResponseEntity("", HttpStatus.OK));
+    }
+
+    @Test
+    public void testAddDefaultRole() throws Exception {
+        var orgId = UUID.randomUUID();
+
+        service.sendRequest(orgId, null);
+
+        verify(restTemplate).exchange(urlCaptor.capture(), eq(HttpMethod.POST), eq(null), eq(String.class));
+
+        URL url = new URL(urlCaptor.getValue());
+
+        assertTrue(url.getQuery().contains("userId=" + mockUser.getId()));
+        assertTrue(url.getQuery().contains("role=" + Role.TERMINOLOGY_EDITOR.toString()));
+        assertTrue(url.getQuery().contains("organizationId=" + orgId.toString()));
+    }
+
+    @Test
+    public void testAddMultipleRoles() throws Exception {
+        var orgId = UUID.randomUUID();
+
+        service.sendRequest(orgId, Role.CODE_LIST_EDITOR + "," + Role.TERMINOLOGY_EDITOR);
+
+        verify(restTemplate).exchange(urlCaptor.capture(), eq(HttpMethod.POST), eq(null), eq(String.class));
+
+        URL url = new URL(urlCaptor.getValue());
+
+        assertTrue(url.getQuery().contains("role=" + Role.CODE_LIST_EDITOR + "," + Role.TERMINOLOGY_EDITOR.toString()));
+    }
+}


### PR DESCRIPTION
Possibility to define for which services the access is requested instead of hard coded Terminology access. 

Sample request
```
curl -X POST "http://localhost:9103/terminology-api/api/v1/frontend/request?organizationId=<id>&roles=TERMINOLOGY_EDITOR&roles=CODE_LIST_EDITOR" \
-H "Cookie: JSESSIONID=xxx" -H "Content-Type: application/json"
```