### PR TITLE
YTI-2584: remove terminology suffix

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/TermedRequester.java
+++ b/src/main/java/fi/vm/yti/terminology/api/TermedRequester.java
@@ -26,6 +26,9 @@ public class TermedRequester {
     private static final String API_PW = "API_PW";
     private static TermedContentType DEFAULT_CONTENT_TYPE = TermedContentType.JSON;
 
+    public static final String PATH_NODE_TREES = "/node-trees";
+    public static final String PATH_GRAPHS = "/graphs";
+
     private final String termedUser;
     private final String termedPassword;
     private final String termedUrl;

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendController.java
@@ -1,7 +1,6 @@
 package fi.vm.yti.terminology.api.frontend;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 import fi.vm.yti.terminology.api.exception.NamespaceInUseException;
 import fi.vm.yti.terminology.api.exception.VocabularyNotFoundException;
@@ -48,7 +47,6 @@ import static fi.vm.yti.terminology.api.validation.ValidationConstants.TEXT_FIEL
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
-import static fi.vm.yti.terminology.api.util.CollectionUtils.mapToSet;
 
 @RestController
 @RequestMapping("/api/v1/frontend")
@@ -199,13 +197,12 @@ public class FrontendController {
             @RequestBody GenericNode vocabularyNode) {
 
         try {
-            logger.info("POST /vocabulary requested with params: templateGraphId: " +
-                templateGraphId.toString() + ", prefix: " + prefix + ", vocabularyNode.id: " + vocabularyNode.getId().toString());
+            logger.info("POST /vocabulary requested with params: templateGraphId: {}, prefix: {}, vocabularyNode.id: {}", templateGraphId, prefix, vocabularyNode.getId());
 
-            UUID predefinedOrGeneratedGraphId = graphId != null ? graphId : UUID.randomUUID();
+            var predefinedOrGeneratedGraphId = graphId != null ? graphId : UUID.randomUUID();
 
             termedService.createVocabulary(templateGraphId, prefix, vocabularyNode, predefinedOrGeneratedGraphId, sync);
-            logger.debug("Vocabulary with prefix \"" + prefix + "\" created");
+            logger.debug("Vocabulary with prefix \"{}\" created", prefix);
 
             return predefinedOrGeneratedGraphId;
         } catch (RuntimeException | Error e) {

--- a/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendTermedService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/frontend/FrontendTermedService.java
@@ -184,24 +184,27 @@ public class FrontendTermedService {
     }
 
     public void createVocabulary(UUID templateGraphId, String prefix, GenericNode vocabularyNode, UUID graphId, boolean sync) {
-
         check(authorizationManager.canCreateVocabulary(vocabularyNode));
 
+        //We have to set uri for vocabulary node by ourselves
+        // otherwise termed will create a uri appending terminological-vocabulary-0
+        vocabularyNode.setUri(namespaceRoot + prefix);
+
         try {
-            List<MetaNode> templateMetaNodes = getTypes(templateGraphId);
-            List<Property> prefLabel = mapToList(vocabularyNode.getProperties().get("prefLabel"), Attribute::asProperty);
+            var templateMetaNodes = getTypes(templateGraphId);
+            var prefLabel = mapToList(vocabularyNode.getProperties().get("prefLabel"), Attribute::asProperty);
 
-            logger.debug("Creating graph for \"" + prefix + "\"");
+            logger.debug("Creating graph for \"{}\"", prefix);
             createGraph(prefix, prefLabel, graphId);
-            logger.debug("Graph created for \"" + prefix + "\"");
-            List<MetaNode> graphMetaNodes = mapToList(templateMetaNodes, node -> node.copyToGraph(graphId));
+            logger.debug("Graph created for \"{}\"", prefix);
+            var graphMetaNodes = mapToList(templateMetaNodes, node -> node.copyToGraph(graphId));
 
-            logger.debug("Updating types for \"" + prefix + "\"");
+            logger.debug("Updating types for \"{}\"", prefix);
             updateTypes(graphId, graphMetaNodes);
-            logger.debug("Handling nodes for \"" + prefix + "\"");
+            logger.debug("Handling nodes for \"{}\"", prefix);
             updateAndDeleteInternalNodes(
                     new GenericDeleteAndSave(emptyList(), singletonList(vocabularyNode.copyToGraph(graphId))), sync, null);
-            logger.debug("Finished for \"" + prefix + "\"");
+            logger.debug("Finished for \"{}\"", prefix);
         } catch (Exception e) {
             logger.error("Error occurred while creating terminology " + graphId, e);
 

--- a/src/main/java/fi/vm/yti/terminology/api/migration/task/V25_RemoveTermedSuffix.java
+++ b/src/main/java/fi/vm/yti/terminology/api/migration/task/V25_RemoveTermedSuffix.java
@@ -1,0 +1,36 @@
+package fi.vm.yti.terminology.api.migration.task;
+
+import fi.vm.yti.migration.MigrationTask;
+import fi.vm.yti.terminology.api.migration.MigrationService;
+import fi.vm.yti.terminology.api.model.termed.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+
+@Component
+public class V25_RemoveTermedSuffix implements MigrationTask {
+
+    private static final Logger log = LoggerFactory.getLogger(V25_RemoveTermedSuffix.class);
+
+
+    private final MigrationService migrationService;
+
+    V25_RemoveTermedSuffix(MigrationService migrationService) {
+        this.migrationService = migrationService;
+    }
+
+    @Override
+    public void migrate() {
+        var nodes = migrationService.getNodes(node -> node.getUri() != null && node.getUri().matches("http://uri.suomi.fi/terminology/[a-zA-Z0-9-_]*/terminological-vocabulary-[0-9]+"));
+        log.info("Updating hiddenTerms for {} concepts", nodes.size());
+
+        nodes.forEach(node -> {
+            var newUri = node.getUri().replaceAll("/terminological-vocabulary-[0-9]*", "");
+            node.setUri(newUri);
+        });
+
+        migrationService.updateAndDeleteInternalNodes(new GenericDeleteAndSave(Collections.emptyList(), nodes));
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/model/termed/GenericNode.java
+++ b/src/main/java/fi/vm/yti/terminology/api/model/termed/GenericNode.java
@@ -143,6 +143,10 @@ public final class GenericNode implements Node, Serializable {
         return uri;
     }
 
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
     public Long getNumber() {
         return number;
     }

--- a/src/test/java/fi/vm/yti/terminology/api/resolve/ResolveServiceTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/resolve/ResolveServiceTest.java
@@ -1,0 +1,97 @@
+package fi.vm.yti.terminology.api.resolve;
+
+import fi.vm.yti.terminology.api.TermedRequester;
+import fi.vm.yti.terminology.api.model.termed.*;
+import fi.vm.yti.terminology.api.util.Parameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@Import({
+        ResolveService.class
+})
+@TestPropertySource(properties = {
+        "namespace.root=http://uri.suomi.fi/terminology/"
+})
+class ResolveServiceTest {
+
+    @MockBean
+    TermedRequester termedRequester;
+
+    @Autowired
+    ResolveService resolveService;
+
+    @ParameterizedTest
+    @CsvSource({"http://uri.suomi.fi/terminology/test/", "http://uri.suomi.fi/terminology/test"})
+    void resolveVocabularyTest() {
+        var uuid = UUID.randomUUID();
+        when(termedRequester.exchange(eq(TermedRequester.PATH_GRAPHS), eq(HttpMethod.GET), any(Parameters.class), any(ParameterizedTypeReference.class)))
+                .thenReturn(List.of(new Graph(
+                        uuid,
+                        "test",
+                        "http://uri.suomi.fi/terminology/test",
+                        emptyList(),
+                        emptyMap(),
+                        emptyMap()
+                )));
+
+        var result = resolveService.resolveResource("http://uri.suomi.fi/terminology/test/");
+
+        verify(termedRequester).exchange(eq(TermedRequester.PATH_GRAPHS), eq(HttpMethod.GET), any(Parameters.class), any(ParameterizedTypeReference.class));
+        verifyNoMoreInteractions(termedRequester);
+        assertEquals(ResolvedResource.Type.VOCABULARY, result.getType());
+        assertEquals(uuid, result.getGraphId());
+        assertNull(result.getId());
+    }
+
+    @Test
+    void resolveResourceTest() {
+        var uuid = UUID.randomUUID();
+        when(termedRequester.exchange(eq(TermedRequester.PATH_GRAPHS), eq(HttpMethod.GET), any(Parameters.class), any(ParameterizedTypeReference.class)))
+                .thenReturn(List.of(new Graph(
+                        uuid,
+                        "test",
+                        "http://uri.suomi.fi/terminology/test",
+                        emptyList(),
+                        emptyMap(),
+                        emptyMap()
+                )));
+        when(termedRequester.exchange(eq(TermedRequester.PATH_NODE_TREES), eq(HttpMethod.GET), any(Parameters.class), any(ParameterizedTypeReference.class)))
+                .thenReturn(List.of(new GenericNode(
+                        new TypeId(NodeType.Concept, new GraphId(uuid)),
+                        Collections.emptyMap(),
+                        Collections.emptyMap()
+                )));
+
+        var result = resolveService.resolveResource("http://uri.suomi.fi/terminology/test/concept-0");
+        verify(termedRequester).exchange(eq(TermedRequester.PATH_GRAPHS), eq(HttpMethod.GET), any(Parameters.class), any(ParameterizedTypeReference.class));
+        verify(termedRequester).exchange(eq(TermedRequester.PATH_NODE_TREES), eq(HttpMethod.GET), any(Parameters.class), any(ParameterizedTypeReference.class));
+        verifyNoMoreInteractions(termedRequester);
+        assertEquals(ResolvedResource.Type.CONCEPT, result.getType());
+        assertEquals(uuid, result.getGraphId());
+        assertNotNull(result.getId()); //this is random uuid so we can only check nullness
+    }
+
+    @Test
+    void resolveInvalidUriTest(){
+        assertThrows(ResolveService.ResolveException.class, () -> resolveService.resolveResource("invalid"));
+    }
+}


### PR DESCRIPTION
Changelog:
- send custom uri to termed api so it does not append suffix during vocabulary. 
- resolve works with or without trailing forward-slash now. 
- fixed a bunch of sonarqube issues
- unit tests