### PR TITLE
YTI-1923 patch existing nodes in excel import

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/importapi/ExcelImportJmsListener.java
+++ b/src/main/java/fi/vm/yti/terminology/api/importapi/ExcelImportJmsListener.java
@@ -1,10 +1,13 @@
 package fi.vm.yti.terminology.api.importapi;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import fi.vm.yti.terminology.api.TermedRequester;
 import fi.vm.yti.terminology.api.model.termed.GenericDeleteAndSave;
+import fi.vm.yti.terminology.api.model.termed.GenericNode;
 import fi.vm.yti.terminology.api.util.Parameters;
+import org.apache.commons.lang3.time.StopWatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jms.annotation.JmsListener;
@@ -12,8 +15,10 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
 
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
 
 @Component
@@ -36,22 +41,29 @@ public class ExcelImportJmsListener {
             .expireAfterAccess(10, TimeUnit.MINUTES)
             .build();
 
+    Cache<String, Set<String>> nodeIdCache = CacheBuilder
+            .newBuilder()
+            .expireAfterAccess(10, TimeUnit.MINUTES)
+            .build();
     /**
      * Receives message from the queue and saves the batch to Termed
      */
     @JmsListener(destination = "${mq.active.subsystem}ExcelImport")
-    public void importNodes(final Message<GenericDeleteAndSave> message,
+    public void importNodes(final Message<List<GenericNode>> message,
                             @Header String jobtoken,
                             @Header String userId,
                             @Header String uri,
                             @Header Integer currentBatch,
-                            @Header Integer totalBatchCount) {
+                            @Header Integer totalBatchCount,
+                            @Header String vocabularyId) {
 
-        LOGGER.info("Handling batch {}/{}, jobtoken {}. Sent by user {}", currentBatch, totalBatchCount, jobtoken, userId);
+        LOGGER.info("Handling batch {}/{}, jobtoken {}, size {}. Sent by user {}", currentBatch, totalBatchCount,
+                jobtoken, message.getPayload().size(), userId);
 
         Parameters params = new Parameters();
         params.add("changeset", "true");
         params.add("sync", "true");
+        params.add("append", "false");
 
         ImportStatusResponse response = statusResponseCache.getIfPresent(jobtoken);
 
@@ -69,25 +81,33 @@ public class ExcelImportJmsListener {
                 return;
             }
 
-            requester.exchange("/nodes", POST, params, String.class, message.getPayload(), userId, "user");
+            GenericDeleteAndSave payload = getPayload(vocabularyId, message.getPayload());
+            StopWatch sw = StopWatch.createStarted();
+            LOGGER.info("Saving to Termed, save: {}, patch: {}", payload.getSave().size(), payload.getPatch().size());
 
-            LOGGER.info("Batch {}/{} handled, jobtoken {}. Imported {} nodes",
-                    currentBatch, totalBatchCount, jobtoken, message.getPayload().getSave().size());
+            requester.exchange("/nodes", POST, params, String.class,
+                    payload, userId, "user");
+
+            LOGGER.info("Batch {}/{} handled, jobtoken {}. Imported {} nodes in {}ms",
+                    currentBatch, totalBatchCount, jobtoken, message.getPayload().size(), sw.getTime());
 
             response.setProcessingProgress(currentBatch);
             response.setProcessingTotal(totalBatchCount);
             response.addStatusMessage(new ImportStatusMessage(
                     ImportStatusMessage.Level.INFO,
                     "Vocabulary",
-                    String.format("Saved %d nodes", message.getPayload().getSave().size()))
+                    String.format("Saved %d nodes", message.getPayload().size()))
             );
             if (currentBatch.equals(totalBatchCount)) {
                 response.setStatus(ImportStatusResponse.ImportStatus.SUCCESS);
                 status = YtiMQService.STATUS_READY;
+                nodeIdCache.invalidate(vocabularyId);
             } else {
                 response.setStatus(ImportStatusResponse.ImportStatus.PROCESSING);
             }
         } catch (Exception e) {
+            nodeIdCache.invalidate(vocabularyId);
+
             response.setStatus(ImportStatusResponse.ImportStatus.FAILURE);
             response.setResultsError(response.getResultsError() == null ? 1 : response.getResultsError() + 1);
             response.addStatusMessage(new ImportStatusMessage(
@@ -100,5 +120,41 @@ public class ExcelImportJmsListener {
         }
         statusResponseCache.put(jobtoken, response);
         mqService.setStatus(status, jobtoken, userId, uri, response.toString());
+    }
+
+    /**
+     * Constructs payload for termed. If node exists add to patch list. If not, add it to save list
+     */
+    private GenericDeleteAndSave getPayload(String graphId, List<GenericNode> nodes) {
+        Set<String> nodeIds = nodeIdCache.getIfPresent(graphId);
+
+        if (nodeIds == null) {
+            nodeIds = new HashSet<>();
+            Parameters parameters = new Parameters();
+            parameters.add("select", "id");
+            parameters.add("where", "graph.id:" + graphId);
+            parameters.add("max", "-1");
+
+            StopWatch sw = StopWatch.createStarted();
+            JsonNode existingNodes = requester.exchange("/node-trees", GET, parameters, JsonNode.class);
+            for (JsonNode n : existingNodes) {
+                nodeIds.add(n.get("id").textValue());
+            }
+            LOGGER.info("Fetch node ids in {}ms", sw.getTime());
+            nodeIdCache.put(graphId, nodeIds);
+        }
+
+        List<GenericNode> save = new ArrayList<>();
+        List<GenericNode> patch = new ArrayList<>();
+
+        for (GenericNode node : nodes) {
+            if (nodeIds.contains(node.getId().toString())) {
+                patch.add(node);
+            } else {
+                save.add(node);
+            }
+        }
+
+        return new GenericDeleteAndSave(Collections.emptyList(), save, patch);
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/importapi/ImportUtil.java
+++ b/src/main/java/fi/vm/yti/terminology/api/importapi/ImportUtil.java
@@ -19,14 +19,14 @@ public class ImportUtil {
      * because all referred nodes must reside in the same batch
      *
      * @param allNodes
-     * @param batchSize
+     * @param maxBatchSize
      * @return
      */
-    public static List<List<GenericNode>> getBatches(List<GenericNode> allNodes, int batchSize) {
+    public static List<List<GenericNode>> getBatches(List<GenericNode> allNodes, int maxBatchSize) {
         Set<UUID> allIds = new LinkedHashSet<>();
-        List<Integer> batchSizes = new ArrayList<>();
+        List<Set<UUID>> batches = new ArrayList<>();
 
-        int currentBatchSize = 0;
+        Set<UUID> currentBatch = new HashSet<>();
 
         for (GenericNode node : allNodes) {
             if (allIds.contains(node.getId())) {
@@ -37,47 +37,44 @@ public class ImportUtil {
                 Set<UUID> references = getReferencesRecursive(
                         allNodes,
                         node.getId(),
-                        new HashSet<>()
+                        new HashSet<>(),
+                        allIds
                 );
+                currentBatch.addAll(references);
                 allIds.addAll(references);
-                currentBatchSize += references.size();
             } else if (node.getType().getId() == NodeType.Collection) {
                 allIds.add(node.getId());
-                currentBatchSize++;
+                currentBatch.add(node.getId());
             } else if (node.getType().getId() == NodeType.TerminologicalVocabulary) {
                 allIds.add(node.getId());
-                currentBatchSize++;
+                currentBatch.add(node.getId());
             }
 
-            if (currentBatchSize > batchSize) {
-                batchSizes.add(currentBatchSize);
-                currentBatchSize = 0;
+            if (currentBatch.size() > maxBatchSize) {
+                batches.add(Set.copyOf(currentBatch));
+                currentBatch = new HashSet<>();
             }
         }
 
-        if (currentBatchSize > 0) {
-            batchSizes.add(currentBatchSize);
+        if (currentBatch.size() > 0) {
+            batches.add(currentBatch);
         }
 
-        List<List<GenericNode>> batches = new ArrayList<>();
+        List<List<GenericNode>> genericNodeBatches = new ArrayList<>();
 
-        int total = 0;
-        for (Integer size : batchSizes) {
-
-            batches.add(
-                    allIds.stream()
-                            .skip(total)
-                            .limit(size)
+        for (Set<UUID> batch : batches) {
+            genericNodeBatches.add(
+                    batch.stream()
                             .map(id -> Iterables.find(allNodes, (n) -> n.getId().equals(id)))
                             .collect(Collectors.toList())
             );
-            total += size;
         }
 
-        return batches;
+        return genericNodeBatches;
     }
 
-    private static Set<UUID> getReferencesRecursive(List<GenericNode> allNodes, UUID current, Set<UUID> result) {
+    private static Set<UUID> getReferencesRecursive(List<GenericNode> allNodes, UUID current,
+                                                    Set<UUID> result, Set<UUID> currentBatch) {
 
         // add current node to result set
         result.add(current);
@@ -94,8 +91,11 @@ public class ImportUtil {
 
         for (UUID refId : conceptRefs) {
             boolean added = result.add(refId);
-            if (added) {
-                getReferencesRecursive(allNodes, refId, result);
+            if (added && !currentBatch.contains(refId)) {
+                // System.out.println("Recursion");
+                getReferencesRecursive(allNodes, refId, result, currentBatch);
+            } else {
+                // System.out.println("No recursion");
             }
         }
 

--- a/src/main/java/fi/vm/yti/terminology/api/importapi/ImportUtil.java
+++ b/src/main/java/fi/vm/yti/terminology/api/importapi/ImportUtil.java
@@ -74,7 +74,7 @@ public class ImportUtil {
     }
 
     private static Set<UUID> getReferencesRecursive(List<GenericNode> allNodes, UUID current,
-                                                    Set<UUID> result, Set<UUID> currentBatch) {
+                                                    Set<UUID> result, Set<UUID> handledIds) {
 
         // add current node to result set
         result.add(current);
@@ -91,11 +91,8 @@ public class ImportUtil {
 
         for (UUID refId : conceptRefs) {
             boolean added = result.add(refId);
-            if (added && !currentBatch.contains(refId)) {
-                // System.out.println("Recursion");
-                getReferencesRecursive(allNodes, refId, result, currentBatch);
-            } else {
-                // System.out.println("No recursion");
+            if (added && !handledIds.contains(refId)) {
+                getReferencesRecursive(allNodes, refId, result, handledIds);
             }
         }
 

--- a/src/main/java/fi/vm/yti/terminology/api/importapi/YtiMQService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/importapi/YtiMQService.java
@@ -134,7 +134,7 @@ public class YtiMQService {
                     logger.debug("Timestamp={}", mess.getHeaders().get("timestamp"));
                     long expirationtime = System.currentTimeMillis() - (long)mess.getHeaders().get("timestamp");
                     logger.debug("current_time-stamp={}", expirationtime);
-                    if( expirationtime > 60 * 1000) {
+                    if( expirationtime > 10 * 60 * 1000) {
                         return HttpStatus.OK;
                     } else {
                         return HttpStatus.PROCESSING;
@@ -256,7 +256,7 @@ public class YtiMQService {
                 javax.jms.Message m = (javax.jms.Message)messages.nextElement();
                 if (m instanceof TextMessage) {
                     TextMessage message = (TextMessage) m;
-                    logger.info(" browse message = {}", message);
+                    logger.trace(" browse message = {}", message);
                 }
                 total++;
             }
@@ -426,12 +426,12 @@ public class YtiMQService {
 
         int count = 1;
 
-        for(List<GenericNode> patch : batches) {
+        for(List<GenericNode> batch : batches) {
             accessor.setHeader("currentBatch", count++);
             accessor.setHeader("totalBatchCount", batches.size());
 
-            Message<GenericDeleteAndSave> message = MessageBuilder
-                    .withPayload(new GenericDeleteAndSave(Collections.emptyList(), patch))
+            Message<List<GenericNode>> message = MessageBuilder
+                    .withPayload(batch)
                     .setHeaders(accessor)
                     .build();
             jmsMessagingTemplate.send(subSystem + "ExcelImport", message);

--- a/src/main/java/fi/vm/yti/terminology/api/importapi/YtiMQService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/importapi/YtiMQService.java
@@ -256,7 +256,7 @@ public class YtiMQService {
                 javax.jms.Message m = (javax.jms.Message)messages.nextElement();
                 if (m instanceof TextMessage) {
                     TextMessage message = (TextMessage) m;
-                    logger.trace(" browse message = {}", message);
+                    logger.info(" browse message = {}", message);
                 }
                 total++;
             }

--- a/src/main/java/fi/vm/yti/terminology/api/model/termed/GenericDeleteAndSave.java
+++ b/src/main/java/fi/vm/yti/terminology/api/model/termed/GenericDeleteAndSave.java
@@ -9,15 +9,23 @@ public final class GenericDeleteAndSave implements DeleteAndSave, Serializable {
 
     private final List<Identifier> delete;
     private final List<GenericNode> save;
+    private final List<GenericNode> patch;
 
     // Jackson constructor
     private GenericDeleteAndSave() {
-        this(emptyList(), emptyList());
+        this(emptyList(), emptyList(), emptyList());
     }
 
     public GenericDeleteAndSave(List<Identifier> delete, List<GenericNode> save) {
         this.delete = delete;
         this.save = save;
+        this.patch = emptyList();
+    }
+
+    public GenericDeleteAndSave(List<Identifier> delete, List<GenericNode> save, List<GenericNode> patch) {
+        this.delete = delete;
+        this.save = save;
+        this.patch = patch;
     }
 
     public List<Identifier> getDelete() {
@@ -26,5 +34,9 @@ public final class GenericDeleteAndSave implements DeleteAndSave, Serializable {
 
     public List<GenericNode> getSave() {
         return save;
+    }
+
+    public List<GenericNode> getPatch() {
+        return patch;
     }
 }

--- a/src/test/java/fi/vm/yti/terminology/api/importapi/ExcelImportListenerTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/importapi/ExcelImportListenerTest.java
@@ -1,10 +1,16 @@
 package fi.vm.yti.terminology.api.importapi;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.vm.yti.terminology.api.TermedRequester;
 import fi.vm.yti.terminology.api.model.termed.*;
 import fi.vm.yti.terminology.api.util.Parameters;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -12,13 +18,12 @@ import org.springframework.http.HttpMethod;
 import org.springframework.messaging.Message;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import static java.util.Collections.emptyMap;
 import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(SpringExtension.class)
 @Import({
@@ -35,48 +40,71 @@ public class ExcelImportListenerTest {
     @Autowired
     ExcelImportJmsListener listener;
 
+    @Captor
+    ArgumentCaptor<GenericDeleteAndSave> payloadCaptor;
+
+    private Message<List<GenericNode>> message;
+
+    private String vocabularyId = UUID.randomUUID().toString();
+    private String jobToken = UUID.randomUUID().toString();
+    private String userId = UUID.randomUUID().toString();
+
+    private UUID nodeId = UUID.randomUUID();
+
+    @BeforeEach
+    public void setUp() throws JsonProcessingException {
+        message = mock(Message.class);
+        // Response for getting existing node ids
+        JsonNode response = new ObjectMapper().readTree("[{\"id\": \"" + nodeId.toString()  + "\"}]");
+
+        when(message.getPayload()).thenReturn(List.of(getNode(nodeId)));
+        when(requester.exchange(
+                eq("/node-trees"),
+                eq(HttpMethod.GET),
+                any(Parameters.class),
+                eq(JsonNode.class))).thenReturn(response);
+    }
+
+    @Test
+    public void testPayload() {
+        UUID nonExistingNodeId = UUID.randomUUID();
+        when(message.getPayload()).thenReturn(
+                List.of(
+                        getNode(nodeId),
+                        getNode(nonExistingNodeId)
+                )
+        );
+        listener.importNodes(message, jobToken, userId, "http://uri", 1, 2, vocabularyId);
+        verify(requester)
+                .exchange(anyString(),
+                        any(HttpMethod.class),
+                        any(Parameters.class),
+                        any(Class.class),
+                        payloadCaptor.capture(),
+                        anyString(),
+                        anyString());
+
+        assertEquals(payloadCaptor.getValue().getDelete().size(), 0);
+        assertEquals(payloadCaptor.getValue().getSave().get(0).getId(), nonExistingNodeId);
+        assertEquals(payloadCaptor.getValue().getPatch().get(0).getId(), nodeId);
+    }
+
     @Test
     public void batchProcessing() {
-        Message<GenericDeleteAndSave> message = mock(Message.class);
-        when(message.getPayload()).thenReturn(
-                new GenericDeleteAndSave(
-                        Collections.emptyList(), List.of(getNode()))
-        );
-        var jobToken = UUID.randomUUID().toString();
-        var userId = UUID.randomUUID().toString();
-
-        listener.importNodes(message, jobToken, userId, "http://uri", 1, 2);
-
+        listener.importNodes(message, jobToken, userId, "http://uri", 1, 2, vocabularyId);
         verify(mqService).setStatus(eq(YtiMQService.STATUS_PROCESSING), anyString(),
                 anyString(), anyString(), anyString());
     }
 
     @Test
     public void batchReady() {
-        Message<GenericDeleteAndSave> message = mock(Message.class);
-        when(message.getPayload()).thenReturn(
-                new GenericDeleteAndSave(
-                        Collections.emptyList(), List.of(getNode()))
-        );
-        var jobToken = UUID.randomUUID().toString();
-        var userId = UUID.randomUUID().toString();
-
-        listener.importNodes(message, jobToken, userId, "http://uri", 2, 2);
-
+        listener.importNodes(message, jobToken, userId, "http://uri", 2, 2, vocabularyId);
         verify(mqService).setStatus(eq(YtiMQService.STATUS_READY), anyString(),
                 anyString(), anyString(), anyString());
     }
 
     @Test
     public void batchFailed() {
-        Message<GenericDeleteAndSave> message = mock(Message.class);
-        when(message.getPayload()).thenReturn(
-                new GenericDeleteAndSave(
-                        Collections.emptyList(), List.of(getNode()))
-        );
-        var jobToken = UUID.randomUUID().toString();
-        var userId = UUID.randomUUID().toString();
-
         doThrow(RuntimeException.class)
                 .when(requester)
                     .exchange(anyString(),
@@ -87,8 +115,8 @@ public class ExcelImportListenerTest {
                         anyString(),
                         anyString());
 
-        listener.importNodes(message, jobToken, userId, "http://uri", 1, 2);
-        listener.importNodes(message, jobToken, userId, "http://uri", 2, 2);
+        listener.importNodes(message, jobToken, userId, "http://uri", 1, 2, vocabularyId);
+        listener.importNodes(message, jobToken, userId, "http://uri", 2, 2, vocabularyId);
 
         verify(mqService).setStatus(eq(YtiMQService.STATUS_FAILED), anyString(),
                 anyString(), anyString(), anyString());
@@ -103,8 +131,8 @@ public class ExcelImportListenerTest {
                 anyString());
     }
 
-    private GenericNode getNode() {
-        return new GenericNode(
+    private GenericNode getNode(UUID uuid) {
+        return new GenericNode(uuid,
                 "code", "uri", 0L,
                 null, null, null, null,
                 new TypeId(NodeType.Concept, new GraphId(UUID.randomUUID())),


### PR DESCRIPTION
Use patch, when importing nodes from excel. Thus, existing properties won't override in case it is missing from excel. 
Also, added some performace improvements to handling excel data.

Termed [PR](https://github.com/VRK-YTI/termed-api/pull/2) 