### PR TITLE
Yti 1815 backend internalnode validation

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
@@ -5,6 +5,7 @@ import java.util.*;
 import fi.vm.yti.terminology.api.exception.NamespaceInUseException;
 import fi.vm.yti.terminology.api.exception.VocabularyNotFoundException;
 import fi.vm.yti.terminology.api.frontend.searchdto.*;
+import fi.vm.yti.terminology.api.validation.ValidGenericDeleteAndSave;
 import fi.vm.yti.terminology.api.validation.ValidVocabularyNode;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -338,6 +339,7 @@ public class FrontendController {
     @PostMapping(path = "/modify", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
     void updateAndDeleteInternalNodes(@Parameter(description = "Whether to do synchronous modification, i.e., wait for the result. This is recommended.")
                                       @RequestParam(required = false, defaultValue = "true") boolean sync,
+                                      @ValidGenericDeleteAndSave
                                       @RequestBody GenericDeleteAndSave deleteAndSave) {
         logger.info("POST /modify requested with deleteAndSave: delete ids: ");
         for (int i = 0; i < deleteAndSave.getDelete().size(); i++) {
@@ -349,6 +351,20 @@ public class FrontendController {
         }
 
         termedService.bulkChange(deleteAndSave, sync);
+    }
+
+    @Operation(summary = "Validate a bulk modification request", description = "Validate several nodes")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "JSON for the bulk request containing nodes to validate")
+    @ApiResponse(responseCode = "200", description = "OK on success")
+    @PostMapping(path = "/validate", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
+    public String validateInternalNodes(@ValidGenericDeleteAndSave
+                                      @RequestBody GenericDeleteAndSave deleteAndSave) {
+        logger.info("POST /validate requested with deleteAndSave: delete ids: ");
+        deleteAndSave.getDelete().forEach(e -> logger.info(e.getId().toString()));
+        logger.info("and save ids: ");
+        deleteAndSave.getSave().forEach(e -> logger.info(e.getId().toString()));
+
+        return "OK";
     }
 
     @Operation(summary = "Delete several nodes", description = "May be used, e.g., to delete a concept and its terms in one request")

--- a/src/main/java/fi/vm/yti/terminology/api/validation/BaseValidator.java
+++ b/src/main/java/fi/vm/yti/terminology/api/validation/BaseValidator.java
@@ -1,0 +1,42 @@
+package fi.vm.yti.terminology.api.validation;
+
+import javax.validation.ConstraintValidatorContext;
+import java.lang.annotation.Annotation;
+
+public abstract class BaseValidator implements Annotation{
+
+    static final String MISSING_VALUE = "Missing value";
+
+    private boolean constraintViolationAdded;
+
+    @Override
+    public Class<? extends Annotation> annotationType() {
+        return BaseValidator.class;
+    }
+
+
+    /**
+     * Add constraint violation to the constraint validator context
+     * @param context Constraint validator context
+     * @param message Message
+     * @param property Property
+     */
+    void addConstraintViolation(ConstraintValidatorContext context, String message, String property) {
+        if (!this.constraintViolationAdded) {
+            context.disableDefaultConstraintViolation();
+            this.constraintViolationAdded = true;
+        }
+
+        context.buildConstraintViolationWithTemplate(message)
+                .addPropertyNode(property)
+                .addConstraintViolation();
+    }
+
+    public boolean isConstraintViolationAdded() {
+        return constraintViolationAdded;
+    }
+
+    public void setConstraintViolationAdded(boolean constraintViolationAdded) {
+        this.constraintViolationAdded = constraintViolationAdded;
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/validation/GenericDeleteAndSaveValidator.java
+++ b/src/main/java/fi/vm/yti/terminology/api/validation/GenericDeleteAndSaveValidator.java
@@ -1,0 +1,98 @@
+package fi.vm.yti.terminology.api.validation;
+
+import fi.vm.yti.terminology.api.frontend.Status;
+import fi.vm.yti.terminology.api.model.termed.GenericDeleteAndSave;
+import fi.vm.yti.terminology.api.model.termed.GenericNode;
+import fi.vm.yti.terminology.api.model.termed.NodeType;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class GenericDeleteAndSaveValidator extends BaseValidator implements
+        ConstraintValidator<ValidGenericDeleteAndSave, GenericDeleteAndSave> {
+
+    @Override
+    public boolean isValid(GenericDeleteAndSave deleteAndSave, ConstraintValidatorContext context) {
+        setConstraintViolationAdded(false);
+        Stream.concat(deleteAndSave.getSave().stream(), deleteAndSave.getPatch().stream()).forEach(node -> {
+            //These checks are split into smaller functions to improve readability and documentation
+            checkPropertiesAndPrefLabel(node, context);
+            checkNodeType(node, context);
+        });
+
+
+        return !isConstraintViolationAdded();
+    }
+
+
+    /**
+     * Checks if generic node has properties node and if the properties node contains prefLabel
+     * Adds constraint violation if check doesn't pass
+     * @param node Node to check
+     * @param context Constraint validator context
+     */
+    private void checkPropertiesAndPrefLabel(GenericNode node, ConstraintValidatorContext context){
+        final var prefLabel = "prefLabel";
+        final var properties = node.getProperties();
+        if (properties.isEmpty() ) {
+            this.addConstraintViolation(context, MISSING_VALUE,"properties");
+        }else if(!node.getType().getId().equals(NodeType.Concept)
+                && (properties.get(prefLabel) == null || properties.get(prefLabel).isEmpty())){
+            this.addConstraintViolation(context, MISSING_VALUE, prefLabel);
+        }
+    }
+
+    /**
+     * Checks if node has a node type,
+     * if node type is Concept or Term check status
+     * If node type is Concept check if it has a single prefLabelXl
+     * @param node Node to check
+     * @param context Constraint validator context
+     */
+    private void checkNodeType(GenericNode node, ConstraintValidatorContext context){
+        //validate like vocabulary node if concept or term
+        final var nodeType = node.getType().getId();
+        if (nodeType == null) {
+            this.addConstraintViolation(context, MISSING_VALUE, "type");
+        } else if (nodeType.equals(NodeType.Concept) || nodeType.equals(NodeType.Term)) {
+            checkStatus(node, context);
+            if (nodeType.equals(NodeType.Concept)) {
+                final var prefLabelXl = node.getReferences().get("prefLabelXl");
+                if (prefLabelXl == null || prefLabelXl.size() != 1) {
+                    addConstraintViolation(context, MISSING_VALUE, "prefLabelXl");
+                }
+            }
+        }
+    }
+
+    /**
+     * Check that status exists and not empty,
+     * Status must also be one of {@link Status}
+     * @param node Node to check
+     * @param context Constraint validator context
+     */
+    private void checkStatus(GenericNode node, ConstraintValidatorContext context){
+        final var statusProperty = "status";
+        final var status = node.getProperties().get(statusProperty);
+        if (status == null || status.isEmpty()) {
+            addConstraintViolation(
+                    context,
+                    MISSING_VALUE,
+                    statusProperty);
+        } else {
+            // status must be one of Status enum
+            if (status.size() != 1 || !getStatusNames().contains(status.get(0).getValue())) {
+                addConstraintViolation(context, "Invalid value", statusProperty);
+            }
+        }
+    }
+    private static List<String> getStatusNames() {
+        return Arrays.stream(Status.class.getEnumConstants())
+                .map(Enum::name)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/validation/ValidGenericDeleteAndSave.java
+++ b/src/main/java/fi/vm/yti/terminology/api/validation/ValidGenericDeleteAndSave.java
@@ -1,0 +1,26 @@
+package fi.vm.yti.terminology.api.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({
+        ElementType.METHOD,
+        ElementType.FIELD,
+        ElementType.CONSTRUCTOR,
+        ElementType.PARAMETER,
+        ElementType.TYPE_USE
+})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = GenericDeleteAndSaveValidator.class)
+public @interface ValidGenericDeleteAndSave {
+
+    String message() default "Invalid data";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/fi/vm/yti/terminology/api/validation/VocabularyNodeValidator.java
+++ b/src/main/java/fi/vm/yti/terminology/api/validation/VocabularyNodeValidator.java
@@ -4,7 +4,6 @@ import fi.vm.yti.terminology.api.frontend.Status;
 import fi.vm.yti.terminology.api.frontend.TerminologyType;
 import fi.vm.yti.terminology.api.model.termed.Attribute;
 import fi.vm.yti.terminology.api.model.termed.GenericNode;
-import fi.vm.yti.terminology.api.model.termed.Identifier;
 import org.apache.commons.collections4.CollectionUtils;
 
 import javax.validation.ConstraintValidator;
@@ -12,7 +11,6 @@ import javax.validation.ConstraintValidatorContext;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 public class VocabularyNodeValidator extends BaseValidator implements
@@ -145,26 +143,26 @@ public class VocabularyNodeValidator extends BaseValidator implements
         // references
         //
         final var references = genericNode.getReferences();
-        if (references == null || references.size() == 0) {
+        if (references == null || references.isEmpty()) {
             this.addConstraintViolation(
                     context,
-                    "Missing value",
+                    MISSING_VALUE,
                     "references");
         }
 
         // contributor
-        if (!references.containsKey("contributor") || references.get("contributor").size() == 0) {
+        if (!references.containsKey("contributor") || references.get("contributor").isEmpty()) {
             this.addConstraintViolation(
                     context,
-                    "Missing value",
+                    MISSING_VALUE,
                     "contributor");
         }
 
         // inGroup
-        if (!references.containsKey("inGroup") || references.get("inGroup").size() == 0) {
+        if (!references.containsKey("inGroup") || references.get("inGroup").isEmpty()) {
             this.addConstraintViolation(
                     context,
-                    "Missing value",
+                    MISSING_VALUE,
                     "inGroup");
         }
 

--- a/src/test/java/fi/vm/yti/terminology/api/frontend/FrontEndControllerInternalNodeTests.java
+++ b/src/test/java/fi/vm/yti/terminology/api/frontend/FrontEndControllerInternalNodeTests.java
@@ -1,0 +1,195 @@
+package fi.vm.yti.terminology.api.frontend;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.vm.yti.security.AuthenticatedUserProvider;
+import fi.vm.yti.terminology.api.ExceptionHandlerAdvice;
+import fi.vm.yti.terminology.api.model.termed.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+import static java.util.Collections.singletonList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@TestPropertySource(properties = {
+        "spring.cloud.config.import-check.enabled=false"
+})
+@WebMvcTest(controllers = FrontendController.class)
+public class FrontEndControllerInternalNodeTests {
+
+
+    public static final String TEMPLATE_GRAPH_ID = "61cf6bde-46e6-40bb-b465-9b2c66bf4ad8";
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private FrontendTermedService termedService;
+
+    @MockBean
+    private FrontendElasticSearchService elasticSearchService;
+
+    @MockBean
+    private FrontendGroupManagementService groupManagementService;
+
+    @MockBean
+    private AuthenticatedUserProvider userProvider;
+
+    @Autowired
+    private FrontendController frontendController;
+
+    @MockBean
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    public void setup() {
+        mvc = MockMvcBuilders
+                .standaloneSetup(frontendController)
+                .setControllerAdvice(new ExceptionHandlerAdvice())
+                .build();
+    }
+
+    @Test
+    public void shouldValidateAndCreate() throws Exception {
+        var termNode = constructNodeWithType(NodeType.Term, constructTermProperties(), constructTermReferences());
+        var conceptNode = constructNodeWithType(NodeType.Concept, constructConceptProperties(), constructConceptReferences());
+        var nodes = new GenericDeleteAndSave(Collections.emptyList(), List.of(termNode, conceptNode));
+
+        this.mvc
+                .perform(post("/api/v1/frontend/modify")
+                        .contentType("application/json")
+                        .content(convertObjectToJsonString(nodes)))
+                .andExpect(status().isOk());
+
+        verify(termedService).bulkChange(any(GenericDeleteAndSave.class), anyBoolean());
+        verifyNoMoreInteractions(this.termedService);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideMissingData")
+    public void shouldFailOnMissingData(GenericDeleteAndSave node) throws Exception {
+        mvc.perform(post("/api/v1/frontend/validate")
+                .contentType("application/json")
+                .content(convertObjectToJsonString(node)))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().contentType("application/json"))
+            .andExpect(jsonPath("$.message").value("Object validation failed"))
+            .andExpect(jsonPath("$.details").exists());
+        verifyNoMoreInteractions(termedService);
+    }
+
+    private static HashMap<String, List<Attribute>> constructTermProperties() {
+        var properties = new HashMap<String, List<Attribute>>();
+        properties.put("prefLabel", List.of(new Attribute("en", "test label")));
+        properties.put("source", Collections.emptyList());
+        properties.put("scope", singletonList(new Attribute("", "")));
+        properties.put("termStyle", singletonList(new Attribute("", "")));
+        properties.put("termFamily", singletonList(new Attribute("", "")));
+        properties.put("termConjugation", singletonList(new Attribute("", "")));
+        properties.put("termInfo", singletonList(new Attribute("", "")));
+        properties.put("wordClass", singletonList(new Attribute("", "")));
+        properties.put("termHomographNumber", singletonList(new Attribute("", "")));
+        properties.put("editorialNote", Collections.emptyList());
+        properties.put("draftComment", singletonList(new Attribute("", "")));
+        properties.put("historyNote", singletonList(new Attribute("", "")));
+        properties.put("changeNote", singletonList(new Attribute("", "")));
+        properties.put("status", singletonList(new Attribute("", "DRAFT")));
+        return properties;
+    }
+
+    private static HashMap<String, List<Identifier>> constructTermReferences() {
+        return new HashMap<>();
+    }
+
+    private static HashMap<String, List<Attribute>> constructConceptProperties(){
+        var properties = new HashMap<String, List<Attribute>>();
+        properties.put("definition", Collections.emptyList());
+        properties.put("note", Collections.emptyList());
+        properties.put("editorialNote", Collections.emptyList());
+        properties.put("conceptScope", singletonList(new Attribute("", "")));
+        properties.put("conceptClass", singletonList(new Attribute("", "")));
+        properties.put("wordClass", singletonList(new Attribute("", "")));
+        properties.put("changeNote", singletonList(new Attribute("", "")));
+        properties.put("historyNote", singletonList(new Attribute("", "")));
+        properties.put("status", singletonList(new Attribute("", "DRAFT")));
+        properties.put("notation", singletonList(new Attribute("", "")));
+        properties.put("source", Collections.emptyList());
+        properties.put("externalLink", singletonList(new Attribute("", "")));
+        properties.put("subjectArea", singletonList(new Attribute("", "")));
+        return properties;
+    }
+
+    private static HashMap<String, List<Identifier>> constructConceptReferences() {
+        var references = new HashMap<String, List<Identifier>>();
+        var prefLabelXl = new Identifier(
+                UUID.randomUUID(),
+                new TypeId(
+                        NodeType.Term,
+                        new GraphId(UUID.randomUUID())));
+        references.put("prefLabelXl", singletonList(prefLabelXl));
+        return references;
+    }
+
+    private static GenericNode constructNodeWithType(
+            NodeType type,
+            Map<String, List<Attribute>> properties,
+            Map<String, List<Identifier>> references){
+        TypeId typeid = new TypeId(type, new GraphId(UUID.fromString(TEMPLATE_GRAPH_ID)));
+        return new GenericNode(typeid, properties, references);
+    }
+
+    private static Stream<Arguments> provideMissingData() {
+        var args = new ArrayList<GenericDeleteAndSave>();
+
+        // without properties
+        var genericNode = constructNodeWithType(NodeType.Term, Collections.emptyMap(), constructTermReferences());
+        args.add(new GenericDeleteAndSave(Collections.emptyList(), List.of(genericNode)));
+
+        // without a prefLabel
+        var properties = constructTermProperties();
+        properties.remove("prefLabel");
+        genericNode = constructNodeWithType(NodeType.Term, properties, constructTermReferences());
+        args.add(new GenericDeleteAndSave(Collections.emptyList(), List.of(genericNode)));
+
+        // with no status term node
+        properties = constructTermProperties();
+        properties.remove("status");
+        genericNode = constructNodeWithType(NodeType.Term, properties, constructTermReferences());
+        args.add(new GenericDeleteAndSave(Collections.emptyList(), List.of(genericNode)));
+
+        // with no status term node
+        properties = constructConceptProperties();
+        properties.remove("status");
+        genericNode = constructNodeWithType(NodeType.Concept, properties, constructConceptReferences());
+        args.add(new GenericDeleteAndSave(Collections.emptyList(), List.of(genericNode)));
+
+        // without a prefLabelXLReferences
+        var references = constructConceptReferences();
+        references.remove("prefLabelXl");
+        genericNode = constructNodeWithType(NodeType.Concept, constructConceptProperties(), references);
+        args.add(new GenericDeleteAndSave(Collections.emptyList(), List.of(genericNode)));
+
+        return args.stream().map(Arguments::of);
+    }
+
+    private String convertObjectToJsonString(GenericDeleteAndSave node) throws JsonProcessingException {
+        return new ObjectMapper().writeValueAsString(node);
+    }
+
+}

--- a/src/test/java/fi/vm/yti/terminology/api/frontend/FrontEndControllerInternalNodeTests.java
+++ b/src/test/java/fi/vm/yti/terminology/api/frontend/FrontEndControllerInternalNodeTests.java
@@ -22,7 +22,6 @@ import java.util.stream.Stream;
 
 import static java.util.Collections.singletonList;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;

--- a/src/test/java/fi/vm/yti/terminology/api/frontend/FrontendControllerTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/frontend/FrontendControllerTest.java
@@ -28,8 +28,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @TestPropertySource(properties = {

--- a/src/test/java/fi/vm/yti/terminology/api/frontend/FrontendControllerTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/frontend/FrontendControllerTest.java
@@ -38,6 +38,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(controllers = FrontendController.class)
 public class FrontendControllerTest {
 
+    public static final String TEMPLATE_GRAPH_ID = "61cf6bde-46e6-40bb-b465-9b2c66bf4ad8";
+
+    private static final String TEST_NODE_ID = "75ad9343-c3f7-417f-99e4-7aff07f5daf6";
+
     @Autowired
     private MockMvc mvc;
 
@@ -61,8 +65,6 @@ public class FrontendControllerTest {
 
     private LocalValidatorFactoryBean localValidatorFactory;
 
-    private static String testNodeId = "75ad9343-c3f7-417f-99e4-7aff07f5daf6";
-
     @BeforeEach
     public void setup() {
         this.mvc = MockMvcBuilders
@@ -73,16 +75,12 @@ public class FrontendControllerTest {
 
     @Test
     public void shouldValidateAndCreate() throws Exception {
-
-        // templateGraph UUID, predefined in database
-        var templateGraphId = "61cf6bde-46e6-40bb-b465-9b2c66bf4ad8";
-
         var vocabularyNode = this.constructVocabularyNode();
 
         this.mvc
                 .perform(post("/api/v1/frontend/validatedVocabulary")
                         .param("prefix", "test1")
-                        .param("templateGraphId", templateGraphId)
+                        .param("templateGraphId", TEMPLATE_GRAPH_ID)
                         .contentType("application/json")
                         .content(convertObjectToJsonString(vocabularyNode)))
                 // .andDo(print())
@@ -105,13 +103,13 @@ public class FrontendControllerTest {
     public void shouldValidatePrefix(String prefix, boolean shouldSucceed) throws Exception {
 
         // templateGraph UUID, predefined in database
-        var templateGraphId = "61cf6bde-46e6-40bb-b465-9b2c66bf4ad8";
+
         var vocabularyNode = this.constructVocabularyNode();
 
         var request = this.mvc
                 .perform(post("/api/v1/frontend/validatedVocabulary")
                         .param("prefix", prefix)
-                        .param("templateGraphId", templateGraphId)
+                        .param("templateGraphId", TEMPLATE_GRAPH_ID)
                         .contentType("application/json")
                         .content(convertObjectToJsonString(vocabularyNode)));
 
@@ -155,12 +153,12 @@ public class FrontendControllerTest {
     public void shouldFailOnMissingData(GenericNode vocabularyNode) throws Exception {
 
         // templateGraph UUID, predefined in database
-        var templateGraphId = "61cf6bde-46e6-40bb-b465-9b2c66bf4ad8";
+
 
         this.mvc
                 .perform(post("/api/v1/frontend/vocabulary/validate")
                         .param("prefix", "test1")
-                        .param("templateGraphId", templateGraphId)
+                        .param("templateGraphId", TEMPLATE_GRAPH_ID)
                         .contentType("application/json")
                         .content(convertObjectToJsonString(vocabularyNode)))
                 .andExpect(status().isBadRequest())
@@ -182,14 +180,14 @@ public class FrontendControllerTest {
     public void shouldValidateOnly() throws Exception {
 
         // templateGraph UUID, predefined in database
-        var templateGraphId = "61cf6bde-46e6-40bb-b465-9b2c66bf4ad8";
+
 
         var vocabularyNode = constructVocabularyNode();
 
         this.mvc
                 .perform(post("/api/v1/frontend/vocabulary/validate")
                         .param("prefix", "test1")
-                        .param("templateGraphId", templateGraphId)
+                        .param("templateGraphId", TEMPLATE_GRAPH_ID)
                         .contentType("application/json")
                         .content(convertObjectToJsonString(vocabularyNode)))
                 // .andDo(print())
@@ -204,7 +202,7 @@ public class FrontendControllerTest {
     public void shouldFailOnLanguageMismatch() throws Exception {
 
         // templateGraph UUID, predefined in database
-        var templateGraphId = "61cf6bde-46e6-40bb-b465-9b2c66bf4ad8";
+
 
         var properties = constructProperties();
 
@@ -221,7 +219,7 @@ public class FrontendControllerTest {
         this.mvc
                 .perform(post("/api/v1/frontend/vocabulary/validate")
                         .param("prefix", "test1")
-                        .param("templateGraphId", templateGraphId)
+                        .param("templateGraphId", TEMPLATE_GRAPH_ID)
                         .contentType("application/json")
                         .content(convertObjectToJsonString(vocabularyNode)))
                 //.andDo(print())
@@ -348,10 +346,10 @@ public class FrontendControllerTest {
             Map<String, List<Identifier>> referrers) {
 
         // templateGraph UUID, predefined in database
-        var templateGraphId = "61cf6bde-46e6-40bb-b465-9b2c66bf4ad8";
+
 
         var vocabularyNode = new GenericNode(
-                UUID.fromString(testNodeId),
+                UUID.fromString(TEST_NODE_ID),
                 null,
                 null,
                 40L,
@@ -363,7 +361,7 @@ public class FrontendControllerTest {
                 // type
                 new TypeId(
                         NodeType.TerminologicalVocabulary,
-                        new GraphId(UUID.fromString(templateGraphId))),
+                        new GraphId(UUID.fromString(TEMPLATE_GRAPH_ID))),
 
                 properties,             // properties
                 references,             // references
@@ -378,6 +376,6 @@ public class FrontendControllerTest {
         return mapper.writeValueAsString(node);
     }
 
-    private Matcher<String> uuidMatcher = Matchers.matchesRegex(
+    private final Matcher<String> uuidMatcher = Matchers.matchesRegex(
             "^\"?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"?$");
 }


### PR DESCRIPTION
Changelog: 
- Added validation for internal nodes
- Added BaseValidator and made both validators use that as a base
 - FrontEndController has new endpoint validate
 - Cleaned up VocabularyNodeValidator a bit
 - Added mvc test to FrontendController internal nodes
 - Cleaned up some tests at the same time