### PR TITLE
YTI-2197 remove trailing slash from uri

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendTermedService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendTermedService.java
@@ -534,7 +534,7 @@ public class FrontendTermedService {
         List<GenericNode> nodes = dump.getNodes().stream().map(n -> new GenericNode(
                 nodeIdMap.get(n.getId()),
                 n.getCode(),
-                String.format("%s%s/",
+                String.format("%s%s",
                         formatNamespace(createVersionDTO.getNewCode()), n.getCode()),
                 n.getNumber(),
                 n.getCreatedBy(),

--- a/src/test/java/fi/vm/yti/terminology/api/frontend/FrontendTermedServiceTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/frontend/FrontendTermedServiceTest.java
@@ -610,7 +610,7 @@ class FrontendTermedServiceTest {
     }
 
     private String getUri(String prefix, String code) {
-        return "http://uri.suomi.fi/terminology/" + prefix + "/" + code + "/";
+        return "http://uri.suomi.fi/terminology/" + prefix + "/" + code;
     }
 
     private String getUri(String prefix, GenericNode node) {


### PR DESCRIPTION
Remove trailing slash from uri because it causes problems in fetching concepts from datamodel application