### PR TITLE
YTI-2085 Add error message to response if row does not exist

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/exception/ExcelParseException.java
+++ b/src/main/java/fi/vm/yti/terminology/api/exception/ExcelParseException.java
@@ -11,6 +11,7 @@ public class ExcelParseException extends RuntimeException {
 
     public ExcelParseException(String message) {
         super(message);
+        this.reason = message;
     }
 
     public ExcelParseException(String message, Row row, String column) {

--- a/src/main/java/fi/vm/yti/terminology/api/importapi/excel/ExcelParser.java
+++ b/src/main/java/fi/vm/yti/terminology/api/importapi/excel/ExcelParser.java
@@ -600,7 +600,7 @@ public class ExcelParser {
     private XSSFRow getRow(XSSFSheet sheet, int rowNumber, boolean isMandatory) {
         XSSFRow row = sheet.getRow(rowNumber);
         if (row == null && isMandatory) {
-            throw new ExcelParseException(String.format("Row %d doesn't exist", rowNumber));
+            throw new ExcelParseException(String.format("Row %d doesn't exist, sheet %s", rowNumber, sheet.getSheetName()));
         }
         return row;
     }


### PR DESCRIPTION
Instead of empty message, return following response
```
{"message":"Row 0 doesn't exist, sheet Concepts","errorDetails":{}}
```