### PR TITLE
Add endpoint for mass updating statuses of nodes

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
@@ -1,9 +1,8 @@
 package fi.vm.yti.terminology.api.frontend;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import fi.vm.yti.terminology.api.frontend.searchdto.*;
 import org.jetbrains.annotations.Nullable;
@@ -283,6 +282,30 @@ public class FrontendController {
             logger.info(ident.getId().toString());
         }
         termedService.removeNodes(sync, disconnect, identifiers);
+    }
+
+    @Operation(
+            summary = "Update statuses",
+            description = "Update statuses of several terms or concepts at once")
+    @ApiResponse(
+            responseCode = "200",
+            description = "The operation was successful")
+    @PostMapping(
+            path = "/modifyStatuses",
+            consumes = APPLICATION_JSON_VALUE,
+            produces = APPLICATION_JSON_VALUE)
+    void updateStatuses(
+            @Parameter(description = "Graph to update") @RequestParam UUID graphId,
+            @Parameter(description = "Modify nodes matching this status") @RequestParam String oldStatus,
+            @Parameter(description = "New status to assign to all matched nodes") @RequestParam String newStatus,
+            @Parameter(description = "Modify nodes matching these types (Concept, Term)") @RequestParam Set<String> types) {
+        logger.debug(
+                "POST /modifyStatuses requested with graphId: {}, oldStatus: {}, newState: {}, types: {}",
+                graphId.toString(),
+                oldStatus,
+                newStatus,
+                String.join(",", types));
+        termedService.modifyStatuses(graphId, types, oldStatus, newStatus);
     }
 
     @Operation(summary = "Get meta model")

--- a/src/main/java/fi/vm/yti/terminology/api/security/AuthorizationManager.java
+++ b/src/main/java/fi/vm/yti/terminology/api/security/AuthorizationManager.java
@@ -65,7 +65,7 @@ public class AuthorizationManager {
         return user.isSuperuser() || userOrganization.isPresent();
     }
 
-    private boolean canModifyAllGraphs(Collection<UUID> graphIds) {
+    public boolean canModifyAllGraphs(Collection<UUID> graphIds) {
 
         Set<UUID> organizationIds = graphIds.stream()
                 .flatMap(graphId -> termedService.getOrganizationIds(graphId).stream())


### PR DESCRIPTION
This feature allows mass updating several nodes with a new status, matching the provided node type and existing status.

Example request with curl:

```sh
curl \
    -X POST \
    -H 'Content-Type: application/json' \
    -H 'Accept: */*' \
    -H 'Cookie: 36ECA8FBF0C8EBB83A8049F27BC1E0F3' \
    "http://localhost:9103/terminology-api/api/v1/frontend/modifyStatuses?graphId=933a668f-41ea-4312-8081-26312194fced&oldStatus=DRAFT&newStatus=VALID&types=Term,Concept"
```

YTI-1741