### PR TITLE
YTI-3683 reverse note list in NTRF import

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/importapi/NtrfMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/importapi/NtrfMapper.java
@@ -918,7 +918,9 @@ public class NtrfMapper {
                     vocabulary);
         }
         // NOTE
+        // reverse the order, because notes are displayed in the UI newest (=last one in the list) first.
         List<NOTE> notes = o.getNOTE();
+        Collections.reverse(notes);
         for (NOTE n : notes) {
             handleNOTE(currentConcept, n, o.getValue().value(), parentProperties, properties,
                     vocabulary);

--- a/src/test/java/fi/vm/yti/terminology/api/importapi/NtrfTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/importapi/NtrfTest.java
@@ -97,7 +97,7 @@ public class NtrfTest {
         // Concept properties
         assertEquals("Käsitteen luokka", getPropertyValue(concept, "conceptClass"));
         assertEquals("Käyttöala", getPropertyValue(concept, "conceptScope"));
-        assertEquals(Arrays.asList("Huomautus 1", "Huomautus 2"), getPropertyValues(concept, "note"));
+        assertEquals(Arrays.asList("Huomautus 2", "Huomautus 1"), getPropertyValues(concept, "note"));
         assertEquals("Käsitteen määritelmä", getPropertyValue(concept, "definition"));
         assertEquals(Arrays.asList(" - Viimeksi muokattu, 2022-03-30", "Editorial note concept"),
                 getPropertyValues(concept, "editorialNote"));


### PR DESCRIPTION
Notes are displayed newest first. That's why we need to reverse note list to make sure that first note in the xml file is on top of the list in the UI.