### PR TITLE
YTI-2064: Search result contains incomplete terminologies

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/DeepConceptQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/DeepConceptQueryFactory.java
@@ -77,7 +77,9 @@ public class DeepConceptQueryFactory {
         // is in some visible state.
         if (!superUser) {
             var incompleteQuery = QueryBuilders.boolQuery()
-                    .should(QueryBuilders.boolQuery().mustNot(QueryBuilders.termQuery("status", "INCOMPLETE")))
+                    .should(QueryBuilders.boolQuery()
+                            .mustNot(QueryBuilders.termQuery("status", "INCOMPLETE"))
+                            .mustNot(QueryBuilders.termQuery("vocabulary.status", "INCOMPLETE")))
                     .should(QueryBuilders.termsQuery("vocabulary.id", incompleteFromTerminologies))
                     .minimumShouldMatch(1);
             mustQueries.add(incompleteQuery);

--- a/src/test/resources/es/request/deep_concept_request.json
+++ b/src/test/resources/es/request/deep_concept_request.json
@@ -33,11 +33,10 @@
                       }
                     },
                     {
-                      "terms": {
-                        "vocabulary.status": [
-                          "INCOMPLETE"
-                        ],
-                        "boost": 1.0
+                      "term": {
+                        "vocabulary.status": {
+                          "value": "INCOMPLETE"
+                        }
                       }
                     }
                   ]

--- a/src/test/resources/es/request/deep_concept_request.json
+++ b/src/test/resources/es/request/deep_concept_request.json
@@ -31,6 +31,14 @@
                       "term": {
                         "status": { "value": "INCOMPLETE" }
                       }
+                    },
+                    {
+                      "terms": {
+                        "vocabulary.status": [
+                          "INCOMPLETE"
+                        ],
+                        "boost": 1.0
+                      }
                     }
                   ]
                 }


### PR DESCRIPTION
Changelog:
- Elasticsearch DeepConceptQuery takes into account that the vocabulary where we are doing the deep search should not be INCOMPLETE
