### PR TITLE
YTI-2115 performance improvements

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
@@ -507,9 +507,9 @@ public class FrontendController {
         logger.info("GET /conceptCounts requested");
 
         // fetch collections separately and add the count to dto because collections are not stored in elastic search
-        JsonNode collectionList = termedService.getCollectionList(graphId);
+        Long collectionCount = termedService.getCollectionCount(graphId);
         CountSearchResponse conceptCounts = elasticSearchService.getConceptCounts(graphId);
-        conceptCounts.getCounts().getCategories().put(CountDTO.Category.COLLECTION.getName(), Long.valueOf(collectionList.size()));
+        conceptCounts.getCounts().getCategories().put(CountDTO.Category.COLLECTION.getName(), collectionCount);
         return conceptCounts;
     }
 

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendTermedService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendTermedService.java
@@ -13,6 +13,7 @@ import fi.vm.yti.terminology.api.exception.NodeNotFoundException;
 import fi.vm.yti.terminology.api.exception.VocabularyNotFoundException;
 import fi.vm.yti.terminology.api.frontend.searchdto.CreateVersionDTO;
 import fi.vm.yti.terminology.api.frontend.searchdto.CreateVersionResponse;
+import fi.vm.yti.terminology.api.migration.DomainIndex;
 import fi.vm.yti.terminology.api.model.termed.*;
 import fi.vm.yti.terminology.api.security.AuthorizationManager;
 import fi.vm.yti.terminology.api.util.JsonUtils;
@@ -112,6 +113,7 @@ public class FrontendTermedService {
                 + TerminologicalVocabulary + ")");
 
         params.add("max", "-1");
+        addGraphTypeIds(graphId, params);
 
         List<GenericNodeInlined> result = requireNonNull(termedRequester.exchange("/node-trees", GET, params,
                 new ParameterizedTypeReference<List<GenericNodeInlined>>() {
@@ -231,6 +233,7 @@ public class FrontendTermedService {
         params.add("where", "graph.id:" + graphId);
         params.add("where", "id:" + conceptId);
         params.add("max", "-1");
+        addGraphTypeIds(graphId, params);
 
         List<GenericNodeInlined> result = requireNonNull(termedRequester.exchange("/node-trees", GET, params,
                 new ParameterizedTypeReference<List<GenericNodeInlined>>() {
@@ -262,6 +265,7 @@ public class FrontendTermedService {
         params.add("where", "graph.id:" + graphId);
         params.add("where", "id:" + collectionId);
         params.add("max", "-1");
+        addGraphTypeIds(graphId, params);
 
         List<GenericNodeInlined> result = requireNonNull(termedRequester.exchange("/node-trees", GET, params,
                 new ParameterizedTypeReference<List<GenericNodeInlined>>() {
@@ -292,8 +296,18 @@ public class FrontendTermedService {
         params.add("where", "graph.id:" + graphId);
         params.add("where", "type.id:" + "Collection");
         params.add("max", "-1");
+        addGraphTypeIds(graphId, params);
 
         return requireNonNull(termedRequester.exchange("/node-trees", GET, params, JsonNode.class));
+    }
+
+    public Long getCollectionCount(UUID graphId) {
+        JsonNode collections = termedRequester.exchange(
+                String.format("/graphs/%s/types/%s/nodes", graphId, NodeType.Collection),
+                GET,
+                new Parameters(),
+                JsonNode.class);
+        return collections != null ? Long.valueOf(collections.size()) : 0L;
     }
 
     public @NotNull List<GenericNode> getNodes(UUID graphId) {
@@ -721,6 +735,12 @@ public class FrontendTermedService {
 
     private static boolean isUUID(String s) {
         return UUID_PATTERN.matcher(s).matches();
+    }
+
+    private static void addGraphTypeIds(UUID graphId, Parameters params) {
+        params.add("graphTypeId", graphId.toString());
+        params.add("graphTypeId", DomainIndex.ORGANIZATION_DOMAIN.getGraphId().toString());
+        params.add("graphTypeId", DomainIndex.GROUP_DOMAIN.getGraphId().toString());
     }
 
     // XXX consider cache spanning to multiple requests

--- a/src/main/java/fi/vm/yti/terminology/api/security/DefaultAuthorizationTermedService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/security/DefaultAuthorizationTermedService.java
@@ -5,6 +5,7 @@ import com.google.common.cache.CacheBuilder;
 import fi.vm.yti.terminology.api.TermedRequester;
 import fi.vm.yti.terminology.api.model.termed.GenericNode;
 import fi.vm.yti.terminology.api.model.termed.Identifier;
+import fi.vm.yti.terminology.api.model.termed.NodeType;
 import fi.vm.yti.terminology.api.util.Parameters;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -57,18 +58,12 @@ public class DefaultAuthorizationTermedService implements AuthorizationTermedSer
     }
 
     private Set<UUID> fetchOrganizationIds(UUID graphId) {
-
-        Parameters params = new Parameters();
-        params.add("select", "id");
-        params.add("select", "references.contributor");
-        params.add("where",
-                "graph.id:" + graphId +
-                " AND (type.id:" + Vocabulary +
-                " OR type.id:" + TerminologicalVocabulary + ")");
-        params.add("max", "-1");
-
-        List<GenericNode> result = termedRequester.exchange("/node-trees", GET, params, new ParameterizedTypeReference<List<GenericNode>>() {});
-
+        List<GenericNode> result = termedRequester
+                .exchange(String.format("/graphs/%s/types/%s/nodes", graphId, NodeType.TerminologicalVocabulary),
+                        GET,
+                        new Parameters(),
+                        new ParameterizedTypeReference<>() {}
+                );
         GenericNode vocabularyNode = requireSingle(result);
 
         return mapToSet(vocabularyNode.getReferences().getOrDefault("contributor", emptyList()), Identifier::getId);

--- a/src/test/java/fi/vm/yti/terminology/api/frontend/FrontendTermedServiceTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/frontend/FrontendTermedServiceTest.java
@@ -591,6 +591,24 @@ class FrontendTermedServiceTest {
         assertEquals(conceptNode.getId(), collectionNode.getReferences().get("member").get(0).getId());
     }
 
+    @Test
+    public void testGetCollectionCount() throws JsonProcessingException {
+        var graphId = UUID.randomUUID();
+        JsonNode jsonNode = new ObjectMapper()
+                .readTree("[ { \"id\":\"2809414d-3bb1-4e0e-b315-a035ad8bb311\" } ]");
+
+        when(termedRequester.exchange(
+                    eq(String.format("/graphs/%s/types/%s/nodes", graphId, NodeType.Collection)),
+                    eq(HttpMethod.GET),
+                    any(Parameters.class),
+                    any(Class.class)))
+                .thenReturn(jsonNode);
+
+        Long collectionCount = frontEndTermedService.getCollectionCount(graphId);
+
+        assertEquals(1L, collectionCount);
+    }
+
     private String getUri(String prefix, String code) {
         return "http://uri.suomi.fi/terminology/" + prefix + "/" + code + "/";
     }

--- a/src/test/java/fi/vm/yti/terminology/service/DefaultAuthorizationTermedServiceTest.java
+++ b/src/test/java/fi/vm/yti/terminology/service/DefaultAuthorizationTermedServiceTest.java
@@ -38,26 +38,16 @@ public class DefaultAuthorizationTermedServiceTest {
 
     private UUID organizationId = UUID.fromString("9adc94fb-65ab-4fd1-a9ef-de126b26cbe6");
 
-    @BeforeEach
-    public void setUp() {
-        when(requester
-                .exchange(eq("/node-trees"),
-                        eq(HttpMethod.GET),
-                        any(Parameters.class),
-                        any(ParameterizedTypeReference.class)
-                )
-        ).thenReturn(getSampleNode());
-    }
-
     @Test
     public void cachedOrganizations() {
         UUID graphId = UUID.randomUUID();
+        mockTermedRequest(graphId);
 
         Set<UUID> ids = service.getOrganizationIds(graphId);
         service.getOrganizationIds(graphId);
 
         // expect only one requester interaction, because result is cached
-        verify(requester).exchange(eq("/node-trees"),
+        verify(requester).exchange(eq(getPath(graphId)),
                 eq(HttpMethod.GET),
                 any(Parameters.class),
                 any(ParameterizedTypeReference.class));
@@ -67,6 +57,7 @@ public class DefaultAuthorizationTermedServiceTest {
     @Test
     public void cachedOrganizationsExpired() throws Exception {
         UUID graphId = UUID.randomUUID();
+        mockTermedRequest(graphId);
 
         Set<UUID> ids = service.getOrganizationIds(graphId);
 
@@ -76,7 +67,7 @@ public class DefaultAuthorizationTermedServiceTest {
         service.getOrganizationIds(graphId);
 
         // expect two requester interactions, because cache has been expired
-        verify(requester, times(2)).exchange(eq("/node-trees"),
+        verify(requester, times(2)).exchange(eq(getPath(graphId)),
                 eq(HttpMethod.GET),
                 any(Parameters.class),
                 any(ParameterizedTypeReference.class));
@@ -112,5 +103,19 @@ public class DefaultAuthorizationTermedServiceTest {
         );
 
         return Arrays.asList(node);
+    }
+
+    private void mockTermedRequest(UUID graphId) {
+        when(requester
+                .exchange(eq(getPath(graphId)),
+                        eq(HttpMethod.GET),
+                        any(Parameters.class),
+                        any(ParameterizedTypeReference.class)
+                )
+        ).thenReturn(getSampleNode());
+    }
+
+    private String getPath(UUID graphId) {
+        return String.format("/graphs/%s/types/%s/nodes", graphId, NodeType.TerminologicalVocabulary);
     }
 }


### PR DESCRIPTION
- Use `/graph` endpoints instead of `/node-trees` for fetching organization ids and collections' count. These queries perform much better in termed
- Add graphTypeId parameters for /node-trees requests to make them lighter (see termed-api [PR](https://github.com/VRK-YTI/termed-api/pull/3))