### PR TITLE
Yti 1793 search modifications

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/ConceptQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/ConceptQueryFactory.java
@@ -15,7 +15,6 @@ import fi.vm.yti.terminology.api.frontend.Status;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.MultiMatchQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
@@ -38,10 +37,10 @@ import fi.vm.yti.terminology.api.util.ElasticRequestUtils;
 public class ConceptQueryFactory {
 
     // Default options
-    private final static boolean CONFIG_ONLY_CHECK_TERMINOLOGY_STATE = true;
-    private final static boolean CONFIG_DO_NOT_CHECK_TERMINOLOGY_STATE_FOR_GIVEN_TERMINOLOGIES = true;
-    private final static boolean CONFIG_DO_NOT_CHECK_TERMINOLOGY_STATE_FOR_GIVEN_CONCEPTS = true;
-    private final static boolean CONFIG_DO_NOT_CHECK_CONCEPT_STATE_FOR_GIVEN_CONCEPTS = true;
+    private static final boolean CONFIG_ONLY_CHECK_TERMINOLOGY_STATE = true;
+    private static final boolean CONFIG_DO_NOT_CHECK_TERMINOLOGY_STATE_FOR_GIVEN_TERMINOLOGIES = true;
+    private static final boolean CONFIG_DO_NOT_CHECK_TERMINOLOGY_STATE_FOR_GIVEN_CONCEPTS = true;
+    private static final boolean CONFIG_DO_NOT_CHECK_CONCEPT_STATE_FOR_GIVEN_CONCEPTS = true;
 
     private static final Logger log = LoggerFactory.getLogger(ConceptQueryFactory.class);
 
@@ -64,7 +63,13 @@ public class ConceptQueryFactory {
         List<QueryBuilder> mustNotParts = new ArrayList<>();
 
         if (request.getQuery() != null && !request.getQuery().isEmpty()) {
-            mustParts.add(ElasticRequestUtils.buildPrefixSuffixQuery(request.getQuery()).field("label.*"));
+            mustParts.add(ElasticRequestUtils.buildPrefixSuffixQuery(request.getQuery())
+                .field("label.*", 5.0f)
+                .field("altLabel.*", 3.0f)
+                .field("searchTerm.*", 3.0f)
+                .field("hiddenTerm.*", 3.0f)
+                .field("notRecommendedSynonym.*", 1.5f)
+            );
         }
 
         final boolean directConceptsGiven = request.getConceptId() != null && request.getConceptId().length > 0;
@@ -161,7 +166,7 @@ public class ConceptQueryFactory {
         ssb.sort(SortBuilders.fieldSort("sortByLabel." + sortLanguage).order(sortBy == ConceptSearchRequest.SortBy.PREF_LABEL ? sortDirection.getEsOrder() : SortOrder.ASC));
 
         SearchRequest sr = new SearchRequest("concepts").source(ssb);
-        log.debug("Concept Query request: " + sr.toString());
+        log.debug("Concept Query request: {}", sr.toString());
         return sr;
     }
 

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/DeepConceptQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/DeepConceptQueryFactory.java
@@ -63,7 +63,9 @@ public class DeepConceptQueryFactory {
         var mustQueries = new ArrayList<QueryBuilder>();
 
         // NOTE: In deep concept query the query should always be non-empty.
-        var labelQuery = ElasticRequestUtils.buildPrefixSuffixQuery(query).field("label.*");
+        var labelQuery = ElasticRequestUtils.buildPrefixSuffixQuery(query)
+                .field("label.*", 5.0f)
+                .field("altLabel.*", 3.0f);
         mustQueries.add(labelQuery);
 
         if (statuses != null && statuses.length > 0) {

--- a/src/main/resources/create_concept_mappings.json
+++ b/src/main/resources/create_concept_mappings.json
@@ -35,6 +35,33 @@
       }
     },
     {
+      "altLabel": {
+        "path_match": "searchTerm.*",
+        "mapping": {
+          "type": "text",
+          "analyzer": "termed"
+        }
+      }
+    },
+    {
+      "altLabel": {
+        "path_match": "hiddenTerm.*",
+        "mapping": {
+          "type": "text",
+          "analyzer": "termed"
+        }
+      }
+    },
+    {
+      "altLabel": {
+        "path_match": "notRecommendedSynonym.*",
+        "mapping": {
+          "type": "text",
+          "analyzer": "termed"
+        }
+      }
+    },
+    {
       "definition": {
         "path_match": "definition.*",
         "mapping": {

--- a/src/test/java/fi/vm/yti/terminology/elasticsearch/query/ConceptQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/terminology/elasticsearch/query/ConceptQueryFactoryTest.java
@@ -1,0 +1,30 @@
+package fi.vm.yti.terminology.elasticsearch.query;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.vm.yti.terminology.api.frontend.elasticqueries.ConceptQueryFactory;
+import fi.vm.yti.terminology.api.frontend.searchdto.ConceptSearchRequest;
+import fi.vm.yti.terminology.elasticsearch.EsUtils;
+import org.elasticsearch.action.search.SearchRequest;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+public class ConceptQueryFactoryTest {
+
+    ConceptQueryFactory factory = new ConceptQueryFactory(new ObjectMapper(), "testNamespace");
+
+
+    @Test
+    public void createQuery() throws Exception {
+        var jsonExpected = new JSONObject(EsUtils.getJsonString("/es/request/concept_request.json"));
+
+        ConceptSearchRequest request = new ConceptSearchRequest();
+        request.setQuery("test");
+
+        SearchRequest searchRequest = factory.createQuery(request, true, limitToTheseTerminologyIds -> null);
+
+        JSONAssert.assertEquals(jsonExpected.toString(), searchRequest.source().toString(), JSONCompareMode.LENIENT);
+
+    }
+}

--- a/src/test/resources/es/request/concept_request.json
+++ b/src/test/resources/es/request/concept_request.json
@@ -1,0 +1,14 @@
+{
+  "query": {
+    "query_string": {
+      "query": "test test* *test",
+      "fields" : [
+        "label.*^5.0",
+        "altLabel.*^3.0",
+        "searchTerm.*^3.0",
+        "hiddenTerm.*^3.0",
+        "notRecommendedSynonym.*^1.5"
+      ]
+    }
+  }
+}

--- a/src/test/resources/es/request/deep_concept_request.json
+++ b/src/test/resources/es/request/deep_concept_request.json
@@ -4,7 +4,14 @@
       "must": [
         {
           "query_string": {
-            "query": "test test* *test"
+            "query": "test test* *test",
+            "fields" : [
+              "label.*^5.0",
+              "altLabel.*^3.0",
+              "searchTerm.*^3.0",
+              "hiddenTerm.*^3.0",
+              "notRecommendedSynonym.*^1.5"
+            ]
           }
         },
         {


### PR DESCRIPTION
Changelog:
- Added the following terms to elastic search query in terminology search and concept search. 
  - altLabel (5 boost)
  - searchTerm (3 boost)
  - hiddenTerm (3 boost)
  - notRecommendedSynonym (1.5 boost)
- Added elasticsearch indexing for the same terms
- Unit test for the creation of the queries for these terms
- Fixed some minor recommended code smells