### PR TITLE
YTI-1936 optimize fetching terminology

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
@@ -156,6 +156,14 @@ public class FrontendController {
         return termedService.getVocabulary(graphId);
     }
 
+    @Operation(summary = "Get terminology basic info as JSON")
+    @ApiResponse(responseCode = "200", description = "The requested terminology node data")
+    @GetMapping(path = "/simpleVocabulary", produces = APPLICATION_JSON_VALUE)
+    TerminologySearchResponse getSimpleVocabulary(@Parameter(description = "ID for the requested terminology") @RequestParam UUID graphId) {
+        logger.info("GET /simpleVocabulary requested with graphId: " + graphId.toString());
+        return elasticSearchService.findTerminology(graphId);
+    }
+
     @Operation(summary = "Get basic info for all terminologies", description = "Get basic info for termonologies in Termed JSON format. The list may be filtered for INCOMPLETE terminologies.")
     @Parameter(
         name = "incomplete",

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendElasticSearchService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendElasticSearchService.java
@@ -157,6 +157,17 @@ public class FrontendElasticSearchService {
         }
     }
 
+    TerminologySearchResponse findTerminology(UUID terminologyId) {
+        SearchRequest request = terminologyQueryFactory.createFindTerminologyByIdQuery(terminologyId);
+        try {
+            SearchResponse response = esRestClient.search(request, RequestOptions.DEFAULT);
+            return terminologyQueryFactory.parseResponse(response, new TerminologySearchRequest(), Collections.emptyMap());
+        } catch (IOException e) {
+            logger.error("Error fetching terminology", e);
+            throw new RuntimeException(e);
+        }
+    }
+
     private boolean superUser() {
         return userProvider.getUser().isSuperuser();
     }

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/TerminologyQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/TerminologyQueryFactory.java
@@ -252,6 +252,17 @@ public class TerminologyQueryFactory {
         return sr;
     }
 
+    public SearchRequest createFindTerminologyByIdQuery(UUID terminologyId) {
+        QueryBuilder query = QueryBuilders.boolQuery()
+                .must(QueryBuilders.matchQuery("type.graph.id", terminologyId.toString()));
+
+        return new SearchRequest("vocabularies")
+                .source(new SearchSourceBuilder()
+                        .size(1)
+                        .query(query)
+                );
+    }
+
     public Set<String> parseMatchingTerminologiesResponse(SearchResponse response) {
         Set<String> ret = new HashSet<>();
         for (SearchHit hit : response.getHits()) {

--- a/src/main/java/fi/vm/yti/terminology/api/index/IndexTermedService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/index/IndexTermedService.java
@@ -2,6 +2,7 @@ package fi.vm.yti.terminology.api.index;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import fi.vm.yti.terminology.api.TermedRequester;
+import fi.vm.yti.terminology.api.migration.DomainIndex;
 import fi.vm.yti.terminology.api.util.JsonUtils;
 import fi.vm.yti.terminology.api.util.Parameters;
 import fi.vm.yti.terminology.api.model.termed.*;
@@ -202,15 +203,12 @@ public class IndexTermedService {
 
         Parameters params = new Parameters();
         params.add("select", "*");
-/*
-        params.add("select", "id");
-        params.add("select", "type");
-        params.add("select", "properties.*");
-        params.add("select", "lastModifiedDate");
-        */
         params.add("where", "graph.id:" + graphId);
         params.add("where", "type.id:" + vocabularyType.name());
         params.add("max", "-1");
+        params.add("graphTypeId", graphId.toString());
+        params.add("graphTypeId", DomainIndex.ORGANIZATION_DOMAIN.getGraphId().toString());
+        params.add("graphTypeId", DomainIndex.GROUP_DOMAIN.getGraphId().toString());
 
         return findSingle(termedRequester.exchange("/node-trees", GET, params, JsonNode.class));
     }

--- a/src/test/java/fi/vm/yti/terminology/elasticsearch/query/TerminologyQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/terminology/elasticsearch/query/TerminologyQueryFactoryTest.java
@@ -12,6 +12,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import java.util.Collections;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -51,5 +52,13 @@ public class TerminologyQueryFactoryTest {
         assertEquals("DRAFT", dto.getStatus());
         assertEquals("Testipalveluluokka label", dto.getInformationDomains().get(0).getLabel().get("fi"));
         assertEquals("TERMINOLOGICAL_VOCABULARY", dto.getType());
+    }
+
+    @Test
+    public void testCreateTerminologyByIdQuery() throws Exception {
+        UUID id = UUID.fromString("1259496e-6996-43d2-894c-95c85543e5a1");
+        String expectedRequest = EsUtils.getJsonString("/es/request/terminology_by_id_request.json");
+        SearchRequest findTerminologyByIdQuery = factory.createFindTerminologyByIdQuery(id);
+        JSONAssert.assertEquals(expectedRequest, findTerminologyByIdQuery.source().toString(), JSONCompareMode.LENIENT);
     }
 }

--- a/src/test/resources/es/request/terminology_by_id_request.json
+++ b/src/test/resources/es/request/terminology_by_id_request.json
@@ -1,0 +1,16 @@
+{
+  "size": 1,
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "match": {
+            "type.graph.id": {
+              "query": "1259496e-6996-43d2-894c-95c85543e5a1"
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
- Pass required graph ids to termed, so the query executed right after cache invalidation is not so heavy. 
- Created endpoint /simpleVocabulary, which returns limited amount of information fetched from Elasticsearch. This can be used if only e.g. name and id of the terminology are needed

See [termed changes](https://github.com/VRK-YTI/termed-api/pull/3)