### PR TITLE
YTI-1884 Fix termed service caching

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/security/DefaultAuthorizationTermedService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/security/DefaultAuthorizationTermedService.java
@@ -22,7 +22,6 @@ import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.web.util.TagUtils.SCOPE_REQUEST;
 
 @Service
-@Scope(value = SCOPE_REQUEST, proxyMode = INTERFACES)
 public class DefaultAuthorizationTermedService implements AuthorizationTermedService {
 
     private final Map<UUID, Set<UUID>> cache = new HashMap<>();

--- a/src/main/java/fi/vm/yti/terminology/api/security/DefaultAuthorizationTermedService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/security/DefaultAuthorizationTermedService.java
@@ -1,39 +1,59 @@
 package fi.vm.yti.terminology.api.security;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import fi.vm.yti.terminology.api.TermedRequester;
 import fi.vm.yti.terminology.api.model.termed.GenericNode;
 import fi.vm.yti.terminology.api.model.termed.Identifier;
 import fi.vm.yti.terminology.api.util.Parameters;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Scope;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import static fi.vm.yti.terminology.api.model.termed.VocabularyNodeType.TerminologicalVocabulary;
 import static fi.vm.yti.terminology.api.model.termed.VocabularyNodeType.Vocabulary;
 import static fi.vm.yti.terminology.api.util.CollectionUtils.mapToSet;
 import static fi.vm.yti.terminology.api.util.CollectionUtils.requireSingle;
 import static java.util.Collections.emptyList;
-import static org.springframework.context.annotation.ScopedProxyMode.INTERFACES;
 import static org.springframework.http.HttpMethod.GET;
-import static org.springframework.web.util.TagUtils.SCOPE_REQUEST;
 
 @Service
 public class DefaultAuthorizationTermedService implements AuthorizationTermedService {
 
-    private final Map<UUID, Set<UUID>> cache = new HashMap<>();
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultAuthorizationTermedService.class);
+
+    private final Cache<UUID, Set<UUID>> cache;
     private final TermedRequester termedRequester;
 
     @Autowired
-    public DefaultAuthorizationTermedService(TermedRequester termedRequester) {
+    public DefaultAuthorizationTermedService(
+            TermedRequester termedRequester,
+            @Value("${termed.cache.expiration:1800}") Long cacheExpireTime
+    ) {
         this.termedRequester = termedRequester;
+
+        this.cache = CacheBuilder.newBuilder()
+                .expireAfterWrite(cacheExpireTime, TimeUnit.SECONDS)
+                .maximumSize(1000)
+                .build();
     }
 
     @NotNull public Set<UUID> getOrganizationIds(UUID graphId) {
-        return cache.computeIfAbsent(graphId, this::fetchOrganizationIds);
+        Set<UUID> uuids = null;
+        try {
+            uuids = cache.get(graphId, () -> fetchOrganizationIds(graphId));
+        } catch (ExecutionException e) {
+            LOG.error("Error fetching cached organization ids", e);
+        }
+        return uuids;
     }
 
     private Set<UUID> fetchOrganizationIds(UUID graphId) {

--- a/src/test/java/fi/vm/yti/terminology/api/frontend/FrontendTermedServiceTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/frontend/FrontendTermedServiceTest.java
@@ -14,6 +14,7 @@ import fi.vm.yti.terminology.api.model.termed.*;
 import fi.vm.yti.terminology.api.security.AuthorizationManager;
 import fi.vm.yti.terminology.api.util.Parameters;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -151,6 +152,11 @@ class FrontendTermedServiceTest {
     final JsonNode initOrgsNodeMissing = mapper.readTree(organizationsJsonMissingData);
 
     FrontendTermedServiceTest() throws JsonProcessingException {
+    }
+
+    @BeforeEach
+    public void setUp() {
+        frontEndTermedService.flushCache();
     }
 
     @Test

--- a/src/test/java/fi/vm/yti/terminology/service/DefaultAuthorizationTermedServiceTest.java
+++ b/src/test/java/fi/vm/yti/terminology/service/DefaultAuthorizationTermedServiceTest.java
@@ -1,0 +1,116 @@
+package fi.vm.yti.terminology.service;
+
+import fi.vm.yti.terminology.api.TermedRequester;
+import fi.vm.yti.terminology.api.model.termed.*;
+import fi.vm.yti.terminology.api.security.DefaultAuthorizationTermedService;
+import fi.vm.yti.terminology.api.util.Parameters;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.*;
+
+@ExtendWith(SpringExtension.class)
+@Import({
+        DefaultAuthorizationTermedService.class,
+})
+@TestPropertySource(properties = {
+        "termed.cache.expiration=3"
+})
+public class DefaultAuthorizationTermedServiceTest {
+
+    @MockBean
+    TermedRequester requester;
+
+    @Autowired
+    DefaultAuthorizationTermedService service;
+
+    private UUID organizationId = UUID.fromString("9adc94fb-65ab-4fd1-a9ef-de126b26cbe6");
+
+    @BeforeEach
+    public void setUp() {
+        when(requester
+                .exchange(eq("/node-trees"),
+                        eq(HttpMethod.GET),
+                        any(Parameters.class),
+                        any(ParameterizedTypeReference.class)
+                )
+        ).thenReturn(getSampleNode());
+    }
+
+    @Test
+    public void cachedOrganizations() {
+        UUID graphId = UUID.randomUUID();
+
+        Set<UUID> ids = service.getOrganizationIds(graphId);
+        service.getOrganizationIds(graphId);
+
+        // expect only one requester interaction, because result is cached
+        verify(requester).exchange(eq("/node-trees"),
+                eq(HttpMethod.GET),
+                any(Parameters.class),
+                any(ParameterizedTypeReference.class));
+        assertEquals(organizationId, ids.iterator().next());
+    }
+
+    @Test
+    public void cachedOrganizationsExpired() throws Exception {
+        UUID graphId = UUID.randomUUID();
+
+        Set<UUID> ids = service.getOrganizationIds(graphId);
+
+        // Wait for cache expiration
+        Thread.sleep(4000);
+
+        service.getOrganizationIds(graphId);
+
+        // expect two requester interactions, because cache has been expired
+        verify(requester, times(2)).exchange(eq("/node-trees"),
+                eq(HttpMethod.GET),
+                any(Parameters.class),
+                any(ParameterizedTypeReference.class));
+
+        assertEquals(organizationId, ids.iterator().next());
+    }
+
+    private List<GenericNode> getSampleNode() {
+        var node = new GenericNode(
+                UUID.randomUUID(),
+                null,
+                null,
+                1L,
+                "creator",
+                new Date(),
+                "modifier",
+                new Date(),
+                new TypeId(
+                        NodeType.TerminologicalVocabulary,
+                        new GraphId(UUID.randomUUID())),
+                Collections.emptyMap(),
+                Map.of("contributor",
+                        List.of(new Identifier(
+                                organizationId,
+                                        new TypeId(
+                                                NodeType.Organization,
+                                                new GraphId(UUID.randomUUID())
+                                        )
+                                )
+                        )
+                ),
+                Collections.emptyMap()
+        );
+
+        return Arrays.asList(node);
+    }
+}


### PR DESCRIPTION
- Use session scope instead of request scope in DefaultAuthorizationTermedService, because caching doesn't work, if new instance is created for each request
- Use guava cache with configurable expiration time and added caching also for fetching organizations and groups