### PR TITLE
Add validation of vocabulary nodes in frontend controller

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/ExceptionHandlerAdvice.java
+++ b/src/main/java/fi/vm/yti/terminology/api/ExceptionHandlerAdvice.java
@@ -25,7 +25,6 @@ import java.util.stream.Collectors;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
-// TODO: we've now extended from another class, does it add some unexpected responses?
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @ControllerAdvice
 public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler {

--- a/src/main/java/fi/vm/yti/terminology/api/ExceptionHandlerAdvice.java
+++ b/src/main/java/fi/vm/yti/terminology/api/ExceptionHandlerAdvice.java
@@ -1,14 +1,34 @@
 package fi.vm.yti.terminology.api;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.ConstraintViolationException;
+
+import fi.vm.yti.terminology.api.model.rest.ApiError;
+import fi.vm.yti.terminology.api.model.rest.ApiValidationError;
+import fi.vm.yti.terminology.api.model.rest.ApiValidationErrorDetails;
+import org.hibernate.validator.internal.engine.ConstraintViolationImpl;
+import org.hibernate.validator.internal.engine.path.PathImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import java.util.stream.Collectors;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+// TODO: we've now extended from another class, does it add some unexpected responses?
+@Order(Ordered.HIGHEST_PRECEDENCE)
 @ControllerAdvice
-public class ExceptionHandlerAdvice {
+public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(ResponseEntityExceptionHandler.class);
 
@@ -17,5 +37,35 @@ public class ExceptionHandlerAdvice {
                        HttpServletRequest request) throws Throwable {
         logger.warn("Rogue catchable thrown while handling request to \"" + request.getServletPath() + "\"", throwable);
         throw throwable;
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(
+            HttpMessageNotReadableException ex,
+            HttpHeaders headers,
+            HttpStatus status,
+            WebRequest request) {
+        String error = "Malformed JSON request";
+        return buildResponseEntity(new ApiError(HttpStatus.BAD_REQUEST, error, ex));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    protected ResponseEntity<Object> handleConstraintViolationException(
+            ConstraintViolationException ex) {
+        var apiError = new ApiValidationError(BAD_REQUEST);
+        apiError.setMessage("Object validation failed");
+        var errors = ex.getConstraintViolations().stream()
+                .map(c -> new ApiValidationErrorDetails(
+                        c.getMessage(),
+                        ((PathImpl) c.getPropertyPath()).getLeafNode().getName(),
+                        c.getInvalidValue().toString()))
+                .collect(Collectors.toList());
+
+        apiError.setDetails(errors);
+        return buildResponseEntity(apiError);
+    }
+
+    private ResponseEntity<Object> buildResponseEntity(ApiError apiError) {
+        return new ResponseEntity<>(apiError, apiError.getStatus());
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
@@ -36,6 +36,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import javax.validation.constraints.Size;
+
 import static fi.vm.yti.terminology.api.model.termed.NodeType.Group;
 import static fi.vm.yti.terminology.api.model.termed.NodeType.Organization;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -166,11 +168,22 @@ public class FrontendController {
     @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The JSON data for the new terminology node")
     @ApiResponse(responseCode = "200", description = "The ID for the newly created terminology")
     @PostMapping(path = "/vocabulary", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
-    UUID createVocabulary(@Parameter(description = "The meta model graph for the new terminology") @RequestParam UUID templateGraphId,
-                          @Parameter(description = "The prefix, i.e., freely selectable part of terminology namespace") @RequestParam String prefix,
-                          @Parameter(description = "If given, tries to use the ID for the terminology") @RequestParam(required = false) @Nullable UUID graphId,
-                          @Parameter(description = "Whether to do synchronous creation, i.e., wait for the result. This is recommended.") @RequestParam(required = false, defaultValue = "true") boolean sync,
-                          @ValidVocabularyNode @RequestBody GenericNode vocabularyNode) {
+    UUID createVocabulary(
+            @Parameter(description = "The meta model graph for the new terminology")
+            @RequestParam UUID templateGraphId,
+
+            @Size(min = 3, message = "Prefix must be minimum of 3 characters")
+            @Parameter(description = "The prefix, i.e., freely selectable part of terminology namespace")
+            @RequestParam String prefix,
+
+            @Parameter(description = "If given, tries to use the ID for the terminology")
+            @RequestParam(required = false) @Nullable UUID graphId,
+
+            @Parameter(description = "Whether to do synchronous creation, i.e., wait for the result. This is recommended.")
+            @RequestParam(required = false, defaultValue = "true") boolean sync,
+
+            @ValidVocabularyNode
+            @RequestBody GenericNode vocabularyNode) {
 
         try {
             logger.info("POST /vocabulary requested with params: templateGraphId: " +
@@ -194,10 +207,19 @@ public class FrontendController {
     @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The JSON data for the terminology node to validate")
     @ApiResponse(responseCode = "200", description = "OK on success")
     @PostMapping(path = "/vocabulary/validate", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
-    String validateVocabulary(@Parameter(description = "The meta model graph for the new terminology") @RequestParam UUID templateGraphId,
-                            @Parameter(description = "The prefix, i.e., freely selectable part of terminology namespace") @RequestParam String prefix,
-                            @Parameter(description = "If given, tries to use the ID for the terminology") @RequestParam(required = false) @Nullable UUID graphId,
-                            @ValidVocabularyNode @RequestBody GenericNode vocabularyNode) {
+    String validateVocabulary(
+            @Parameter(description = "The meta model graph for the new terminology")
+            @RequestParam UUID templateGraphId,
+
+            @Size(min = 3, message = "Prefix must be minimum of 3 characters")
+            @Parameter(description = "The prefix, i.e., freely selectable part of terminology namespace")
+            @RequestParam String prefix,
+
+            @Parameter(description = "If given, tries to use the ID for the terminology")
+            @RequestParam(required = false) @Nullable UUID graphId,
+
+            @ValidVocabularyNode
+            @RequestBody GenericNode vocabularyNode) {
 
         logger.info("POST /vocabulary/validate requested with params: templateGraphId: " +
                 templateGraphId.toString() + ", prefix: " +

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
@@ -1,16 +1,16 @@
 package fi.vm.yti.terminology.api.frontend;
 
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import fi.vm.yti.terminology.api.exception.NamespaceInUseException;
 import fi.vm.yti.terminology.api.exception.VocabularyNotFoundException;
 import fi.vm.yti.terminology.api.frontend.searchdto.*;
+import fi.vm.yti.terminology.api.validation.ValidVocabularyNode;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -35,6 +35,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
 import static fi.vm.yti.terminology.api.model.termed.NodeType.Group;
 import static fi.vm.yti.terminology.api.model.termed.NodeType.Organization;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -44,6 +45,7 @@ import static org.springframework.web.bind.annotation.RequestMethod.POST;
 @RestController
 @RequestMapping("/api/v1/frontend")
 @Tag(name = "Frontend")
+@Validated
 public class FrontendController {
 
     private final FrontendTermedService termedService;
@@ -164,22 +166,28 @@ public class FrontendController {
     @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The JSON data for the new terminology node")
     @ApiResponse(responseCode = "200", description = "The ID for the newly created terminology")
     @PostMapping(path = "/vocabulary", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
-    UUID createVocabulary(@Parameter(description = "The meta model graph for the new terminology") @RequestParam UUID templateGraphId,
+    String createVocabulary(@Parameter(description = "The meta model graph for the new terminology") @RequestParam UUID templateGraphId,
                           @Parameter(description = "The prefix, i.e., freely selectable part of terminology namespace") @RequestParam String prefix,
                           @Parameter(description = "If given, tries to use the ID for the terminology") @RequestParam(required = false) @Nullable UUID graphId,
                           @Parameter(description = "Whether to do synchronous creation, i.e., wait for the result. This is recommended.") @RequestParam(required = false, defaultValue = "true") boolean sync,
-                          @RequestBody GenericNode vocabularyNode) {
+                          @Parameter(description = "Do not actually create vocabulary, only validate the input.") @RequestParam(required = false, defaultValue = "false") boolean validateOnly,
+                          @ValidVocabularyNode @RequestBody GenericNode vocabularyNode) {
 
         try {
             logger.info("POST /vocabulary requested with params: templateGraphId: " +
                 templateGraphId.toString() + ", prefix: " + prefix + ", vocabularyNode.id: " + vocabularyNode.getId().toString());
 
             UUID predefinedOrGeneratedGraphId = graphId != null ? graphId : UUID.randomUUID();
-            termedService.createVocabulary(templateGraphId, prefix, vocabularyNode, predefinedOrGeneratedGraphId, sync);
-            logger.debug("Vocabulary with prefix \"" + prefix + "\" created");
-            return predefinedOrGeneratedGraphId;
+
+            if (!validateOnly) {
+                termedService.createVocabulary(templateGraphId, prefix, vocabularyNode, predefinedOrGeneratedGraphId, sync);
+                logger.debug("Vocabulary with prefix \"" + prefix + "\" created");
+                return predefinedOrGeneratedGraphId.toString();
+            }
+
+            return "OK";
         } catch (RuntimeException | Error e) {
-            logger.error("createVocabuluary failed", e);
+            logger.error("createVocabulary failed", e);
             throw e;
         } finally {
             logger.debug("Vocabulary creation finished");

--- a/src/main/java/fi/vm/yti/terminology/api/model/rest/ApiError.java
+++ b/src/main/java/fi/vm/yti/terminology/api/model/rest/ApiError.java
@@ -1,0 +1,55 @@
+package fi.vm.yti.terminology.api.model.rest;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ApiError {
+
+    private HttpStatus status;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
+    private LocalDateTime timestamp;
+
+    private String message;
+
+    // TODO: not for production build
+    private String debugMessage;
+
+    private ApiError() {
+        this.timestamp = LocalDateTime.now();
+    }
+
+    public ApiError(HttpStatus status) {
+        this();
+        this.status = status;
+    }
+
+    public ApiError(HttpStatus status, Throwable ex) {
+        this();
+        this.status = status;
+        this.message = "Unexpected error";
+        this.debugMessage = ex.getLocalizedMessage();
+    }
+
+    public ApiError(HttpStatus status, String message, Throwable ex) {
+        this();
+        this.status = status;
+        this.message = message;
+        this.debugMessage = ex.getLocalizedMessage();
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/model/rest/ApiError.java
+++ b/src/main/java/fi/vm/yti/terminology/api/model/rest/ApiError.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import org.springframework.http.HttpStatus;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 public class ApiError {
 
@@ -14,9 +13,6 @@ public class ApiError {
     private LocalDateTime timestamp;
 
     private String message;
-
-    // TODO: not for production build
-    private String debugMessage;
 
     private ApiError() {
         this.timestamp = LocalDateTime.now();
@@ -31,14 +27,12 @@ public class ApiError {
         this();
         this.status = status;
         this.message = "Unexpected error";
-        this.debugMessage = ex.getLocalizedMessage();
     }
 
     public ApiError(HttpStatus status, String message, Throwable ex) {
         this();
         this.status = status;
         this.message = message;
-        this.debugMessage = ex.getLocalizedMessage();
     }
 
     public HttpStatus getStatus() {

--- a/src/main/java/fi/vm/yti/terminology/api/model/rest/ApiValidationError.java
+++ b/src/main/java/fi/vm/yti/terminology/api/model/rest/ApiValidationError.java
@@ -1,0 +1,23 @@
+package fi.vm.yti.terminology.api.model.rest;
+
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+public class ApiValidationError extends ApiError {
+
+    private List<ApiValidationErrorDetails> details;
+
+    public ApiValidationError(HttpStatus status) {
+        super(status);
+    }
+
+    public List<ApiValidationErrorDetails> getDetails() {
+        return details;
+    }
+
+    public void setDetails(List<ApiValidationErrorDetails> details) {
+        this.details = details;
+    }
+}
+

--- a/src/main/java/fi/vm/yti/terminology/api/model/rest/ApiValidationErrorDetails.java
+++ b/src/main/java/fi/vm/yti/terminology/api/model/rest/ApiValidationErrorDetails.java
@@ -1,0 +1,29 @@
+package fi.vm.yti.terminology.api.model.rest;
+
+public class ApiValidationErrorDetails {
+
+    private String field;
+
+    private Object rejectedValue;
+
+    private String message;
+
+    public ApiValidationErrorDetails(String message, String field, String rejectedValue) {
+        this.message = message;
+        this.rejectedValue = rejectedValue;
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public Object getRejectedValue() {
+        return rejectedValue;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}
+

--- a/src/main/java/fi/vm/yti/terminology/api/model/termed/GenericNode.java
+++ b/src/main/java/fi/vm/yti/terminology/api/model/termed/GenericNode.java
@@ -13,26 +13,34 @@ public final class GenericNode implements Node {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private UUID id = null;
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String code = null;
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String uri = null;
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Long number = null;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String createdBy = null;
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Date createdDate = null;
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String lastModifiedBy = null;
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Date lastModifiedDate = null;
 
     private final TypeId type;
 
     private final Map<String, List<Attribute>> properties;
+
     private final Map<String, List<Identifier>> references;
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private  Map<String, List<Identifier>> referrers = null;
 

--- a/src/main/java/fi/vm/yti/terminology/api/validation/ValidVocabularyNode.java
+++ b/src/main/java/fi/vm/yti/terminology/api/validation/ValidVocabularyNode.java
@@ -1,0 +1,26 @@
+package fi.vm.yti.terminology.api.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({
+        ElementType.METHOD,
+        ElementType.FIELD,
+        ElementType.CONSTRUCTOR,
+        ElementType.PARAMETER,
+        ElementType.TYPE_USE
+})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = VocabularyNodeValidator.class)
+public @interface ValidVocabularyNode {
+
+    String message() default "Invalid data";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/fi/vm/yti/terminology/api/validation/VocabularyNodeValidator.java
+++ b/src/main/java/fi/vm/yti/terminology/api/validation/VocabularyNodeValidator.java
@@ -1,0 +1,78 @@
+package fi.vm.yti.terminology.api.validation;
+
+import fi.vm.yti.terminology.api.model.termed.GenericNode;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.lang.annotation.*;
+
+public class VocabularyNodeValidator implements
+        ConstraintValidator<ValidVocabularyNode, GenericNode>, Annotation {
+
+    private boolean constraintViolationAdded;
+
+    @Override
+    public Class<? extends Annotation> annotationType() {
+        return null;
+    }
+
+    @Override
+    public boolean isValid(GenericNode genericNode, ConstraintValidatorContext context) {
+        this.constraintViolationAdded = false;
+
+        final var properties = genericNode.getProperties();
+        if (properties.size() == 0) {
+            this.addConstraintViolation(
+                    context,
+                    "Missing value",
+                    "properties");
+        }
+
+        final var prefLabel = properties.get("prefLabel");
+        if (prefLabel == null || prefLabel.size() == 0 || prefLabel.get(0).getValue().isEmpty()) {
+            this.addConstraintViolation(
+                    context,
+                    "Missing value",
+                    "prefLabel");
+        }
+
+        final var references = genericNode.getReferences();
+        if (references == null || references.size() == 0) {
+            this.addConstraintViolation(
+                    context,
+                    "Missing value",
+                    "references");
+        }
+
+        if (!references.containsKey("contributor") || references.get("contributor").size() == 0) {
+            this.addConstraintViolation(
+                    context,
+                    "Missing value",
+                    "contributor");
+        }
+
+        if (!references.containsKey("inGroup") || references.get("inGroup").size() == 0) {
+            this.addConstraintViolation(
+                    context,
+                    "Missing value",
+                    "inGroup");
+        }
+
+        return !this.constraintViolationAdded;
+    }
+
+    private void addConstraintViolation(
+            ConstraintValidatorContext context,
+            String message,
+            String property) {
+
+        if (!this.constraintViolationAdded) {
+            context.disableDefaultConstraintViolation();
+            this.constraintViolationAdded = true;
+        }
+
+        context.buildConstraintViolationWithTemplate(message)
+                .addPropertyNode(property)
+                .addConstraintViolation();
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/validation/VocabularyNodeValidator.java
+++ b/src/main/java/fi/vm/yti/terminology/api/validation/VocabularyNodeValidator.java
@@ -1,6 +1,7 @@
 package fi.vm.yti.terminology.api.validation;
 
 import fi.vm.yti.terminology.api.frontend.Status;
+import fi.vm.yti.terminology.api.frontend.TerminologyType;
 import fi.vm.yti.terminology.api.model.termed.GenericNode;
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -44,13 +45,38 @@ public class VocabularyNodeValidator implements
                     "language");
         }
 
+        //
+        // terminologyType
+        //
+        final var terminologyType = properties.get("terminologyType");
+        if (terminologyType == null) {
+            this.addConstraintViolation(
+                    context,
+                    "Missing value",
+                    "terminologyType");
+        } else if (languages.size() != 1) {
+            this.addConstraintViolation(
+                    context,
+                    "Invalid value",
+                    "terminologyType");
+        } else {
+            final var validTypes = new String[] {
+                    TerminologyType.TERMINOLOGICAL_VOCABULARY.name(),
+                    TerminologyType.OTHER_VOCABULARY.name()
+            };
+            if (!Arrays.asList(validTypes).contains(terminologyType.get(0).getValue())) {
+                this.addConstraintViolation(
+                        context,
+                        "Invalid value",
+                        "terminologyType");
+            }
+
+        }
+
+        // type.id should always match TerminologicalVocabulary
         final var vocabularyType = genericNode.getType();
-        final var validTypes = new String[] {
-                "TerminologicalVocabulary",
-                "OtherVocabulary"
-        };
-        if (vocabularyType.getId() == null || !Arrays.asList(validTypes)
-                .contains(vocabularyType.getId().toString())) {
+        if (vocabularyType.getId() == null ||
+                !vocabularyType.getId().toString().equals("TerminologicalVocabulary")) {
             this.addConstraintViolation(
                     context,
                     "Missing value",

--- a/src/test/java/fi/vm/yti/terminology/api/frontend/FrontendControllerTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/frontend/FrontendControllerTest.java
@@ -1,0 +1,290 @@
+package fi.vm.yti.terminology.api.frontend;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.vm.yti.security.AuthenticatedUserProvider;
+import fi.vm.yti.terminology.api.ExceptionHandlerAdvice;
+import fi.vm.yti.terminology.api.model.termed.*;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+import static java.util.Collections.singletonList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@TestPropertySource(properties = {
+        "spring.cloud.config.import-check.enabled=false"
+})
+@WebMvcTest(controllers = FrontendController.class)
+public class FrontendControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private FrontendTermedService termedService;
+
+    @MockBean
+    private FrontendElasticSearchService elasticSearchService;
+
+    @MockBean
+    private FrontendGroupManagementService groupManagementService;
+
+    @MockBean
+    private AuthenticatedUserProvider userProvider;
+
+    @Autowired
+    private FrontendController frontendController;
+
+    @MockBean
+    private ObjectMapper objectMapper;
+
+    private LocalValidatorFactoryBean localValidatorFactory;
+
+    @BeforeEach
+    public void setup() {
+        this.mvc = MockMvcBuilders
+                .standaloneSetup(this.frontendController)
+                .setControllerAdvice(new ExceptionHandlerAdvice())
+                .build();
+    }
+
+    @Test
+    public void shouldValidateAndCreate() throws Exception {
+
+        // templateGraph UUID, predefined in database
+        var templateGraphId = "61cf6bde-46e6-40bb-b465-9b2c66bf4ad8";
+
+        var vocabularyNode = this.constructVocabularyNode();
+
+        this.mvc
+                .perform(post("/api/v1/frontend/vocabulary")
+                        .param("prefix", "test1")
+                        .param("templateGraphId", templateGraphId)
+                        .param("validateOnly", "false")
+                        .contentType("application/json")
+                        .content(convertObjectToJsonString(vocabularyNode)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"))
+                .andExpect(content().string(this.uuidMatcher));
+
+        verify(this.termedService, times(1))
+                .createVocabulary(
+                        any(UUID.class),
+                        any(String.class),
+                        any(GenericNode.class),
+                        any(UUID.class),
+                        eq(true));
+        verifyNoMoreInteractions(this.termedService);
+        System.out.println("done!");
+
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideVocabularyNodesWithMissingData")
+    public void shouldFailOnMissingData(GenericNode vocabularyNode) throws Exception {
+
+        // templateGraph UUID, predefined in database
+        var templateGraphId = "61cf6bde-46e6-40bb-b465-9b2c66bf4ad8";
+
+        this.mvc
+                .perform(post("/api/v1/frontend/vocabulary")
+                        .param("prefix", "test1")
+                        .param("templateGraphId", templateGraphId)
+                        .param("validateOnly", "true")
+                        .contentType("application/json")
+                        .content(convertObjectToJsonString(vocabularyNode)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType("application/json"))
+                .andExpect(jsonPath("$.message").value("Object validation failed"))
+                .andExpect(jsonPath("$.details").exists());
+
+        verify(this.termedService, times(0))
+                .createVocabulary(
+                        any(UUID.class),
+                        any(String.class),
+                        any(GenericNode.class),
+                        any(UUID.class),
+                        eq(true));
+        verifyNoMoreInteractions(this.termedService);
+        System.out.println("done!");
+
+    }
+
+    @Test
+    public void shouldValidateOnly() throws Exception {
+
+        // templateGraph UUID, predefined in database
+        var templateGraphId = "61cf6bde-46e6-40bb-b465-9b2c66bf4ad8";
+
+        UUID userId = UUID.fromString("c1094f2e-2be3-47d2-b27b-fbe5344b711e");
+
+        var vocabularyNode = constructVocabularyNode();
+
+        this.mvc
+                .perform(get("/api/v1/frontend/authenticated-user")
+                        .contentType("application/json"))
+                .andExpect(status().isOk());
+
+        this.mvc
+                .perform(post("/api/v1/frontend/vocabulary")
+                        .param("prefix", "test1")
+                        .param("templateGraphId", templateGraphId)
+                        .param("validateOnly", "true")
+                        .contentType("application/json")
+                        .content(convertObjectToJsonString(vocabularyNode)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"))
+                .andExpect(content().string("OK"));
+
+        verifyNoMoreInteractions(this.termedService);
+        System.out.println("done!");
+
+    }
+
+    private static Stream<Arguments> provideVocabularyNodesWithMissingData() {
+        var args = new ArrayList<GenericNode>();
+
+        // without a property
+        var properties = constructProperties();
+        properties.remove("prefLabel");
+        args.add(constructVocabularyNode(
+                properties, constructReferences(), constructReferrers()));
+
+        // without contributor
+        var references = constructReferences();
+        references.remove("contributor");
+        references.put("contributor", new ArrayList<>());
+        args.add(constructVocabularyNode(
+                constructProperties(), references, constructReferrers()));
+
+        // without group
+        references = constructReferences();
+        references.remove("inGroup");
+        references.put("inGroup", new ArrayList<>());
+        args.add(constructVocabularyNode(
+                constructProperties(), references, constructReferrers()));
+
+        return args.stream().map(a -> Arguments.of(a));
+    }
+
+    private static HashMap<String, List<Attribute>> constructProperties() {
+        // prepare vocabularyNode for creating a new vocabulary
+        var properties = new HashMap<String, List<Attribute>>();
+        properties.put(
+                "prefLabel",
+                Arrays.asList(
+                        new Attribute("en", "test label")
+                ));
+        properties.put("description", new ArrayList());
+        properties.put(
+                "language",
+                singletonList(new Attribute("", "fi")));
+        properties.put(
+                "status",
+                singletonList(new Attribute("", "DRAFT")));
+        properties.put(
+                "priority",
+                singletonList(new Attribute("", "")));
+        properties.put(
+                "contact",
+                singletonList(new Attribute("", "")));
+        properties.put(
+                "origin",
+                singletonList(new Attribute("", "")));
+
+        return properties;
+    }
+
+    private static HashMap<String, List<Identifier>> constructReferences() {
+        var references = new HashMap<String, List<Identifier>>();
+
+        var org1 = new Identifier(
+                UUID.fromString("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63"),
+                new TypeId(
+                        NodeType.Organization,
+                        new GraphId(UUID.fromString("228cce1e-8360-4039-a3f7-725df5643354"))));
+        references.put("contributor", Arrays.asList(org1));
+
+        var group1 = new Identifier(
+                UUID.fromString("9ba19f8d-d688-39cc-b620-ebb7875e6e9b"),
+                new TypeId(
+                        NodeType.Group,
+                        new GraphId(UUID.fromString("7f4cb68f-31f6-4bf9-b699-9d72dd110c4c"))));
+        references.put("inGroup", Arrays.asList(group1));
+
+        return references;
+    }
+
+    private static HashMap<String, List<Identifier>> constructReferrers() {
+        var referrers = new HashMap<String, List<Identifier>>();
+        return referrers;
+    }
+
+    private static GenericNode constructVocabularyNode() {
+        return constructVocabularyNode(
+                constructProperties(),
+                constructReferences(),
+                constructReferrers());
+    }
+
+    private static GenericNode constructVocabularyNode(
+            Map<String, List<Attribute>> properties,
+            Map<String, List<Identifier>> references,
+            Map<String, List<Identifier>> referrers) {
+
+        // templateGraph UUID, predefined in database
+        var templateGraphId = "61cf6bde-46e6-40bb-b465-9b2c66bf4ad8";
+
+        var vocabularyNode = new GenericNode(
+                UUID.randomUUID(), // TODO node graph id predefined
+                null,
+                null,
+                40L,
+                "creator",
+                new Date(),             // createdDate
+                "modifier",
+                new Date(),             // lastModifiedDate
+
+                // type
+                new TypeId(
+                        NodeType.TerminologicalVocabulary,
+                        new GraphId(UUID.fromString(templateGraphId))),
+
+                properties,             // properties
+                references,             // references
+                referrers               // referrers
+        );
+
+        return vocabularyNode;
+    }
+
+    private String convertObjectToJsonString(GenericNode node) throws JsonProcessingException {
+        var mapper = new ObjectMapper();
+        return mapper.writeValueAsString(node);
+    }
+
+    private Matcher<String> uuidMatcher = Matchers.matchesRegex(
+            "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$");
+}

--- a/src/test/java/fi/vm/yti/terminology/api/frontend/FrontendControllerTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/frontend/FrontendControllerTest.java
@@ -81,7 +81,7 @@ public class FrontendControllerTest {
 
         this.mvc
                 .perform(post("/api/v1/frontend/vocabulary")
-                        .param("prefix", "te")
+                        .param("prefix", "test1")
                         .param("templateGraphId", templateGraphId)
                         .contentType("application/json")
                         .content(convertObjectToJsonString(vocabularyNode)))
@@ -117,7 +117,7 @@ public class FrontendControllerTest {
 
         if (shouldSucceed) {
             request
-                    .andDo(print())
+                    // .andDo(print())
                     .andExpect(status().isOk())
                     .andExpect(content().contentType("application/json"))
                     .andExpect(content().string(this.uuidMatcher));
@@ -192,7 +192,7 @@ public class FrontendControllerTest {
                         .param("templateGraphId", templateGraphId)
                         .contentType("application/json")
                         .content(convertObjectToJsonString(vocabularyNode)))
-                //.andDo(print())
+                // .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().contentType("application/json"))
                 .andExpect(content().string("OK"));
@@ -250,9 +250,9 @@ public class FrontendControllerTest {
         args.add(constructVocabularyNode(
                 properties, constructReferences(), constructReferrers()));
 
-        // without type
+        // without terminologyType
         properties = constructProperties();
-        properties.remove("status");
+        properties.remove("terminologyType");
         args.add(constructVocabularyNode(
                 properties, constructReferences(), constructReferrers()));
 
@@ -291,6 +291,9 @@ public class FrontendControllerTest {
         properties.put(
                 "language",
                 singletonList(new Attribute("", "en")));
+        properties.put(
+                "terminologyType",
+                singletonList(new Attribute("", "TERMINOLOGICAL_VOCABULARY")));
         properties.put(
                 "status",
                 singletonList(new Attribute("", "DRAFT")));


### PR DESCRIPTION
## Implementation

Validation of vocabulary nodes is now implemented with a custom validation constraint, which is enabled specifically for the `vocabularyNode` argument of the `createVocabulary` method in `FrontendController`.

This is done with a single validator (`VocabularyNodeValidator`) instead of applying smaller validators directly in `GenericNode`, with the assumption that these validations might be specific to this use case and `GenericNode` may still have other uses where different validations may be needed.

## Validation only

The `createVocabulary` controller method has also been extended with a new parameter `validateOnly`, which will skip the actual vocabulary creation, and can be used to only validate input.

## Error messages

Validation errors are returned to user as JSON objects representing the newly added `ApiValidationError`, which extends a base class `ApiError`. `ApiError` may later be used as a generic error message for all API errors.

Example of `ApiError`:
```json
{
  "status": "BAD_REQUEST",
  "timestamp": "19-04-2022 04:38:10",
  "message": "Malformed JSON request"
}
```

Example of `ApiValidationError`:
```json
{
  "status": "BAD_REQUEST",
  "timestamp": "19-04-2022 04:32:26",
  "message": "Object validation failed",
  "details": [
    {
      "field": "vocabularyNode",
      "rejectedValue": "fi.vm.yti.terminology.api.model.termed.GenericNode@5b78c905",
      "message": "Invalid data"
    },
    {
      "field": "contributor",
      "rejectedValue": "fi.vm.yti.terminology.api.model.termed.GenericNode@5b78c905",
      "message": "Missing value"
    }
  ]
}
```