### PR TITLE
YTI-1767 Create new attribute terminologyType

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/frontend/TerminologyType.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/TerminologyType.java
@@ -1,0 +1,6 @@
+package fi.vm.yti.terminology.api.frontend;
+
+public enum TerminologyType {
+    TERMINOLOGICAL_VOCABULARY,
+    OTHER_VOCABULARY
+}

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/TerminologyQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/TerminologyQueryFactory.java
@@ -2,17 +2,14 @@ package fi.vm.yti.terminology.api.frontend.elasticqueries;
 
 import java.util.*;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import fi.vm.yti.terminology.api.exception.InvalidQueryException;
-import org.apache.lucene.queryparser.flexible.core.QueryNodeException;
-import org.apache.lucene.queryparser.flexible.standard.StandardQueryParser;
+import fi.vm.yti.terminology.api.frontend.TerminologyType;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -131,14 +128,17 @@ public class TerminologyQueryFactory {
 
         QueryBuilder typeQuery = null;
         if (types != null && types.length > 0)  {
-            final var validTypes = new String[] { "TerminologicalVocabulary", "OtherVocabulary" };
+            final var validTypes = new String[] {
+                    TerminologyType.TERMINOLOGICAL_VOCABULARY.name(),
+                    TerminologyType.OTHER_VOCABULARY.name()
+            };
             if (!Arrays.asList(validTypes).containsAll(Arrays.asList(types))) {
                 log.error("One or more vocabulary types were invalid");
                 throw new InvalidQueryException("One or more vocabulary types were invalid");
             }
             // vocabulary type query must also be applied later when
             // filtering by additionalTerminologyIds
-            typeQuery = QueryBuilders.termsQuery("type.id", types);
+            typeQuery = QueryBuilders.termsQuery("terminologyType", types);
             mustQueries.add(typeQuery);
         }
 

--- a/src/main/java/fi/vm/yti/terminology/api/migration/AttributeIndex.java
+++ b/src/main/java/fi/vm/yti/terminology/api/migration/AttributeIndex.java
@@ -1,5 +1,6 @@
 package fi.vm.yti.terminology.api.migration;
 
+import fi.vm.yti.terminology.api.frontend.TerminologyType;
 import fi.vm.yti.terminology.api.model.termed.AttributeMeta;
 import fi.vm.yti.terminology.api.model.termed.TypeId;
 import org.jetbrains.annotations.NotNull;
@@ -593,6 +594,25 @@ public final class AttributeIndex {
                         PropertyUtil.prefLabel(
                                 "Kopioitu sanastosta",
                                 "Copied from"
+                        ),
+                        type("string:single")
+                )
+        );
+    }
+
+    @NotNull
+    public static AttributeMeta terminologyType(TypeId domain, long index) {
+        return new AttributeMeta(
+                "^(" + TerminologyType.OTHER_VOCABULARY  + "|" + TerminologyType.TERMINOLOGICAL_VOCABULARY + ")$",
+                "terminologyType",
+                "http://uri.suomi.fi/datamodel/ns/term/#terminologyType",
+                index,
+                domain,
+                emptyMap(),
+                merge(
+                        PropertyUtil.prefLabel(
+                                "Sanaston tyyppi",
+                                "Terminology type"
                         ),
                         type("string:single")
                 )

--- a/src/main/java/fi/vm/yti/terminology/api/migration/task/V21_TerminologyType.java
+++ b/src/main/java/fi/vm/yti/terminology/api/migration/task/V21_TerminologyType.java
@@ -1,0 +1,37 @@
+package fi.vm.yti.terminology.api.migration.task;
+
+import fi.vm.yti.migration.MigrationTask;
+import fi.vm.yti.terminology.api.migration.AttributeIndex;
+import fi.vm.yti.terminology.api.migration.MigrationService;
+import fi.vm.yti.terminology.api.model.termed.NodeType;
+import fi.vm.yti.terminology.api.model.termed.VocabularyNodeType;
+import org.springframework.stereotype.Component;
+
+/**
+ * TerminologyType acts as a "label" to indicate whether the vocabulary is maintained by professional terminology. The purpose of
+ * this property is different from using TypeId to separate different types of terminology nodes. In this case each terminology
+ * type contains the same information. Separating with TypeId, each type can contain different set of metanodes and properties.
+ *
+ * @see fi.vm.yti.terminology.api.frontend.TerminologyType
+ */
+@Component
+public class V21_TerminologyType implements MigrationTask {
+
+    private final MigrationService migrationService;
+
+    V21_TerminologyType(MigrationService migrationService) {
+        this.migrationService = migrationService;
+    }
+
+    @Override
+    public void migrate() {
+
+        migrationService.updateTypes(VocabularyNodeType.TerminologicalVocabulary, meta -> {
+            NodeType type = meta.getDomain().getId();
+
+            if (type.equals(NodeType.TerminologicalVocabulary)) {
+                meta.addAttribute(AttributeIndex.terminologyType(meta.getDomain(), 25));
+            }
+        });
+    }
+}

--- a/src/main/resources/create_vocabulary_mappings.json
+++ b/src/main/resources/create_vocabulary_mappings.json
@@ -77,6 +77,9 @@
     "type.id": {
       "type": "keyword"
     },
+    "terminologyType": {
+      "type": "keyword"
+    },
     "references.contributor.id": {
       "type": "keyword"
     },


### PR DESCRIPTION
Created new attribute terminologyType for TerminologicalVocabulary nodes. TerminologyType attribute is mapped to ES index, although for now there is no possibility to filter terminologies based on this attribute value. Added regex for the attribute to accept only values `TERMINOLOGICAL_VOCABULARY` and `OTHER_VOCABULARY`

Sample payload for searching with terminologyType = OTHER_VOCABULARY
```
{
  "query": {
      "match": {
        "properties.terminologyType.value": {
        	"query": "OTHER_VOCABULARY" 
        }
      }
  }   
}
```