### PR TITLE
YTI-2127 concept search improvements

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/ConceptQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/ConceptQueryFactory.java
@@ -69,6 +69,7 @@ public class ConceptQueryFactory {
                 .field("searchTerm.*", 3.0f)
                 .field("hiddenTerm.*", 3.0f)
                 .field("notRecommendedSynonym.*", 1.5f)
+                .field("definition.*", 3.0f)
             );
         }
 
@@ -157,19 +158,20 @@ public class ConceptQueryFactory {
             .size(request.getPageSize() != null ? request.getPageSize().intValue() : 100)
             .from(request.getPageFrom() != null ? request.getPageFrom().intValue() : 0);
 
-        ConceptSearchRequest.SortBy sortBy = request.getSortBy() != null ? request.getSortBy() : ConceptSearchRequest.SortBy.PREF_LABEL;
-        ConceptSearchRequest.SortDirection sortDirection = request.getSortDirection() != null ? request.getSortDirection() : ConceptSearchRequest.SortDirection.ASC;
-        if (sortBy == ConceptSearchRequest.SortBy.MODIFIED) {
-            ssb.sort(SortBuilders.fieldSort("modified").order(sortDirection.getEsOrder()));
-        }
-        String sortLanguage = request.getSortLanguage() != null && !request.getSortLanguage().isEmpty() ? request.getSortLanguage() : "fi";
-        ssb.sort(SortBuilders
+        if ("".equals(request.getQuery()) || request.getQuery() == null || request.getSortBy() != null) {
+            ConceptSearchRequest.SortBy sortBy = request.getSortBy() != null ? request.getSortBy() : ConceptSearchRequest.SortBy.PREF_LABEL;
+            ConceptSearchRequest.SortDirection sortDirection = request.getSortDirection() != null ? request.getSortDirection() : ConceptSearchRequest.SortDirection.ASC;
+            if (sortBy == ConceptSearchRequest.SortBy.MODIFIED) {
+                ssb.sort(SortBuilders.fieldSort("modified").order(sortDirection.getEsOrder()));
+            }
+            String sortLanguage = request.getSortLanguage() != null && !request.getSortLanguage().isEmpty() ? request.getSortLanguage() : "fi";
+            ssb.sort(SortBuilders
                     .fieldSort("sortByLabel." + sortLanguage)
                     .order(sortBy == ConceptSearchRequest.SortBy.PREF_LABEL ? sortDirection.getEsOrder() : SortOrder.ASC)
                     .unmappedType("keyword"));
-
+        }
         SearchRequest sr = new SearchRequest("concepts").source(ssb);
-        log.debug("Concept Query request: {}", sr.toString());
+        log.debug("Concept Query request: {}", sr);
         return sr;
     }
 

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/DeepConceptQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/DeepConceptQueryFactory.java
@@ -64,7 +64,8 @@ public class DeepConceptQueryFactory {
                 .field("altLabel.*", 3.0f)
                 .field("searchTerm.*", 3.0f)
                 .field("hiddenTerm.*", 3.0f)
-                .field("notRecommendedSynonym.*", 1.5f);
+                .field("notRecommendedSynonym.*", 1.5f)
+                .field("definition.*", 3.0f);
         mustQueries.add(labelQuery);
 
         if (statuses != null && statuses.length > 0) {

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/TerminologyQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/elasticqueries/TerminologyQueryFactory.java
@@ -99,8 +99,8 @@ public class TerminologyQueryFactory {
             var labelQuery = ElasticRequestUtils
                     .buildPrefixSuffixQuery(query)
                     .fields(Map.of(
-                            "properties.prefLabel.value", 1.0f,
-                            "references.contributor.properties.prefLabel.value", 2.0f));
+                            "properties.prefLabel.value", 5.0f,
+                            "references.contributor.properties.prefLabel.value", 1.0f));
             mustQueries.add(labelQuery);
         }
 

--- a/src/main/java/fi/vm/yti/terminology/api/index/IndexTermedService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/index/IndexTermedService.java
@@ -141,6 +141,9 @@ public class IndexTermedService {
         params.add("select", "properties.status");
         params.add("select", "references.prefLabelXl:2");
         params.add("select", "references.altLabelXl:2");
+        params.add("select", "references.searchTerm:2");
+        params.add("select", "references.notRecommendedSynonym:2");
+        params.add("select", "references.hiddenTerm:2");
         params.add("select", "references.broader");
         params.add("select", "referrers.broader");
         params.add("where", "graph.id:" + vocabulary.getGraphId());

--- a/src/main/resources/create_concept_mappings.json
+++ b/src/main/resources/create_concept_mappings.json
@@ -4,7 +4,8 @@
       "label": {
         "path_match": "label.*",
         "mapping": {
-          "type": "text"
+          "type": "text",
+          "analyzer": "termed"
         }
       }
     },
@@ -35,7 +36,7 @@
       }
     },
     {
-      "altLabel": {
+      "searchTerm": {
         "path_match": "searchTerm.*",
         "mapping": {
           "type": "text",
@@ -44,7 +45,7 @@
       }
     },
     {
-      "altLabel": {
+      "hiddenTerm": {
         "path_match": "hiddenTerm.*",
         "mapping": {
           "type": "text",
@@ -53,7 +54,7 @@
       }
     },
     {
-      "altLabel": {
+      "notRecommendedSynonym": {
         "path_match": "notRecommendedSynonym.*",
         "mapping": {
           "type": "text",

--- a/src/main/resources/create_index_default.json
+++ b/src/main/resources/create_index_default.json
@@ -1,23 +1,8 @@
 {
   "analysis": {
-    "tokenizer": {
-      "ngram_tokenizer": {
-        "type": "edge_ngram",
-        "min_gram": 4,
-        "max_gram": 15,
-        "token_chars": [
-          "letter",
-          "digit"
-        ]
-      }
-    },
     "analyzer": {
       "termed": {
-        "type": "custom",
-        "tokenizer": "ngram_tokenizer",
-        "filter": [
-          "lowercase"
-        ]
+        "type": "standard"
       }
     }
   }

--- a/src/test/resources/es/request/concept_request.json
+++ b/src/test/resources/es/request/concept_request.json
@@ -7,7 +7,8 @@
         "altLabel.*^3.0",
         "searchTerm.*^3.0",
         "hiddenTerm.*^3.0",
-        "notRecommendedSynonym.*^1.5"
+        "notRecommendedSynonym.*^1.5",
+        "definition.*^3.0"
       ]
     }
   }

--- a/src/test/resources/es/request/deep_concept_request.json
+++ b/src/test/resources/es/request/deep_concept_request.json
@@ -10,7 +10,8 @@
               "altLabel.*^3.0",
               "searchTerm.*^3.0",
               "hiddenTerm.*^3.0",
-              "notRecommendedSynonym.*^1.5"
+              "notRecommendedSynonym.*^1.5",
+              "definition.*^3.0"
             ]
           }
         },

--- a/src/test/resources/es/request/vocabulary_request.json
+++ b/src/test/resources/es/request/vocabulary_request.json
@@ -24,8 +24,8 @@
                 "query_string": {
                   "query": "test test* *test",
                   "fields": [
-                    "properties.prefLabel.value^1.0",
-                    "references.contributor.properties.prefLabel.value^2.0"
+                    "properties.prefLabel.value^5.0",
+                    "references.contributor.properties.prefLabel.value^1.0"
                   ]
                 }
               },


### PR DESCRIPTION
- Search also from concetp's definition
- Sort results alphabetically only if sortBy is specified or query is not specified
- Simplify indexing by using standard analyzer instead of custom one with ngram tokenizer
- Fix indexing for notRecommendedSynonym and searchTerm
- Change boosts in terminology search: matching terminology's name is more important than organization name