### PR TITLE
buildPrefixSufficQuery now sanitizes input by escaping all characters.

### DIFF
--- a/src/test/java/fi/vm/yti/terminology/elasticsearch/query/ElasticRequestUtilsTest.java
+++ b/src/test/java/fi/vm/yti/terminology/elasticsearch/query/ElasticRequestUtilsTest.java
@@ -1,0 +1,21 @@
+package fi.vm.yti.terminology.elasticsearch.query;
+
+import fi.vm.yti.terminology.api.util.ElasticRequestUtils;
+import org.elasticsearch.index.query.QueryStringQueryBuilder;;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ElasticRequestUtilsTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"+", "-", "=", "&", "|", "!", "(", ")", "{", "}", "[", "]", "^", "\"", "~", "*", "?", ":", "\\", "/"})
+    void testBuildSpecialCharacters(String prefix){
+        QueryStringQueryBuilder request = ElasticRequestUtils.buildPrefixSuffixQuery(prefix);
+        // \prefix \prefix* *\prefix
+        assertEquals("\\" + prefix + " \\" + prefix + "* *\\" + prefix, request.queryString());
+    }
+
+
+}


### PR DESCRIPTION
Changelog:
 - Add custom escaping function, copied from Lucene. 
   - Added all characters needed for escaping elasticsearch query
   - Changed escape to handle being added as a json body
     - This means more '\' characters
- Unit tests for checking escape characters. 