### PR TITLE
Added unmapped types to concept and vocabulary searches.

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/ConceptQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/ConceptQueryFactory.java
@@ -163,7 +163,10 @@ public class ConceptQueryFactory {
             ssb.sort(SortBuilders.fieldSort("modified").order(sortDirection.getEsOrder()));
         }
         String sortLanguage = request.getSortLanguage() != null && !request.getSortLanguage().isEmpty() ? request.getSortLanguage() : "fi";
-        ssb.sort(SortBuilders.fieldSort("sortByLabel." + sortLanguage).order(sortBy == ConceptSearchRequest.SortBy.PREF_LABEL ? sortDirection.getEsOrder() : SortOrder.ASC));
+        ssb.sort(SortBuilders
+                    .fieldSort("sortByLabel." + sortLanguage)
+                    .order(sortBy == ConceptSearchRequest.SortBy.PREF_LABEL ? sortDirection.getEsOrder() : SortOrder.ASC)
+                    .unmappedType("keyword"));
 
         SearchRequest sr = new SearchRequest("concepts").source(ssb);
         log.debug("Concept Query request: {}", sr.toString());

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/TerminologyQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/TerminologyQueryFactory.java
@@ -122,7 +122,7 @@ public class TerminologyQueryFactory {
 
         if (groupIds != null && groupIds.length > 0)  {
             try {
-                Arrays.stream(groupIds).forEach(x -> UUID.fromString(x));
+                Arrays.stream(groupIds).forEach(UUID::fromString);
             } catch (IllegalArgumentException exception){
                 log.error("One or more group IDs were invalid");
                 throw new InvalidQueryException("One or more group IDs were invalid");
@@ -134,7 +134,7 @@ public class TerminologyQueryFactory {
 
         if (organizationIds != null && organizationIds.length > 0)  {
             try {
-                Arrays.stream(organizationIds).forEach(x -> UUID.fromString(x));
+                Arrays.stream(organizationIds).forEach(UUID::fromString);
             } catch (IllegalArgumentException exception){
                 log.error("One or more organization IDs were invalid");
                 throw new InvalidQueryException("One or organization IDs were invalid");
@@ -214,11 +214,12 @@ public class TerminologyQueryFactory {
                 .query(shouldQuery != null ? shouldQuery : mustQuery)
                 .sort(SortBuilders
                         .fieldSort("sortByLabel." + sortLanguage)
-                        .order(SortOrder.ASC));
+                        .order(SortOrder.ASC)
+                        .unmappedType("keyword"));
 
         SearchRequest sr = new SearchRequest("vocabularies")
             .source(sourceBuilder);
-        log.debug("Terminology Query request: " + sr.toString());
+        log.debug("Terminology Query request: {}", sr.toString());
         return sr;
     }
 


### PR DESCRIPTION
Unmapped types set an empty value of specified type (instead of null) if the field is unmapped. In this case all the languages in sortByLabel.

This bug fix wont be noticed on a database with data already in it. 

Fixed some small sonarqube issues