### PR TITLE
support B and I elements in NTRF import

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/importapi/NtrfMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/importapi/NtrfMapper.java
@@ -1606,6 +1606,10 @@ public class NtrfMapper {
                 JAXBElement el = (JAXBElement) element;
                 if (el.getName().toString().equalsIgnoreCase("HOGR")) {
                     result = result.trim() + " (" + el.getValue().toString() + ")";
+                // B and I tags
+                } else if (el.getName().toString().equalsIgnoreCase("B") ||
+                        el.getName().toString().equalsIgnoreCase("I")) {
+                    result = result.trim() + " " + el.getValue().toString();
                 }
             } else {
                 logger.error("DEF, unhandled CLASS={}", element.getClass().getName());

--- a/src/test/resources/concept-definition-and-note.xml
+++ b/src/test/resources/concept-definition-and-note.xml
@@ -7,7 +7,7 @@
                 <TERM>huoneisto</TERM>
             </TE>
             <DEF>
-                Definition test links:
+                Definition <I>test</I> links:
                     <ECON href="http://uri.suomi.fi/terminology/rak/concept-1" typr="closeMatch">econ link</ECON>
                     <RCONEXT href="http://uri.suomi.fi/terminology/rak/concept-1">rconext link</RCONEXT>
                     <BCONEXT href="http://uri.suomi.fi/terminology/rak/concept-1">bconext link</BCONEXT>
@@ -18,7 +18,7 @@
                 .
             </DEF>
             <NOTE>
-                Note test links:
+                Note <B>test</B> links:
                     <ECON href="http://uri.suomi.fi/terminology/rak/concept-1" typr="exactMatch">econ link</ECON>
                     <RCONEXT href="http://uri.suomi.fi/terminology/rak/concept-1">rconext link</RCONEXT>
                     <BCONEXT href="http://uri.suomi.fi/terminology/rak/concept-1">bconext link</BCONEXT>


### PR DESCRIPTION
The B and I tags were ignored in notes, causing parts of the text to be missing.

This change adds supports for those two tags, but any other unknown tags will still be ignored.