### PR TITLE
YTI-1886 Validation and migration changes

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/migration/AttributeIndex.java
+++ b/src/main/java/fi/vm/yti/terminology/api/migration/AttributeIndex.java
@@ -603,7 +603,6 @@ public final class AttributeIndex {
     @NotNull
     public static AttributeMeta terminologyType(TypeId domain, long index) {
         return new AttributeMeta(
-                "^(" + TerminologyType.OTHER_VOCABULARY  + "|" + TerminologyType.TERMINOLOGICAL_VOCABULARY + ")$",
                 "terminologyType",
                 "http://uri.suomi.fi/datamodel/ns/term/#terminologyType",
                 index,

--- a/src/main/java/fi/vm/yti/terminology/api/migration/task/V22_LinkAndSubjectAreaProperties.java
+++ b/src/main/java/fi/vm/yti/terminology/api/migration/task/V22_LinkAndSubjectAreaProperties.java
@@ -8,10 +8,10 @@ import fi.vm.yti.terminology.api.model.termed.VocabularyNodeType;
 import org.springframework.stereotype.Component;
 
 @Component
-public class V22_LinkTermEquivalencyAndSubjectAreaProperties implements MigrationTask  {
+public class V22_LinkAndSubjectAreaProperties implements MigrationTask  {
     private final MigrationService migrationService;
 
-    V22_LinkTermEquivalencyAndSubjectAreaProperties(MigrationService migrationService) {
+    V22_LinkAndSubjectAreaProperties(MigrationService migrationService) {
         this.migrationService = migrationService;
     }
 
@@ -26,9 +26,6 @@ public class V22_LinkTermEquivalencyAndSubjectAreaProperties implements Migratio
                 meta.addAttribute(AttributeIndex.subjectArea(meta.getDomain(), 35));
             }
 
-            if (type.equals(NodeType.Term)) {
-                meta.addAttribute(AttributeIndex.termEquivalencyRelation(meta.getDomain(), 20));
-            }
         });
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/validation/VocabularyNodeValidator.java
+++ b/src/main/java/fi/vm/yti/terminology/api/validation/VocabularyNodeValidator.java
@@ -48,29 +48,36 @@ public class VocabularyNodeValidator implements
         //
         // terminologyType
         //
-        final var terminologyType = properties.get("terminologyType");
+        //
+        /* TODO: add null check for terminologyType after release
         if (terminologyType == null) {
             this.addConstraintViolation(
                     context,
                     "Missing value",
                     "terminologyType");
-        } else if (languages.size() != 1) {
-            this.addConstraintViolation(
-                    context,
-                    "Invalid value",
-                    "terminologyType");
-        } else {
-            final var validTypes = new String[] {
-                    TerminologyType.TERMINOLOGICAL_VOCABULARY.name(),
-                    TerminologyType.OTHER_VOCABULARY.name()
-            };
-            if (!Arrays.asList(validTypes).contains(terminologyType.get(0).getValue())) {
+        }
+        */
+        final var terminologyType = properties.get("terminologyType");
+        if (terminologyType != null) {
+            if (terminologyType.size() != 1) {
                 this.addConstraintViolation(
                         context,
                         "Invalid value",
                         "terminologyType");
+            } else {
+                // TODO: remove empty string from validTypes after release
+                final var validTypes = new String[]{
+                        "",
+                        TerminologyType.TERMINOLOGICAL_VOCABULARY.name(),
+                        TerminologyType.OTHER_VOCABULARY.name()
+                };
+                if (!Arrays.asList(validTypes).contains(terminologyType.get(0).getValue())) {
+                    this.addConstraintViolation(
+                            context,
+                            "Invalid value",
+                            "terminologyType");
+                }
             }
-
         }
 
         // type.id should always match TerminologicalVocabulary

--- a/src/main/java/fi/vm/yti/terminology/api/validation/VocabularyNodeValidator.java
+++ b/src/main/java/fi/vm/yti/terminology/api/validation/VocabularyNodeValidator.java
@@ -126,6 +126,7 @@ public class VocabularyNodeValidator implements
                     "prefLabel");
         } else {
             // should have one label for each language
+            /* TODO enable language mismatch check after new version release
             var labelLanguages = prefLabel.stream()
                     .map(label -> label.getLang())
                     .collect(Collectors.toList());
@@ -135,6 +136,7 @@ public class VocabularyNodeValidator implements
                         "Language mismatch",
                         "prefLabel");
             }
+            */
 
             // empty strings as values?
             var emptyValues = prefLabel.stream()


### PR DESCRIPTION
* Validate terminologyType only if given
* Remove regular  expression from terminologyType
* Remove redundant property termEquivalencyRelation from term

It's quite a bad practice to modify existing migration scripts but since changes are deployed only dev environment, I think it's clearer in this case manually clean up the database, rather than create new migration script to revert these changes. Besides, changing regular expression is not even possible to modify with existing functionalities