### PR TITLE
YTI-1871 Default statuses and sorting

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/ConceptQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/ConceptQueryFactory.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import fi.vm.yti.terminology.api.frontend.Status;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.index.query.BoolQueryBuilder;
@@ -97,6 +98,15 @@ public class ConceptQueryFactory {
         if (request.getStatus() != null && request.getStatus().length > 0) {
             QueryBuilder statusQuery = QueryBuilders.termsQuery("status", request.getStatus());
             mustParts.add(statusQuery);
+        } else if (request.getStatus() != null && request.getStatus().length == 0) {
+            // By default, do not show RETIRED and SUPERSEDED statuses
+            // for old application (request.getStatus() == null) show all statuses
+            mustParts.add(QueryBuilders.termsQuery("status",
+                    Status.DRAFT.name(),
+                    Status.VALID.name(),
+                    Status.INCOMPLETE.name(),
+                    Status.SUGGESTED.name())
+            );
         }
 
         // Checks regarding data in INCOMPLETE state. Basic idea is to show INCOMPLETE things only to the contributors. But.

--- a/src/main/java/fi/vm/yti/terminology/api/index/Concept.java
+++ b/src/main/java/fi/vm/yti/terminology/api/index/Concept.java
@@ -3,10 +3,9 @@ package fi.vm.yti.terminology.api.index;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import fi.vm.yti.terminology.api.util.IndexUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import fi.vm.yti.terminology.api.util.JsonUtils;
 
 import java.util.*;
 
@@ -189,21 +188,6 @@ final class Concept {
         return narrowerIds;
     }
 
-    private @NotNull Map<String, List<String>> getSingleLabelAsLower() {
-
-        Map<String, List<String>> result = new LinkedHashMap<>();
-
-        for (Map.Entry<String, List<String>> entry : label.entrySet()) {
-
-            String language = entry.getKey();
-            List<String> singleLocalizationAsLower = entry.getValue().stream().limit(1).map(String::toLowerCase).collect(toList());
-
-            result.put(language, singleLocalizationAsLower);
-        }
-
-        return result;
-    }
-
     @NotNull JsonNode toElasticSearchDocument(ObjectMapper mapper) {
 
         ObjectNode output = mapper.createObjectNode();
@@ -214,7 +198,7 @@ final class Concept {
         output.set("definition", localizableToJson(mapper, definition));
         output.set("label", localizableToJson(mapper, label));
         output.set("altLabel", localizableToJson(mapper, altLabel));
-        output.set("sortByLabel", localizableToJson(mapper, getSingleLabelAsLower()));
+        output.set("sortByLabel", localizableToJson(mapper, IndexUtil.createSortLabels(label)));
 
         if (createdDate != null) {
             output.put("created", createdDate);

--- a/src/main/java/fi/vm/yti/terminology/api/index/IndexElasticSearchService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/index/IndexElasticSearchService.java
@@ -3,12 +3,10 @@ package fi.vm.yti.terminology.api.index;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import fi.vm.yti.terminology.api.exception.ElasticEndpointException;
 import fi.vm.yti.terminology.api.util.RestHighLevelClientWrapper;
 import org.apache.http.HttpEntity;
-import org.apache.http.HttpHost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
 import org.elasticsearch.action.search.SearchRequest;
@@ -16,7 +14,6 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.RequestOptions;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -35,9 +32,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import fi.vm.yti.terminology.api.util.JsonUtils;
 import fi.vm.yti.terminology.api.util.Parameters;
-import fi.vm.yti.terminology.api.model.termed.*;
 
 import static fi.vm.yti.terminology.api.util.ElasticRequestUtils.responseContentAsJson;
 import static fi.vm.yti.terminology.api.util.ElasticRequestUtils.responseContentAsString;
@@ -151,7 +146,7 @@ public class IndexElasticSearchService {
         vocabularies.forEach(o -> {
             try {
                 String line = "{\"index\":{\"_index\": \"vocabularies\", \"_type\": \"vocabulary" + "\", \"_id\":"
-                        + o.get("id") + "}}\n" + mapper.writeValueAsString(o) + "\n";
+                          + o.get("id") + "}}\n" + Vocabulary.toElasticSearchVocabularyIndexObject(mapper, o) + "\n";
                 indexLines.add(line);
                 if (log.isDebugEnabled()) {
                     log.debug("reindex line:" + line);
@@ -200,7 +195,7 @@ public class IndexElasticSearchService {
         ObjectMapper mapper = new ObjectMapper();
         try {
             String index = "{\"index\":{\"_index\": \"vocabularies\", \"_type\": \"" + "vocabulary" + "\", \"_id\":"
-                    + jn.get("id") + "}}\n" + mapper.writeValueAsString(jn) + "\n";
+                    + jn.get("id") + "}}\n" + Vocabulary.toElasticSearchVocabularyIndexObject(mapper, jn) + "\n";
             String delete = "";
             // CHANGED CONTENT TYPE FOR ELASTIC 6.X
             HttpEntity entity = new NStringEntity(index + delete,

--- a/src/main/java/fi/vm/yti/terminology/api/index/Vocabulary.java
+++ b/src/main/java/fi/vm/yti/terminology/api/index/Vocabulary.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import fi.vm.yti.terminology.api.util.IndexUtil;
 import org.jetbrains.annotations.NotNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -11,6 +13,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import fi.vm.yti.terminology.api.util.JsonUtils;
+
+import static fi.vm.yti.terminology.api.util.JsonUtils.localizableToJson;
 
 public final class Vocabulary {
 
@@ -76,5 +80,11 @@ public final class Vocabulary {
         output.put("status", status);
 
         return output;
+    }
+
+    static @NotNull String toElasticSearchVocabularyIndexObject(ObjectMapper mapper, JsonNode jsonNode) throws JsonProcessingException {
+        Map<String, List<String>> prefLabel = JsonUtils.localizableFromTermedProperties(jsonNode.get("properties"), "prefLabel");
+        ((ObjectNode)jsonNode).set("sortByLabel", localizableToJson(mapper, IndexUtil.createSortLabels(prefLabel)));
+        return mapper.writeValueAsString(jsonNode);
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/util/IndexUtil.java
+++ b/src/main/java/fi/vm/yti/terminology/api/util/IndexUtil.java
@@ -1,0 +1,39 @@
+package fi.vm.yti.terminology.api.util;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toList;
+
+public class IndexUtil {
+
+    static final List<String> SORT_LABEL_LANGUAGES = List.of("fi", "sv", "en");
+
+    public static Map<String, List<String>> createSortLabels(Map<String, List<String>> label) {
+        Map<String, List<String>> result = new LinkedHashMap<>();
+
+        for (Map.Entry<String, List<String>> entry : label.entrySet()) {
+
+            String language = entry.getKey();
+            List<String> singleLocalizationAsLower = entry.getValue().stream().limit(1).map(String::toLowerCase).collect(toList());
+
+            result.put(language, singleLocalizationAsLower);
+        }
+
+        // Add default sort label for missing languages
+        List<String> defaultValue = result
+                .getOrDefault("fi", result.get(0))
+                .stream()
+                .map(String::toLowerCase)
+                .collect(toList());
+
+        SORT_LABEL_LANGUAGES.forEach(lang -> {
+            if (!result.containsKey(lang)) {
+                result.put(lang, defaultValue);
+            }
+        });
+
+        return result;
+    }
+}


### PR DESCRIPTION
* By default show only statuses DRAFT, VALID, INCOMPLETE and SUGGESTED
* Add sortBy labels for terminologies and concepts for each language