### PR TITLE
Endpoint for status counts added

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
@@ -510,4 +510,17 @@ public class FrontendController {
             throw new RuntimeException(e);
         }
     }
+
+    @RequestMapping(value = "/statusCounts", method = GET, produces = APPLICATION_JSON_VALUE)
+    StatusCountSearchResponse getStatusCounts(@RequestParam UUID graphId) {
+        logger.info("GET /statusCounts requested");
+
+        try {
+            return termedService.getConceptTermsCount(graphId);
+        } catch (Exception e) {
+            logger.error("Unhandled error occurred while getting terminology({}) status counts", graphId, e);
+            throw new RuntimeException(e);
+        }
+    }
+
 }

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
@@ -511,6 +511,8 @@ public class FrontendController {
         }
     }
 
+    @Operation(summary = "Get status counts", description = "Return status counts for concepts and terms of a terminology")
+    @ApiResponse(responseCode = "200", description = "JSON list of status counts of concepts and terms")
     @RequestMapping(value = "/statusCounts", method = GET, produces = APPLICATION_JSON_VALUE)
     StatusCountSearchResponse getStatusCounts(@RequestParam UUID graphId) {
         logger.info("GET /statusCounts requested");

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendTermedService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendTermedService.java
@@ -252,7 +252,6 @@ public class FrontendTermedService {
         if (result.size() == 0) {
             throw new NodeNotFoundException(graphId, conceptId);
         } else {
-            System.out.println("GetConcept " + result.get(0).getProperties().get("status").stream().iterator().next().getValue());
             return userNameToDisplayName(result.get(0), new UserIdToDisplayNameMapper(),
                     authorizationManager.isUserPartOfOrganization(graphId));
         }

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendTermedService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendTermedService.java
@@ -13,6 +13,8 @@ import fi.vm.yti.terminology.api.exception.NodeNotFoundException;
 import fi.vm.yti.terminology.api.exception.VocabularyNotFoundException;
 import fi.vm.yti.terminology.api.frontend.searchdto.CreateVersionDTO;
 import fi.vm.yti.terminology.api.frontend.searchdto.CreateVersionResponse;
+import fi.vm.yti.terminology.api.frontend.searchdto.StatusCountDTO;
+import fi.vm.yti.terminology.api.frontend.searchdto.StatusCountSearchResponse;
 import fi.vm.yti.terminology.api.migration.DomainIndex;
 import fi.vm.yti.terminology.api.model.termed.*;
 import fi.vm.yti.terminology.api.security.AuthorizationManager;
@@ -250,6 +252,7 @@ public class FrontendTermedService {
         if (result.size() == 0) {
             throw new NodeNotFoundException(graphId, conceptId);
         } else {
+            System.out.println("GetConcept " + result.get(0).getProperties().get("status").stream().iterator().next().getValue());
             return userNameToDisplayName(result.get(0), new UserIdToDisplayNameMapper(),
                     authorizationManager.isUserPartOfOrganization(graphId));
         }
@@ -785,4 +788,74 @@ public class FrontendTermedService {
         }
     }
 
+    @NotNull
+    StatusCountSearchResponse getConceptTermsCount(UUID graphId) {
+        StatusCountSearchResponse response = new StatusCountSearchResponse();
+
+        Parameters params = new Parameters();
+        params.add("select", "id");
+        params.add("select", "properties.status");
+        params.add("select", "references.prefLabelXl");
+        params.add("select", "references.altLabelXl");
+        params.add("select", "references.notRecommendedSynonym");
+        params.add("select", "references.searchTerm");
+        params.add("where", "graph.id:" + graphId);
+        params.add("where", "type.id:Concept");
+        params.add("max", "-1");
+        addGraphTypeIds(graphId, params);
+
+        List<GenericNodeInlined> result = requireNonNull(termedRequester.exchange("/node-trees", GET, params,
+                new ParameterizedTypeReference<List<GenericNodeInlined>>() {
+                }));
+
+        if (result.size() == 0) {
+            throw new NodeNotFoundException(graphId, asList(NodeType.Vocabulary, NodeType.TerminologicalVocabulary));
+        } else {
+            Map<String, Long> conceptStatuses = Stream.of(new Object[][] {
+                    {"DRAFT", 0L},
+                    {"RETIRED", 0L},
+                    {"SUPERSEDED", 0L},
+                    {"VALID", 0L}
+            }).collect(Collectors.toMap(data -> (String) data[0], data -> (Long) data[1]));
+            Map<String, Long> termStatuses = Stream.of(new Object[][] {
+                    {"DRAFT", 0L},
+                    {"RETIRED", 0L},
+                    {"SUPERSEDED", 0L},
+                    {"VALID", 0L}
+            }).collect(Collectors.toMap(data -> (String) data[0], data -> (Long) data[1]));;
+
+            result.forEach(r -> {
+                String conceptStatus = r.getProperties().get("status").get(0).getValue();
+                if (conceptStatuses.containsKey(conceptStatus)) {
+                    conceptStatuses.replace(conceptStatus, conceptStatuses.get(conceptStatus) + 1L);
+                }
+
+                List<GenericNodeInlined> terms = new ArrayList<>();
+
+                if (r.getReferences().containsKey("prefLabelXl")) {
+                    terms.addAll(r.getReferences().get("prefLabelXl"));
+                }
+                if (r.getReferences().containsKey("altLabelXl")) {
+                    terms.addAll(r.getReferences().get("altLabelXl"));
+                }
+                if (r.getReferences().containsKey("notRecommendedSynonym")) {
+                    terms.addAll(r.getReferences().get("notRecommendedSynonym"));
+                }
+                if (r.getReferences().containsKey("searchTerm")) {
+                    terms.addAll(r.getReferences().get("notRecommendedSynonym"));
+                }
+
+                terms.forEach(label -> {
+                    String status = label.getProperties().get("status").get(0).getValue();
+                    if (termStatuses.containsKey(status)) {
+                        termStatuses.replace(status, termStatuses.get(status) + 1L);
+                    }
+                });
+            });
+
+            response.setCounts(new StatusCountDTO(conceptStatuses, termStatuses));
+        }
+
+        return response;
+    }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/StatusCountDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/StatusCountDTO.java
@@ -1,0 +1,40 @@
+package fi.vm.yti.terminology.api.frontend.searchdto;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class StatusCountDTO {
+
+    private Map<String, Long> concepts;
+
+    private Map<String, Long> terms;
+
+    public StatusCountDTO() {
+        this.concepts = Collections.emptyMap();
+        this.terms = Collections.emptyMap();
+    }
+
+    public StatusCountDTO(
+            final Map<String, Long> concepts,
+            final Map<String, Long> terms) {
+        this.concepts = concepts;
+        this.terms = terms;
+    }
+
+    public Map<String, Long> getConcepts() {
+        return concepts;
+    }
+
+    public void setConcepts(Map<String, Long> concepts) {
+        this.concepts = concepts;
+    }
+
+    public Map<String, Long> getTerms() {
+        return terms;
+    }
+
+    public void setTerms(Map<String, Long> terms) {
+        this.terms = terms;
+    }
+
+}

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/StatusCountSearchResponse.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/searchdto/StatusCountSearchResponse.java
@@ -1,0 +1,18 @@
+package fi.vm.yti.terminology.api.frontend.searchdto;
+
+public class StatusCountSearchResponse {
+
+    private StatusCountDTO counts;
+
+    public StatusCountSearchResponse() {
+        this.counts = new StatusCountDTO();
+    }
+
+    public StatusCountDTO getCounts() {
+        return counts;
+    }
+
+    public void setCounts(StatusCountDTO counts) {
+        this.counts = counts;
+    }
+}


### PR DESCRIPTION
Changes in this PR:
- Added new endpoint `/statusCounts` which returns total amounts of different statuses of a terminologies concepts and terms