### PR TITLE
Integration api search fix

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/integration/IntegrationService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/integration/IntegrationService.java
@@ -331,7 +331,7 @@ public class IntegrationService {
 
         String uri = null;
         if (source.get("uri") != null) {
-            uri = source.get("uri").asText();
+            uri = source.get("uri").asText() + "/";
         }
         respItem.setUri(uri);
 

--- a/src/main/java/fi/vm/yti/terminology/api/integration/IntegrationService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/integration/IntegrationService.java
@@ -107,7 +107,7 @@ public class IntegrationService {
         this.elasticSearchService = elasticSearchService;
         this.userProvider = userProvider;
         this.indexName = indexName;
-        this.namespacePattern = Pattern.compile(Pattern.quote(namespaceRoot) + "[a-z0-9][^/]+/");
+        this.namespacePattern = Pattern.compile(Pattern.quote(namespaceRoot) + "[a-z0-9][^/]+");
     }
 
     ResponseEntity<String> handleContainers(IntegrationContainerRequest request) {
@@ -198,9 +198,7 @@ public class IntegrationService {
             terminologyNsUris = new HashSet<>();
             BoolQueryBuilder uriBoolQuery = QueryBuilders.boolQuery();
             for (String uriFromRequest : request.getUri()) {
-                if (!uriFromRequest.endsWith("/")) {
-                    uriFromRequest = uriFromRequest + "/";
-                }
+                uriFromRequest = uriFromRequest.replaceAll("/$", "");
                 if (namespacePattern.matcher(uriFromRequest).matches()) {
                     uriBoolQuery.should(QueryBuilders.prefixQuery("uri", uriFromRequest));
                 } else {
@@ -489,9 +487,7 @@ public class IntegrationService {
             terminologyNsUris = new HashSet<>();
             BoolQueryBuilder uriBoolQuery = QueryBuilders.boolQuery();
             for (String uriFromRequest : request.getContainer()) {
-                if (!uriFromRequest.endsWith("/")) {
-                    uriFromRequest = uriFromRequest + "/";
-                }
+                uriFromRequest = uriFromRequest.replaceAll("/$", "");
                 if (namespacePattern.matcher(uriFromRequest).matches()) {
                     uriBoolQuery.should(QueryBuilders.prefixQuery("uri", uriFromRequest));
                 } else {


### PR DESCRIPTION
Datamodel application requires, that terminology uri ends with `/`.  However, since the URIs don't contain terminological-vocabulary-0 suffix, the prefix query from Elasticsearch didn't work any more. -> Add trailing slash to response but remove it for the search. 