### PR TITLE
YTI-1742 Create new version of the terminology

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/exception/NamespaceInUseException.java
+++ b/src/main/java/fi/vm/yti/terminology/api/exception/NamespaceInUseException.java
@@ -1,0 +1,13 @@
+package fi.vm.yti.terminology.api.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_ACCEPTABLE)
+public class NamespaceInUseException extends RuntimeException {
+    private static final long serialVersionUID = 23234342342L;
+
+    public NamespaceInUseException() {
+        super("Namespace already in use");
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/exception/VocabularyNotFoundException.java
+++ b/src/main/java/fi/vm/yti/terminology/api/exception/VocabularyNotFoundException.java
@@ -3,10 +3,16 @@ package fi.vm.yti.terminology.api.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+import java.util.UUID;
+
 @ResponseStatus(HttpStatus.NOT_FOUND)
 public class VocabularyNotFoundException extends RuntimeException {
 
     public VocabularyNotFoundException(String prefix) {
         super("Vocabulary not found with prefix: " + prefix);
+    }
+
+    public VocabularyNotFoundException(UUID id) {
+        super("Vocabulary not found with id: " + id);
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
@@ -4,6 +4,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import fi.vm.yti.terminology.api.exception.NamespaceInUseException;
+import fi.vm.yti.terminology.api.exception.VocabularyNotFoundException;
 import fi.vm.yti.terminology.api.frontend.searchdto.*;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -378,5 +380,24 @@ public class FrontendController {
         CountSearchResponse conceptCounts = elasticSearchService.getConceptCounts(graphId);
         conceptCounts.getCounts().getCategories().put(CountDTO.Category.COLLECTION.getName(), Long.valueOf(collectionList.size()));
         return conceptCounts;
+    }
+
+    @Operation(summary = "New version", description = "Creates new version of the terminology")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "Terminology's uri and new prefix")
+    @ApiResponse(responseCode = "200", description = "")
+    @RequestMapping(value = "/createVersion", method = POST, produces = APPLICATION_JSON_VALUE)
+    CreateVersionResponse createTerminologyVersion(@RequestBody CreateVersionDTO createVersionDTO) {
+
+        logger.info("POST /createVersion requested");
+
+        try {
+            return termedService.createVersion(createVersionDTO);
+        } catch (NamespaceInUseException | VocabularyNotFoundException e) {
+            logger.error("Error creating new version", e);
+            throw e;
+        } catch (Exception e) {
+            logger.error("Unhandled error occurred while creating new version", e);
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendTermedService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendTermedService.java
@@ -6,9 +6,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.vm.yti.security.AuthenticatedUserProvider;
 import fi.vm.yti.security.YtiUser;
 import fi.vm.yti.terminology.api.TermedRequester;
+import fi.vm.yti.terminology.api.exception.NamespaceInUseException;
 import fi.vm.yti.terminology.api.exception.NodeNotFoundException;
 import fi.vm.yti.terminology.api.exception.VocabularyNotFoundException;
-import fi.vm.yti.terminology.api.integration.IntegrationService;
+import fi.vm.yti.terminology.api.frontend.searchdto.CreateVersionDTO;
+import fi.vm.yti.terminology.api.frontend.searchdto.CreateVersionResponse;
 import fi.vm.yti.terminology.api.model.termed.*;
 import fi.vm.yti.terminology.api.security.AuthorizationManager;
 import fi.vm.yti.terminology.api.util.JsonUtils;
@@ -28,7 +30,6 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import static fi.vm.yti.security.AuthorizationException.check;
 import static fi.vm.yti.terminology.api.model.termed.VocabularyNodeType.TerminologicalVocabulary;
@@ -450,6 +451,117 @@ public class FrontendTermedService {
         return requireNonNull(termedRequester.exchange("/graphs/" + graphId, GET, Parameters.empty(), Graph.class));
     }
 
+    public CreateVersionResponse createVersion(CreateVersionDTO createVersionDTO) throws Exception {
+        logger.info("Creating new version from vocabulary {}. New prefix {}",
+                createVersionDTO.getGraphId(), createVersionDTO.getNewCode());
+
+        check(authorizationManager.canCreateNewVersion(createVersionDTO.getGraphId()));
+
+        if (this.isNamespaceInUse(createVersionDTO.getNewCode())) {
+            throw new NamespaceInUseException();
+        }
+
+        Dump dump = termedRequester.exchange("/graphs/" + createVersionDTO.getGraphId() + "/dump",
+                GET, Parameters.empty(), Dump.class);
+
+        if (dump == null || dump.getGraphs().isEmpty()) {
+            throw new VocabularyNotFoundException(createVersionDTO.getGraphId());
+        }
+
+        Graph oldGraph = dump.getGraphs().get(0);
+        UUID newGraphId = UUID.randomUUID();
+
+        Graph graph = new Graph(newGraphId,
+                createVersionDTO.getNewCode(),
+                formatNamespace(createVersionDTO.getNewCode()),
+                oldGraph.getRoles(),
+                oldGraph.getPermissions(),
+                oldGraph.getProperties());
+
+        List<MetaNode> metaNodes = dump.getTypes().stream().map(t -> new MetaNode(
+                t.getId(),
+                t.getUri(),
+                t.getIndex(),
+                t.getGraph(),
+                t.getPermissions(),
+                t.getProperties(),
+                t.getTextAttributes(),
+                t.getReferenceAttributes())
+            .copyToGraph(newGraphId)
+        ).collect(Collectors.toList());
+
+        // Create id map for saving references
+        Map<UUID, UUID> nodeIdMap = new HashMap<>();
+        dump.getNodes().stream().forEach(n -> nodeIdMap.put(n.getId(), UUID.randomUUID()));
+
+        List<GenericNode> nodes = dump.getNodes().stream().map(n -> new GenericNode(
+                nodeIdMap.get(n.getId()),
+                n.getCode(),
+                String.format("%s%s/",
+                        formatNamespace(createVersionDTO.getNewCode()), n.getCode()),
+                n.getNumber(),
+                n.getCreatedBy(),
+                n.getCreatedDate(),
+                n.getLastModifiedBy(),
+                n.getLastModifiedDate(),
+                n.getType(),
+                getNewVersionProperties(n),
+                n.getReferences(),
+                n.getReferrers())
+            .copyAllToGraph(newGraphId, nodeIdMap)
+        ).collect(Collectors.toList());
+
+        Dump newVersion = new Dump(asList(graph), metaNodes, nodes);
+
+        try {
+            termedRequester.exchange("/dump", POST, Parameters.empty(), String.class, newVersion);
+        } catch (Exception e) {
+            logger.error("Error creating new version", e);
+            throw e;
+        }
+
+        return new CreateVersionResponse(newGraphId, formatNamespace(createVersionDTO.getNewCode()));
+    }
+
+    private Map<String, List<Attribute>> getNewVersionProperties(GenericNode node) {
+        Map<String, List<Attribute>> properties = new HashMap<>();
+        var originalProperties = node.getProperties();
+
+        originalProperties.keySet().stream().forEach(key -> {
+
+            var originalAttributes = originalProperties.get(key);
+
+            // change all statuses to DRAFT
+            if ("status".equals(key)) {
+                var newAttributes = originalAttributes.stream().map(att ->
+                   new Attribute(att.getLang(), "DRAFT", null)
+                ).collect(Collectors.toList());
+
+                properties.put(key, newAttributes);
+            } else if ("prefLabel".equals(key) && isVocabulary(node)) {
+                var newAttributes = originalAttributes.stream().map(att ->
+                        new Attribute(att.getLang(), att.getValue() + " (Copy)", null)
+                ).collect(Collectors.toList());
+
+                properties.put(key, newAttributes);
+            } else {
+                properties.put(key, originalAttributes);
+            }
+        });
+
+        // store origin of new version
+        if (isVocabulary(node)) {
+            properties.put("origin", asList(new Attribute("", node.getUri())));
+        }
+
+        return properties;
+    }
+
+    private boolean isVocabulary(Node node) {
+        return asList(NodeType.TerminologicalVocabulary, NodeType.Vocabulary)
+                .contains(node.getType().getId());
+    }
+
     private @NotNull List<Identifier> getAllNodeIdentifiers(UUID graphId) {
 
         Parameters params = new Parameters();
@@ -601,4 +713,5 @@ public class FrontendTermedService {
             }
         }
     }
+
 }

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendTermedService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendTermedService.java
@@ -514,7 +514,9 @@ public class FrontendTermedService {
         Dump newVersion = new Dump(asList(graph), metaNodes, nodes);
 
         try {
-            termedRequester.exchange("/dump", POST, Parameters.empty(), String.class, newVersion);
+            UUID username = ensureTermedUser(null);
+            termedRequester.exchange("/dump", POST, Parameters.empty(), String.class,
+                    newVersion, username.toString(), USER_PASSWORD);
         } catch (Exception e) {
             logger.error("Error creating new version", e);
             throw e;

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/CreateVersionDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/CreateVersionDTO.java
@@ -1,0 +1,33 @@
+package fi.vm.yti.terminology.api.frontend.searchdto;
+
+import java.util.UUID;
+
+public class CreateVersionDTO {
+    UUID graphId;
+    String newCode;
+
+    public UUID getGraphId() {
+        return graphId;
+    }
+
+    public CreateVersionDTO() {
+        this(UUID.randomUUID(), "");
+    }
+
+    public CreateVersionDTO(UUID graphId, String newCode) {
+        this.graphId = graphId;
+        this.newCode = newCode;
+    }
+
+    public void setGraphId(UUID graphId) {
+        this.graphId = graphId;
+    }
+
+    public String getNewCode() {
+        return newCode;
+    }
+
+    public void setNewCode(String newCode) {
+        this.newCode = newCode;
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/CreateVersionResponse.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/CreateVersionResponse.java
@@ -1,0 +1,29 @@
+package fi.vm.yti.terminology.api.frontend.searchdto;
+
+import java.util.UUID;
+
+public class CreateVersionResponse {
+    UUID newGraphId;
+    String uri;
+
+    public CreateVersionResponse(UUID newGraphId, String uri) {
+        this.newGraphId = newGraphId;
+        this.uri = uri;
+    }
+
+    public UUID getNewGraphId() {
+        return newGraphId;
+    }
+
+    public void setNewGraphId(UUID newGraphId) {
+        this.newGraphId = newGraphId;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/migration/AttributeIndex.java
+++ b/src/main/java/fi/vm/yti/terminology/api/migration/AttributeIndex.java
@@ -581,6 +581,24 @@ public final class AttributeIndex {
         );
     }
 
+    @NotNull
+    public static AttributeMeta origin(TypeId domain, long index) {
+        return new AttributeMeta(
+                "origin",
+                "http://uri.suomi.fi/datamodel/ns/st#origin",
+                index,
+                domain,
+                emptyMap(),
+                merge(
+                        PropertyUtil.prefLabel(
+                                "Kopioitu sanastosta",
+                                "Copied from"
+                        ),
+                        type("string:single")
+                )
+        );
+    }
+
     // prevent construction
     private AttributeIndex() {
     }

--- a/src/main/java/fi/vm/yti/terminology/api/migration/task/V20_AddOriginProperty.java
+++ b/src/main/java/fi/vm/yti/terminology/api/migration/task/V20_AddOriginProperty.java
@@ -1,0 +1,30 @@
+package fi.vm.yti.terminology.api.migration.task;
+
+import fi.vm.yti.migration.MigrationTask;
+import fi.vm.yti.terminology.api.migration.AttributeIndex;
+import fi.vm.yti.terminology.api.migration.MigrationService;
+import fi.vm.yti.terminology.api.model.termed.NodeType;
+import fi.vm.yti.terminology.api.model.termed.VocabularyNodeType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class V20_AddOriginProperty implements MigrationTask {
+
+    private final MigrationService migrationService;
+
+    V20_AddOriginProperty(MigrationService migrationService) {
+        this.migrationService = migrationService;
+    }
+
+    @Override
+    public void migrate() {
+
+        migrationService.updateTypes(VocabularyNodeType.TerminologicalVocabulary, meta -> {
+            NodeType type = meta.getDomain().getId();
+
+            if (type.equals(NodeType.TerminologicalVocabulary)) {
+                meta.addAttribute(AttributeIndex.origin(meta.getDomain(), 21));
+            }
+        });
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/model/termed/Dump.java
+++ b/src/main/java/fi/vm/yti/terminology/api/model/termed/Dump.java
@@ -1,0 +1,45 @@
+package fi.vm.yti.terminology.api.model.termed;
+
+import java.util.List;
+
+import static java.util.Collections.*;
+
+public class Dump {
+    private List<Graph> graphs;
+    private List<MetaNode> types;
+    private List<GenericNode> nodes;
+
+    public Dump() {
+        this(emptyList(), emptyList(), emptyList());
+    }
+
+    public Dump(List<Graph> graphs, List<MetaNode> types, List<GenericNode> nodes) {
+        this.graphs = graphs;
+        this.types = types;
+        this.nodes = nodes;
+    }
+
+    public List<Graph> getGraphs() {
+        return graphs;
+    }
+
+    public void setGraphs(List<Graph> graphs) {
+        this.graphs = graphs;
+    }
+
+    public List<MetaNode> getTypes() {
+        return types;
+    }
+
+    public void setTypes(List<MetaNode> types) {
+        this.types = types;
+    }
+
+    public List<GenericNode> getNodes() {
+        return nodes;
+    }
+
+    public void setNodes(List<GenericNode> nodes) {
+        this.nodes = nodes;
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/security/AuthorizationManager.java
+++ b/src/main/java/fi/vm/yti/terminology/api/security/AuthorizationManager.java
@@ -74,6 +74,12 @@ public class AuthorizationManager {
         return canModifyAllOrganizations(organizationIds);
     }
 
+    public boolean canCreateNewVersion(UUID graphId) {
+        Set<UUID> organizationIds = termedService.getOrganizationIds(graphId);
+
+        return canModifyAllOrganizations(organizationIds);
+    }
+
     private boolean canModifyAllOrganizations(Collection<UUID> organizationIds) {
         YtiUser user = userProvider.getUser();
         return user.isSuperuser() || user.isInAnyRole(EnumSet.of(ADMIN, TERMINOLOGY_EDITOR), organizationIds);

--- a/src/test/java/fi/vm/yti/terminology/api/frontend/FrontendTermedServiceTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/frontend/FrontendTermedServiceTest.java
@@ -4,21 +4,27 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.vm.yti.security.AuthenticatedUserProvider;
+import fi.vm.yti.security.AuthorizationException;
 import fi.vm.yti.terminology.api.TermedRequester;
-import fi.vm.yti.terminology.api.model.termed.NodeType;
+import fi.vm.yti.terminology.api.exception.NamespaceInUseException;
+import fi.vm.yti.terminology.api.exception.VocabularyNotFoundException;
+import fi.vm.yti.terminology.api.frontend.searchdto.CreateVersionDTO;
+import fi.vm.yti.terminology.api.model.termed.*;
 import fi.vm.yti.terminology.api.security.AuthorizationManager;
 import fi.vm.yti.terminology.api.util.Parameters;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.*;
@@ -27,10 +33,15 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static java.util.Collections.*;
+import static java.util.Arrays.*;
 
 @ExtendWith(SpringExtension.class)
 @Import({
         FrontendTermedService.class
+})
+@TestPropertySource(properties = {
+        "namespace.root=http://uri.suomi.fi/terminology/"
 })
 class FrontendTermedServiceTest {
 
@@ -48,6 +59,9 @@ class FrontendTermedServiceTest {
 
     @Autowired
     FrontendTermedService frontEndTermedService;
+
+    @Captor
+    ArgumentCaptor<Dump> dumpCaptor;
 
     ObjectMapper mapper = new ObjectMapper();
 
@@ -435,5 +449,270 @@ class FrontendTermedServiceTest {
                 any(),
                 eq(String.class),
                 anyMap());
+    }
+
+    @Test
+    public void testCreateVersionNotAuthenticated() {
+        assertThrows(AuthorizationException.class, () -> {
+            var dto = new CreateVersionDTO(UUID.randomUUID(), "some_vocabulary");
+            frontEndTermedService.createVersion(dto);
+        });
+    }
+
+    @Test
+    public void testCreateVersionNamespaceAlreadyInUse() throws Exception {
+        mockTermedGetGraphs();
+        mockAuthorization();
+
+        assertThrows(NamespaceInUseException.class, () -> {
+            var dto = new CreateVersionDTO(UUID.randomUUID(), "test");
+            frontEndTermedService.createVersion(dto);
+        });
+    }
+
+    @Test
+    public void testCreateVersionVocabularyNotFound() {
+        mockTermedGetGraphs();
+        mockAuthorization();
+
+        assertThrows(VocabularyNotFoundException.class, () -> {
+            var dto = new CreateVersionDTO(UUID.randomUUID(), "test_v2");
+            frontEndTermedService.createVersion(dto);
+        });
+    }
+
+    @Test
+    public void testCreateNewVersion() throws Exception {
+        UUID vocabularyId = UUID.randomUUID();
+        UUID organizationId = UUID.randomUUID();
+
+        mockTermedGetGraphs();
+        mockAuthorization();
+        mockTermedGetDump(new GraphId(vocabularyId), "prefix", organizationId);
+
+        var dto = new CreateVersionDTO(vocabularyId, "prefix_v2");
+
+        var versionResponse = frontEndTermedService.createVersion(dto);
+
+        verify(termedRequester).exchange(
+                eq("/dump"),
+                eq(HttpMethod.POST),
+                any(Parameters.class),
+                eq(String.class),
+                dumpCaptor.capture());
+
+        // Modified new version data sent to termed-api
+        Dump dump = dumpCaptor.getValue();
+
+        Graph graph = dump.getGraphs().get(0);
+        String newUri = "http://uri.suomi.fi/terminology/" + dto.getNewCode() + "/";
+
+        assertEquals(newUri, versionResponse.getUri());
+
+        assertEquals(dto.getNewCode(), graph.getCode());
+        assertEquals(newUri, graph.getUri());
+
+        // graph with new id is created
+        assertNotEquals(graph.getId(), vocabularyId);
+
+        MetaNode metaNode = dump.getTypes().get(0);
+        assertEquals(graph.getId(), metaNode.getGraph().getId());
+        assertEquals("Concept", metaNode.getId());
+        assertEquals("http://www.w3.org/concept", metaNode.getUri());
+        assertEquals("metanode_prop", metaNode.getProperties().get("prop").get(0).getValue());
+
+        List<GenericNode> nodes = dump.getNodes();
+
+        // each node should have status = DRAFT and they should belong to new graph
+        nodes.forEach(n -> n.getProperties()
+                .getOrDefault("status", new ArrayList<>())
+                .stream()
+                .forEach(p -> {
+                    assertEquals("DRAFT", p.getValue());
+                    assertEquals(graph.getId(), n.getType().getGraphId());
+                }));
+
+        var vocabularyNode = getNodeByType(nodes, NodeType.TerminologicalVocabulary);
+        var conceptNode = getNodeByType(nodes, NodeType.Concept);
+        var termNode = getNodeByType(nodes, NodeType.Term);
+        var collectionNode = getNodeByType(nodes, NodeType.Collection);
+
+        // add new property 'origin' to vocabulary node
+        assertEquals(getUri("prefix", "vocabulary-1234"),
+                vocabularyNode.getProperties().get("origin").get(0).getValue());
+
+        // add suffix to terminology name
+        assertTrue(vocabularyNode.getProperties().get("prefLabel").get(0).getValue().endsWith(" (Copy)"));
+
+        // contributor's id remains the same and it should have its own graph id
+        Identifier contributor = vocabularyNode.getReferences().get("contributor").get(0);
+        assertNotEquals(graph.getId(), contributor.getType().getGraphId());
+        assertEquals(organizationId, contributor.getId());
+
+        // codes remain the same
+        assertEquals("vocabulary-1234", vocabularyNode.getCode());
+        assertEquals("concept-1234", conceptNode.getCode());
+        assertEquals("term-1234", termNode.getCode());
+
+        // uris contain new prefix
+        assertEquals(getUri(dto.getNewCode(), vocabularyNode), vocabularyNode.getUri());
+        assertEquals(getUri(dto.getNewCode(), conceptNode), conceptNode.getUri());
+        assertEquals(getUri(dto.getNewCode(), termNode), termNode.getUri());
+
+        // term and concept refer still each other
+        assertEquals(conceptNode.getReferences().get("prefLabelXl").get(0).getId(),
+                termNode.getId());
+        assertEquals(termNode.getReferrers().get("prefLabelXl").get(0).getId(),
+                conceptNode.getId());
+
+        assertEquals(conceptNode.getId(), collectionNode.getReferences().get("member").get(0).getId());
+    }
+
+    private String getUri(String prefix, String code) {
+        return "http://uri.suomi.fi/terminology/" + prefix + "/" + code + "/";
+    }
+
+    private String getUri(String prefix, GenericNode node) {
+        return getUri(prefix, node.getCode());
+    }
+
+    private GenericNode getNodeByType(List<GenericNode> nodes, NodeType nodeType) {
+        return nodes.stream()
+                .filter(n -> n.getType().getId().equals(nodeType))
+                .findFirst()
+                .get();
+    }
+
+    private void mockAuthorization() {
+        when(authorizationManager.canCreateNewVersion(any(UUID.class))).thenReturn(true);
+    }
+
+    private void mockTermedGetGraphs(Graph... graphs) {
+        var defaultGraph = new Graph(UUID.randomUUID(), "test", "http://uri.suomi.fi/test", emptyList(), emptyMap(), emptyMap());
+
+        var response = asList(defaultGraph);
+        response.addAll(asList(graphs));
+
+        when(termedRequester.exchange(
+                eq("/graphs"),
+                eq(HttpMethod.GET),
+                any(Parameters.class),
+                any(ParameterizedTypeReference.class)))
+                    .thenReturn(response);
+    }
+
+    private void mockTermedGetDump(GraphId graphId, String code, UUID orgId) {
+
+        var organizationGraphId = new GraphId(UUID.randomUUID());
+
+        var graph = new Graph(
+                graphId.getId(),
+                code,
+                "http://uri.suomi.fi/terminology/" + code,
+                emptyList(),
+                emptyMap(),
+                emptyMap());
+
+        var metaNode = new MetaNode(
+                "Concept",
+                "http://www.w3.org/concept",
+                1L,
+                graphId,
+                emptyMap(),
+                Map.of("prop", asList(new Property("fi", "metanode_prop"))),
+                emptyList(),
+                emptyList());
+
+        var organizationIdentifier = new Identifier(
+                orgId,
+                new TypeId(
+                        NodeType.Organization,
+                        organizationGraphId)
+        );
+        var termIdentifier = new Identifier(
+                UUID.randomUUID(),
+                new TypeId(
+                        NodeType.Term,
+                        graphId)
+        );
+        var conceptIdentifier = new Identifier(
+                UUID.randomUUID(),
+                new TypeId(
+                        NodeType.Concept,
+                        graphId));
+
+        var vocabularyNode = new GenericNode(
+                UUID.randomUUID(),
+                "vocabulary-1234",
+                getUri(code, "vocabulary-1234"),
+                1L,
+                "creator_user",
+                new Date(),
+                "modifier_user",
+                new Date(),
+                new TypeId(NodeType.TerminologicalVocabulary, graphId, null),
+                Map.of(
+                        "prefLabel", asList(new Attribute("fi", "value")),
+                        "status", asList(new Attribute("fi", "VALID"))),
+                Map.of("contributor", asList(organizationIdentifier)),
+                emptyMap()
+        );
+
+        var conceptNode = new GenericNode(
+                conceptIdentifier.getId(),
+                "concept-1234",
+                getUri(code, "concept-1234"),
+                1L,
+                "creator_user",
+                new Date(),
+                "modifier_user",
+                new Date(),
+                new TypeId(NodeType.Concept, graphId),
+                Map.of("status", asList(new Attribute("fi", "DRAFT"))),
+                Map.of("prefLabelXl", asList(termIdentifier)),
+                emptyMap()
+        );
+
+        var termNode = new GenericNode(
+                termIdentifier.getId(),
+                "term-1234",
+                getUri(code, "term-1234"),
+                1L,
+                "creator_user",
+                new Date(),
+                "modifier_user",
+                new Date(),
+                new TypeId(NodeType.Term, graphId),
+                Map.of(
+                        "prefLabel", asList(new Attribute("fi", "value")),
+                        "status", asList(new Attribute("fi", "VALID"))),
+                emptyMap(),
+                Map.of("prefLabelXl", asList(conceptIdentifier))
+        );
+
+        var collectionNode = new GenericNode(
+                UUID.randomUUID(),
+                "collection-1234",
+                getUri(code, "collection-1234"),
+                1L,
+                "creator_user",
+                new Date(),
+                "modifier_user",
+                new Date(),
+                new TypeId(NodeType.Collection, graphId),
+                Map.of("prefLabel", asList(new Attribute("fi", "value"))),
+                Map.of("member", asList(conceptIdentifier)),
+                emptyMap());
+
+        when(termedRequester.exchange(
+                eq("/graphs/" + graphId.getId() + "/dump"),
+                eq(HttpMethod.GET),
+                any(Parameters.class),
+                eq(Dump.class)))
+                    .thenReturn(new Dump(
+                            asList(graph),
+                            asList(metaNode),
+                            asList(vocabularyNode, conceptNode, termNode, collectionNode)
+                    ));
     }
 }


### PR DESCRIPTION
* Create a copy of the terminology and store it as new version
* Create new text attribute `origin` to hold information from which terminology new version is created 

```
curl -X POST "http://localhost:9103/terminology-api/api/v1/frontend/createVersion"  \ 
     -H "Content-Type: application/json" \
     -H "Cookie: JSESSIONID=xxx" \
     -d '{"graphId": "1e10f214-2791-48d9-b996-4ea0d3f74b8d",  "newCode": "test_v2"}'
```