### PR TITLE
YTI-3950, YTI-3987 Concept api and service layer

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptDTO.java
@@ -2,6 +2,7 @@ package fi.vm.yti.terminology.api.v2.dto;
 
 import fi.vm.yti.common.dto.LinkDTO;
 import fi.vm.yti.common.enums.Status;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.List;
 import java.util.Map;
@@ -133,5 +134,10 @@ public class ConceptDTO {
 
     public void setConceptClass(String conceptClass) {
         this.conceptClass = conceptClass;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptInfoDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptInfoDTO.java
@@ -10,19 +10,19 @@ import java.util.Set;
 
 public class ConceptInfoDTO extends ResourceCommonInfoDTO {
     private String identifier;
-    private Map<String, String> definition;
-    private Map<String, String> subjectArea;
-    private List<LocalizedValueDTO> notes;
-    private List<LocalizedValueDTO> examples;
+    private Map<String, String> definition = Map.of();
+    private Map<String, String> subjectArea = Map.of();
+    private List<LocalizedValueDTO> notes = List.of();
+    private List<LocalizedValueDTO> examples = List.of();
     private Status status;
     private List<String> sources = List.of();
     private List<LinkDTO> links = List.of();
     private String changeNote;
     private String historyNote;
     private String conceptClass;
-    private List<String> editorialNotes;
-    private Set<ConceptReferenceInfoDTO> references;
-    private Set<TermDTO> terms;
+    private List<String> editorialNotes = List.of();
+    private Set<ConceptReferenceInfoDTO> references = Set.of();
+    private Set<TermDTO> terms = Set.of();
 
     public String getIdentifier() {
         return identifier;

--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptInfoDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptInfoDTO.java
@@ -1,27 +1,28 @@
 package fi.vm.yti.terminology.api.v2.dto;
 
 import fi.vm.yti.common.dto.LinkDTO;
+import fi.vm.yti.common.dto.ResourceCommonInfoDTO;
 import fi.vm.yti.common.enums.Status;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class ConceptDTO {
+public class ConceptInfoDTO extends ResourceCommonInfoDTO {
     private String identifier;
-    private Map<String, String> definition = Map.of();
-    private Map<String, String> subjectArea = Map.of();
-    private List<LocalizedValueDTO> notes = List.of();
-    private List<LocalizedValueDTO> examples = List.of();
+    private Map<String, String> definition;
+    private Map<String, String> subjectArea;
+    private List<LocalizedValueDTO> notes;
+    private List<LocalizedValueDTO> examples;
     private Status status;
     private List<String> sources = List.of();
     private List<LinkDTO> links = List.of();
     private String changeNote;
     private String historyNote;
     private String conceptClass;
-    private List<String> editorialNotes = List.of();
-    private List<ConceptReferenceDTO> references = List.of();
-    private Set<TermDTO> terms = Set.of();
+    private List<String> editorialNotes;
+    private Set<ConceptReferenceInfoDTO> references;
+    private Set<TermDTO> terms;
 
     public String getIdentifier() {
         return identifier;
@@ -87,6 +88,14 @@ public class ConceptDTO {
         this.links = links;
     }
 
+    public String getChangeNote() {
+        return changeNote;
+    }
+
+    public void setChangeNote(String changeNote) {
+        this.changeNote = changeNote;
+    }
+
     public String getHistoryNote() {
         return historyNote;
     }
@@ -95,12 +104,12 @@ public class ConceptDTO {
         this.historyNote = historyNote;
     }
 
-    public String getChangeNote() {
-        return changeNote;
+    public String getConceptClass() {
+        return conceptClass;
     }
 
-    public void setChangeNote(String changeNote) {
-        this.changeNote = changeNote;
+    public void setConceptClass(String conceptClass) {
+        this.conceptClass = conceptClass;
     }
 
     public List<String> getEditorialNotes() {
@@ -111,11 +120,11 @@ public class ConceptDTO {
         this.editorialNotes = editorialNotes;
     }
 
-    public List<ConceptReferenceDTO> getReferences() {
+    public Set<ConceptReferenceInfoDTO> getReferences() {
         return references;
     }
 
-    public void setReferences(List<ConceptReferenceDTO> references) {
+    public void setReferences(Set<ConceptReferenceInfoDTO> references) {
         this.references = references;
     }
 
@@ -125,13 +134,5 @@ public class ConceptDTO {
 
     public void setTerms(Set<TermDTO> terms) {
         this.terms = terms;
-    }
-
-    public String getConceptClass() {
-        return conceptClass;
-    }
-
-    public void setConceptClass(String conceptClass) {
-        this.conceptClass = conceptClass;
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptReferenceDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptReferenceDTO.java
@@ -1,0 +1,25 @@
+package fi.vm.yti.terminology.api.v2.dto;
+
+import fi.vm.yti.terminology.api.v2.enums.ReferenceType;
+
+public class ConceptReferenceDTO {
+
+    private ReferenceType referenceType;
+    private String conceptURI;
+
+    public ReferenceType getReferenceType() {
+        return referenceType;
+    }
+
+    public void setReferenceType(ReferenceType referenceType) {
+        this.referenceType = referenceType;
+    }
+
+    public String getConceptURI() {
+        return conceptURI;
+    }
+
+    public void setConceptURI(String conceptURI) {
+        this.conceptURI = conceptURI;
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptReferenceInfoDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptReferenceInfoDTO.java
@@ -1,0 +1,35 @@
+package fi.vm.yti.terminology.api.v2.dto;
+
+import fi.vm.yti.terminology.api.v2.enums.ReferenceType;
+
+import java.util.Map;
+
+public class ConceptReferenceInfoDTO {
+    private String conceptURI;
+    private ReferenceType referenceType;
+    private Map<String, String> label;
+
+    public String getConceptURI() {
+        return conceptURI;
+    }
+
+    public void setConceptURI(String conceptURI) {
+        this.conceptURI = conceptURI;
+    }
+
+    public ReferenceType getReferenceType() {
+        return referenceType;
+    }
+
+    public void setReferenceType(ReferenceType referenceType) {
+        this.referenceType = referenceType;
+    }
+
+    public Map<String, String> getLabel() {
+        return label;
+    }
+
+    public void setLabel(Map<String, String> label) {
+        this.label = label;
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/LocalizedValueDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/LocalizedValueDTO.java
@@ -1,0 +1,22 @@
+package fi.vm.yti.terminology.api.v2.dto;
+
+public class LocalizedValueDTO {
+    private String language;
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/LocalizedValueDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/LocalizedValueDTO.java
@@ -1,8 +1,17 @@
 package fi.vm.yti.terminology.api.v2.dto;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+
+import java.util.Objects;
+
 public class LocalizedValueDTO {
     private String language;
     private String value;
+
+    public LocalizedValueDTO(String language, String value) {
+        this.language = language;
+        this.value = value;
+    }
 
     public String getValue() {
         return value;
@@ -18,5 +27,15 @@ public class LocalizedValueDTO {
 
     public void setLanguage(String language) {
         this.language = language;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(language, value);
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/TermDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/TermDTO.java
@@ -1,15 +1,31 @@
 package fi.vm.yti.terminology.api.v2.dto;
 
+import fi.vm.yti.common.enums.Status;
+import fi.vm.yti.terminology.api.v2.enums.*;
+
+import java.util.Objects;
+
 public class TermDTO {
-    private String termType;
+    private TermType termType;
     private String language;
     private String label;
+    private Integer homographNumber;
+    private Status status;
+    private String termInfo;
+    private String scope;
+    private String historyNote;
+    private String changeNote;
+    private String termStyle;
+    private TermFamily termFamily;
+    private TermConjugation termConjugation;
+    private TermEquivalency termEquivalency;
+    private WordClass wordClass;
 
-    public String getTermType() {
+    public TermType getTermType() {
         return termType;
     }
 
-    public void setTermType(String termType) {
+    public void setTermType(TermType termType) {
         this.termType = termType;
     }
 
@@ -27,5 +43,109 @@ public class TermDTO {
 
     public void setLabel(String label) {
         this.label = label;
+    }
+
+    public Integer getHomographNumber() {
+        return homographNumber;
+    }
+
+    public void setHomographNumber(Integer homographNumber) {
+        this.homographNumber = homographNumber;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public String getTermInfo() {
+        return termInfo;
+    }
+
+    public void setTermInfo(String termInfo) {
+        this.termInfo = termInfo;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
+    public String getHistoryNote() {
+        return historyNote;
+    }
+
+    public void setHistoryNote(String historyNote) {
+        this.historyNote = historyNote;
+    }
+
+    public String getChangeNote() {
+        return changeNote;
+    }
+
+    public void setChangeNote(String changeNote) {
+        this.changeNote = changeNote;
+    }
+
+    public String getTermStyle() {
+        return termStyle;
+    }
+
+    public void setTermStyle(String termStyle) {
+        this.termStyle = termStyle;
+    }
+
+    public TermFamily getTermFamily() {
+        return termFamily;
+    }
+
+    public void setTermFamily(TermFamily termFamily) {
+        this.termFamily = termFamily;
+    }
+
+    public TermConjugation getTermConjugation() {
+        return termConjugation;
+    }
+
+    public void setTermConjugation(TermConjugation termConjugation) {
+        this.termConjugation = termConjugation;
+    }
+
+    public WordClass getWordClass() {
+        return wordClass;
+    }
+
+    public void setWordClass(WordClass wordClass) {
+        this.wordClass = wordClass;
+    }
+
+    public TermEquivalency getTermEquivalency() {
+        return termEquivalency;
+    }
+
+    public void setTermEquivalency(TermEquivalency termEquivalency) {
+        this.termEquivalency = termEquivalency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TermDTO termDTO = (TermDTO) o;
+        return termType == termDTO.termType
+               && Objects.equals(language, termDTO.language)
+               && Objects.equals(label, termDTO.label)
+               && status == termDTO.status;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(termType, language, label, status);
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/TermDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/TermDTO.java
@@ -2,10 +2,12 @@ package fi.vm.yti.terminology.api.v2.dto;
 
 import fi.vm.yti.common.enums.Status;
 import fi.vm.yti.terminology.api.v2.enums.*;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Objects;
 
 public class TermDTO {
+    private String identifier;
     private TermType termType;
     private String language;
     private String label;
@@ -20,6 +22,14 @@ public class TermDTO {
     private TermConjugation termConjugation;
     private TermEquivalency termEquivalency;
     private WordClass wordClass;
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
 
     public TermType getTermType() {
         return termType;
@@ -147,5 +157,10 @@ public class TermDTO {
     @Override
     public int hashCode() {
         return Objects.hash(termType, language, label, status);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/TerminologyDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/TerminologyDTO.java
@@ -1,0 +1,17 @@
+package fi.vm.yti.terminology.api.v2.dto;
+
+import fi.vm.yti.common.dto.MetaDataDTO;
+import fi.vm.yti.common.enums.GraphType;
+
+public class TerminologyDTO extends MetaDataDTO {
+
+    private GraphType graphType;
+
+    public GraphType getGraphType() {
+        return graphType;
+    }
+
+    public void setGraphType(GraphType graphType) {
+        this.graphType = graphType;
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/ConceptController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/ConceptController.java
@@ -1,0 +1,91 @@
+package fi.vm.yti.terminology.api.v2.endpoint;
+
+import fi.vm.yti.terminology.api.v2.dto.ConceptDTO;
+import fi.vm.yti.terminology.api.v2.dto.ConceptInfoDTO;
+import fi.vm.yti.terminology.api.v2.service.ConceptService;
+import fi.vm.yti.terminology.api.v2.validator.ValidConcept;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URISyntaxException;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@RestController
+@RequestMapping("v2/concept")
+@Tag(name = "Concept")
+@Validated
+public class ConceptController {
+
+    private final ConceptService conceptService;
+
+    public ConceptController(ConceptService conceptService) {
+        this.conceptService = conceptService;
+    }
+
+    @Operation(summary = "Get concept information")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Concept fetched successfully"),
+            @ApiResponse(responseCode = "404", description = "Concept not found",
+                    content = {@Content(mediaType = APPLICATION_JSON_VALUE)}),
+    })
+    @GetMapping(path = "/{prefix}/{conceptIdentifier}", produces = APPLICATION_JSON_VALUE)
+    public ConceptInfoDTO get(@PathVariable @Parameter(description = "Terminology prefix") String prefix,
+                              @PathVariable @Parameter(description = "Concept identifier") String conceptIdentifier) {
+        return conceptService.get(prefix, conceptIdentifier);
+    }
+
+    @Operation(summary = "Create a new concept to terminology")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The JSON data for concept")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "The URI for the newly created concept"),
+            @ApiResponse(responseCode = "400", description = "One or more of the fields in the JSON data was invalid or malformed",
+                    content = {@Content(mediaType = APPLICATION_JSON_VALUE)}),
+            @ApiResponse(responseCode = "401", description = "Current user does not have rights to create concept"),
+    })
+    @PostMapping(path = "/{prefix}", consumes = APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> create(@PathVariable String prefix,
+                                         @RequestBody @ValidConcept ConceptDTO concept) throws URISyntaxException {
+        var conceptURI = conceptService.create(prefix, concept);
+        return ResponseEntity.created(conceptURI).build();
+    }
+
+    @Operation(summary = "Modify concept")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The JSON data for updated concept")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Concept updated successfully"),
+            @ApiResponse(responseCode = "400", description = "One or more of the fields in the JSON data was invalid or malformed",
+                    content = {@Content(mediaType = APPLICATION_JSON_VALUE)}),
+            @ApiResponse(responseCode = "401", description = "Current user does not have rights for this terminology"),
+            @ApiResponse(responseCode = "404", description = "Terminology or concept was not found", content = {@Content(mediaType = APPLICATION_JSON_VALUE)})
+    })
+    @PutMapping(path = "/{prefix}/{conceptIdentifier}", consumes = APPLICATION_JSON_VALUE)
+    public ResponseEntity<Void> update(
+            @PathVariable @Parameter(description = "Terminology prefix") String prefix,
+            @PathVariable @Parameter(description = "Concept identifier") String conceptIdentifier,
+            @RequestBody @ValidConcept ConceptDTO concept) {
+        conceptService.update(prefix, conceptIdentifier, concept);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Delete concept from terminology")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Concept deleted successfully"),
+            @ApiResponse(responseCode = "401", description = "Current user does not have rights for this terminology"),
+            @ApiResponse(responseCode = "404", description = "Terminology or concept was not found",
+                    content = {@Content(mediaType = APPLICATION_JSON_VALUE)}),
+    })
+    @DeleteMapping("/{prefix}/{conceptIdentifier}")
+    public ResponseEntity<Void> delete(@PathVariable @Parameter(description = "Terminology prefix") String prefix,
+                                       @PathVariable @Parameter(description = "Concept identifier") String conceptIdentifier) {
+        conceptService.delete(prefix, conceptIdentifier);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/ConceptController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/ConceptController.java
@@ -70,7 +70,7 @@ public class ConceptController {
     public ResponseEntity<Void> update(
             @PathVariable @Parameter(description = "Terminology prefix") String prefix,
             @PathVariable @Parameter(description = "Concept identifier") String conceptIdentifier,
-            @RequestBody @ValidConcept ConceptDTO concept) {
+            @RequestBody @ValidConcept(update = true) ConceptDTO concept) {
         conceptService.update(prefix, conceptIdentifier, concept);
         return ResponseEntity.noContent().build();
     }
@@ -87,5 +87,15 @@ public class ConceptController {
                                        @PathVariable @Parameter(description = "Concept identifier") String conceptIdentifier) {
         conceptService.delete(prefix, conceptIdentifier);
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Check if concept with identifier exists in terminology")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Concept deleted successfully")
+    })
+    @GetMapping("/{prefix}/{conceptIdentifier}/exists")
+    public Boolean exists(@PathVariable @Parameter(description = "Terminology prefix") String prefix,
+                                       @PathVariable @Parameter(description = "Concept identifier") String conceptIdentifier) {
+        return conceptService.exists(prefix, conceptIdentifier);
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/TerminologyController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/TerminologyController.java
@@ -1,9 +1,8 @@
 package fi.vm.yti.terminology.api.v2.endpoint;
 
-import fi.vm.yti.common.dto.MetaDataDTO;
 import fi.vm.yti.common.dto.MetaDataInfoDTO;
+import fi.vm.yti.terminology.api.v2.dto.TerminologyDTO;
 import fi.vm.yti.terminology.api.v2.service.TerminologyService;
-import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
 import fi.vm.yti.terminology.api.v2.validator.ValidTerminology;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -51,7 +50,7 @@ public class TerminologyController {
             @ApiResponse(responseCode = "401", description = "Current user does not have rights to create terminology"),
     })
     @PostMapping(consumes = APPLICATION_JSON_VALUE)
-    public ResponseEntity<String> create(@RequestBody @ValidTerminology MetaDataDTO terminology) throws URISyntaxException {
+    public ResponseEntity<String> create(@RequestBody @ValidTerminology TerminologyDTO terminology) throws URISyntaxException {
         var uri = terminologyService.create(terminology);
         return ResponseEntity.created(uri).build();
     }
@@ -68,7 +67,7 @@ public class TerminologyController {
     @PutMapping(path = "/{prefix}", consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> update(
             @PathVariable @Parameter(description = "Terminology prefix") String prefix,
-            @RequestBody @ValidTerminology(update = true) MetaDataDTO terminology) {
+            @RequestBody @ValidTerminology(update = true) TerminologyDTO terminology) {
         terminologyService.update(prefix, terminology);
         return ResponseEntity.noContent().build();
     }
@@ -90,7 +89,6 @@ public class TerminologyController {
     @ApiResponse(responseCode = "200", description = "Boolean value indicating whether prefix")
     @GetMapping(value = "/{prefix}/exists", produces = APPLICATION_JSON_VALUE)
     public Boolean exists(@PathVariable @Parameter(description = "Data model prefix") String prefix) {
-        var graphURI = TerminologyURI.createTerminologyURI(prefix).getGraphURI();
-        return terminologyService.exists(graphURI);
+        return terminologyService.exists(prefix);
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/enums/ReferenceType.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/enums/ReferenceType.java
@@ -1,0 +1,39 @@
+package fi.vm.yti.terminology.api.v2.enums;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum ReferenceType {
+    BROADER("broader"),
+    NARROWER("narrower"),
+    IS_PART_OF("isPartOf"),
+    HAS_PART("hasPart"),
+    RELATED("related"),
+    BROAD_MATCH("broadMatch"),
+    NARROW_MATCH("narrowMatch"),
+    CLOSE_MATCH("closeMatch"),
+    EXACT_MATCH("exactMatch"),
+    RELATED_MATCH("relatedMatch");
+
+    private final String property;
+
+    private static final Map<String, ReferenceType> lookup = new HashMap<>();
+
+    static {
+        for (var value : ReferenceType.values()) {
+            lookup.put(value.getProperty(), value);
+        }
+    }
+
+    ReferenceType(String property) {
+        this.property = property;
+    }
+
+    public String getProperty() {
+        return property;
+    }
+
+    public static ReferenceType getByPropertyName(String property) {
+        return lookup.get(property);
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/enums/TermConjugation.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/enums/TermConjugation.java
@@ -1,0 +1,6 @@
+package fi.vm.yti.terminology.api.v2.enums;
+
+public enum TermConjugation {
+    SINGULAR,
+    PLURAL
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/enums/TermEquivalency.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/enums/TermEquivalency.java
@@ -1,0 +1,8 @@
+package fi.vm.yti.terminology.api.v2.enums;
+
+public enum TermEquivalency {
+
+    BROADER,
+    NARROWER,
+    CLOSE
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/enums/TermFamily.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/enums/TermFamily.java
@@ -6,3 +6,4 @@ public enum TermFamily {
     MASCULINE
 }
 
+

--- a/src/main/java/fi/vm/yti/terminology/api/v2/enums/TermFamily.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/enums/TermFamily.java
@@ -1,0 +1,8 @@
+package fi.vm.yti.terminology.api.v2.enums;
+
+public enum TermFamily {
+    NEUTRAL,
+    FEMININE,
+    MASCULINE
+}
+

--- a/src/main/java/fi/vm/yti/terminology/api/v2/enums/TermType.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/enums/TermType.java
@@ -1,0 +1,8 @@
+package fi.vm.yti.terminology.api.v2.enums;
+
+public enum TermType {
+    RECOMMENDED,
+    SYNONYM,
+    NOT_RECOMMENDED,
+    SEARCH_TERM
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/enums/TermType.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/enums/TermType.java
@@ -1,8 +1,33 @@
 package fi.vm.yti.terminology.api.v2.enums;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public enum TermType {
-    RECOMMENDED,
-    SYNONYM,
-    NOT_RECOMMENDED,
-    SEARCH_TERM
+    RECOMMENDED("prefLabel"),
+    SYNONYM("altLabel"),
+    NOT_RECOMMENDED("notRecommendedSynonym"),
+    SEARCH_TERM("hiddenLabel");
+
+    private final String property;
+    private static final Map<String, TermType> lookup = new HashMap<>();
+
+    static {
+        for (var value : TermType.values()) {
+            lookup.put(value.getProperty(), value);
+        }
+    }
+
+    TermType(String property) {
+        this.property = property;
+    }
+
+    public String getProperty() {
+        return property;
+    }
+
+    public static TermType getByPropertyName(String property) {
+        return lookup.get(property);
+    }
+
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/enums/WordClass.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/enums/WordClass.java
@@ -1,0 +1,6 @@
+package fi.vm.yti.terminology.api.v2.enums;
+
+public enum WordClass {
+    ADJECTIVE,
+    VERB
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapper.java
@@ -2,22 +2,21 @@ package fi.vm.yti.terminology.api.v2.mapper;
 
 import fi.vm.yti.common.dto.LinkDTO;
 import fi.vm.yti.common.dto.ResourceCommonInfoDTO;
+import fi.vm.yti.common.properties.SuomiMeta;
 import fi.vm.yti.common.util.MapperUtils;
 import fi.vm.yti.common.util.ModelWrapper;
 import fi.vm.yti.security.YtiUser;
 import fi.vm.yti.terminology.api.v2.dto.*;
-import fi.vm.yti.terminology.api.v2.enums.ReferenceType;
+import fi.vm.yti.terminology.api.v2.enums.*;
 import fi.vm.yti.terminology.api.v2.opensearch.IndexConcept;
 import fi.vm.yti.terminology.api.v2.property.Term;
-import org.apache.jena.rdf.model.Property;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.rdf.model.*;
 import org.apache.jena.sparql.vocabulary.FOAF;
 import org.apache.jena.vocabulary.*;
 
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 public class ConceptMapper {
 
@@ -25,12 +24,22 @@ public class ConceptMapper {
         // only static methods
     }
 
-    public static void dtoToModel(ModelWrapper model, ConceptDTO dto, String identifier, YtiUser user) {
+    public static final List<Property> internalRefProperties = List.of(SKOS.broader, SKOS.narrower,
+            SKOS.related, DCTerms.hasPart, DCTerms.isPartOf);
+
+    public static final List<Property> externalRefProperties = List.of(SKOS.broadMatch, SKOS.narrowMatch,
+            SKOS.closeMatch, SKOS.relatedMatch, SKOS.exactMatch);
+
+    public static final List<Property> termProperties = List.of(SKOS.prefLabel, SKOS.altLabel,
+            Term.notRecommendedSynonym, SKOS.hiddenLabel);
+
+    public static void dtoToModel(ModelWrapper model, ConceptDTO dto, YtiUser user) {
         var modelResource = model.getModelResource();
         var languages = MapperUtils.arrayPropertyToSet(modelResource, DCTerms.language);
 
-        var conceptResource = model.createResourceWithId(identifier)
-                .addProperty(SKOS.inScheme, ResourceFactory.createResource(modelResource.getURI()));
+        var conceptResource = model.createResourceWithId(dto.getIdentifier())
+                .addProperty(SKOS.inScheme, ResourceFactory.createResource(modelResource.getURI()))
+                .addProperty(RDF.type, SKOS.Concept);
 
         MapperUtils.addStatus(conceptResource, dto.getStatus());
 
@@ -47,7 +56,7 @@ public class ConceptMapper {
         addListProperty(conceptResource, Term.source, dto.getSources());
 
         dto.getTerms().forEach(term -> mapTerm(model, term, conceptResource));
-        dto.getReferences().forEach(ref -> mapReferences(ref, conceptResource));
+        mapReferencesToResource(dto, conceptResource);
         dto.getLinks().forEach(link -> mapLinks(model, link, languages, conceptResource));
 
         MapperUtils.addCreationMetadata(conceptResource, user);
@@ -58,35 +67,135 @@ public class ConceptMapper {
         var dto = new ConceptInfoDTO();
 
         dto.setIdentifier(resource.getLocalName());
+        dto.setUri(resource.getURI());
+        dto.setStatus(MapperUtils.getStatus(resource));
         dto.setDefinition(MapperUtils.localizedPropertyToMap(resource, SKOS.definition));
 
-        dto.setExamples(List.of());
-        dto.setNotes(List.of());
+        dto.setExamples(listToLocalizedValues(resource, SKOS.example));
+        dto.setNotes(listToLocalizedValues(resource, SKOS.note));
         dto.setSubjectArea(MapperUtils.localizedPropertyToMap(resource, Term.subjectArea));
 
-        dto.setReferences(mapReferences(model, resource));
+        dto.setReferences(mapInternalReferencesDTO(model, resource));
 
-        dto.setLinks(List.of());
-        dto.setSources(List.of());
+        var links = resource.listProperties(RDFS.seeAlso).mapWith(l -> {
+            var link = new LinkDTO();
+            link.setUri(MapperUtils.propertyToString(l.getResource(), FOAF.homepage));
+            link.setName(MapperUtils.localizedPropertyToMap(l.getResource(), DCTerms.title));
+            link.setDescription(MapperUtils.localizedPropertyToMap(l.getResource(), DCTerms.description));
+            return link;
+        });
+        dto.setLinks(links.toList());
+        dto.setSources(listToValues(resource, Term.source));
 
-        dto.setChangeNote(null);
-        dto.setHistoryNote(null);
-        dto.setEditorialNotes(List.of());
+        dto.setChangeNote(MapperUtils.propertyToString(resource, SKOS.changeNote));
+        dto.setHistoryNote(MapperUtils.propertyToString(resource, SKOS.historyNote));
+
+        // if mapUser is provided, user has permissions to the model
+        if (mapUser != null) {
+            dto.setEditorialNotes(listToValues(resource, SKOS.editorialNote));
+        }
 
         dto.setConceptClass(MapperUtils.propertyToString(resource, Term.conceptClass));
 
-        if (mapUser != null) {
-            mapUser.accept(dto);
-        }
+        dto.setTerms(mapTermDTO(resource, model));
+
+        MapperUtils.mapCreationInfo(dto, resource, mapUser);
         return dto;
     }
 
-    private static Set<ConceptReferenceInfoDTO> mapReferences(ModelWrapper model, Resource resource) {
+    public static void dtoToUpdateModel(ModelWrapper model, String conceptIdentifier, ConceptDTO dto, YtiUser user) {
+        var conceptResource = model.getResourceById(conceptIdentifier);
+        var languages = MapperUtils.arrayPropertyToSet(model.getModelResource(), DCTerms.language);
+
+        conceptResource.removeAll(SuomiMeta.publicationStatus);
+        conceptResource.removeAll(RDFS.seeAlso);
+
+        MapperUtils.addStatus(conceptResource, dto.getStatus());
+
+        MapperUtils.updateLocalizedProperty(languages, dto.getDefinition(), conceptResource, SKOS.definition);
+        MapperUtils.updateLocalizedProperty(languages, dto.getSubjectArea(), conceptResource, Term.subjectArea);
+
+        MapperUtils.updateStringProperty(conceptResource, SKOS.changeNote, dto.getChangeNote());
+        MapperUtils.updateStringProperty(conceptResource, SKOS.historyNote, dto.getHistoryNote());
+        MapperUtils.updateStringProperty(conceptResource, Term.conceptClass, dto.getConceptClass());
+
+        addLocalizedListProperty(conceptResource, SKOS.example, dto.getExamples());
+        addLocalizedListProperty(conceptResource, SKOS.note, dto.getNotes());
+        addListProperty(conceptResource, SKOS.editorialNote, dto.getEditorialNotes());
+        addListProperty(conceptResource, Term.source, dto.getSources());
+
+        mapReferencesToResource(dto, conceptResource);
+
+        // remove terms not included to payload
+        var termURIs = dto.getTerms().stream()
+                .filter(t -> t.getIdentifier() != null)
+                .map(t -> model.getModelResource().getNameSpace() + t.getIdentifier())
+                .toList();
+
+        var removedTerms = getTermSubjects(conceptResource).stream()
+                .filter(t -> !termURIs.contains(t.getURI()))
+                .toList();
+
+        removedTerms.forEach(removed -> {
+            model.removeAll(conceptResource, null, removed);
+            model.removeAll(removed.asResource(), null, null);
+        });
+
+        dto.getTerms().forEach(term -> mapTerm(model, term, conceptResource));
+        dto.getLinks().forEach(link -> mapLinks(model, link, languages, conceptResource));
+
+        MapperUtils.addUpdateMetadata(conceptResource, user);
+    }
+
+    public static IndexConcept toIndexDocument(ModelWrapper model, String identifier) {
+        var resource = model.getResourceById(identifier);
+
+        var prefLabels = resource.listProperties(SKOS.prefLabel)
+                .mapWith(s -> model.getResource(s.getObject().toString()))
+                .toList()
+                .stream().collect(Collectors.toMap(
+                        r -> r.getProperty(SKOSXL.literalForm).getLanguage(),
+                        r -> r.getProperty(SKOSXL.literalForm).getString()));
+
+        var indexConcept = new IndexConcept();
+        indexConcept.setId(resource.getURI());
+        indexConcept.setUri(resource.getURI());
+        indexConcept.setStatus(MapperUtils.getStatus(resource));
+        indexConcept.setLabel(prefLabels);
+        indexConcept.setAltLabel(getIndexedTerm(model, resource, SKOS.altLabel));
+        indexConcept.setNotRecommendedSynonym(getIndexedTerm(model, resource, Term.notRecommendedSynonym));
+        indexConcept.setSearchTerm(getIndexedTerm(model, resource, SKOS.hiddenLabel));
+        indexConcept.setDefinition(MapperUtils.localizedPropertyToMap(resource, SKOS.definition));
+        indexConcept.setCreated(MapperUtils.getLiteral(resource, DCTerms.created, String.class));
+        indexConcept.setModified(MapperUtils.getLiteral(resource, DCTerms.modified, String.class));
+
+        return indexConcept;
+    }
+
+    public static void mapDeleteConcept(ModelWrapper model, String identifier) {
+        var resource = model.getResourceById(identifier);
+
+        getTermSubjects(resource).forEach(term -> model.removeAll(term, null, null));
+        model.removeAll(null, null, resource);
+        model.removeAll(resource, null, null);
+    }
+
+    private static Map<String, List<String>> getIndexedTerm(ModelWrapper model, Resource resource, Property property) {
+        return resource.listProperties(property)
+                .mapWith(s -> model.getResource(s.getObject().toString()))
+                .filterKeep(r -> r.hasProperty(SKOSXL.literalForm))
+                .toList().stream()
+                .collect(Collectors.groupingBy(
+                        r -> r.getProperty(SKOSXL.literalForm).getLanguage(),
+                        Collectors.mapping(r -> r.getProperty(SKOSXL.literalForm).getString(), Collectors.toList())));
+    }
+
+    private static Set<ConceptReferenceInfoDTO> mapInternalReferencesDTO(ModelWrapper model, Resource resource) {
         var references = new HashSet<ConceptReferenceInfoDTO>();
 
-        var refProperties = List.of(SKOS.broader, SKOS.narrower, SKOS.related, DCTerms.hasPart, DCTerms.isPartOf);
-
-        refProperties.forEach(prop -> {
+        // at this point, populate only labels for references to current terminology,
+        // labels for external references must be fetched from index
+        internalRefProperties.forEach(prop -> {
             var ref = MapperUtils.propertyToString(resource, prop);
 
             if (ref != null) {
@@ -99,26 +208,17 @@ public class ConceptMapper {
                             var r = s.getObject().asResource().getProperty(SKOSXL.literalForm);
                             label.put(r.getLanguage(), r.getString());
                         });
-                dto.setReferenceType(ReferenceType.getByPropertyName(prop.getLocalName()));
                 dto.setLabel(label);
+                dto.setReferenceType(ReferenceType.getByPropertyName(prop.getLocalName()));
                 references.add(dto);
             }
         });
 
-
-
         return references;
     }
 
-    public static IndexConcept toIndexDocument(ModelWrapper model, String identifier) {
-        var resource = model.getResourceById(identifier);
-
-        var indexConcept = new IndexConcept();
-        indexConcept.setId(resource.getURI());
-        return indexConcept;
-    }
-
     private static void addLocalizedListProperty(Resource resource, Property property, List<LocalizedValueDTO> values) {
+        resource.removeAll(property);
         if (values.isEmpty()) {
             return;
         }
@@ -129,6 +229,7 @@ public class ConceptMapper {
     }
 
     private static void addListProperty(Resource resource, Property property, List<String> values) {
+        resource.removeAll(property);
         if (values.isEmpty()) {
             return;
         }
@@ -138,19 +239,26 @@ public class ConceptMapper {
         resource.addProperty(property, list);
     }
 
-    private static void mapReferences(ConceptReferenceDTO ref, Resource resource) {
-        switch (ref.getReferenceType()) {
-            case BROADER -> MapperUtils.addOptionalUriProperty(resource, SKOS.broader, ref.getConceptURI());
-            case NARROWER -> MapperUtils.addOptionalUriProperty(resource, SKOS.narrower, ref.getConceptURI());
-            case RELATED -> MapperUtils.addOptionalUriProperty(resource, SKOS.related, ref.getConceptURI());
-            case IS_PART_OF -> MapperUtils.addOptionalUriProperty(resource, DCTerms.isPartOf, ref.getConceptURI());
-            case HAS_PART -> MapperUtils.addOptionalUriProperty(resource, DCTerms.hasPart, ref.getConceptURI());
-            case BROAD_MATCH -> MapperUtils.addOptionalUriProperty(resource, SKOS.broadMatch, ref.getConceptURI());
-            case NARROW_MATCH -> MapperUtils.addOptionalUriProperty(resource, SKOS.narrowMatch, ref.getConceptURI());
-            case CLOSE_MATCH -> MapperUtils.addOptionalUriProperty(resource, SKOS.closeMatch, ref.getConceptURI());
-            case RELATED_MATCH -> MapperUtils.addOptionalUriProperty(resource, SKOS.relatedMatch, ref.getConceptURI());
-            case EXACT_MATCH -> MapperUtils.addOptionalUriProperty(resource, SKOS.exactMatch, ref.getConceptURI());
-        }
+    private static void mapReferencesToResource(ConceptDTO dto, Resource resource) {
+        internalRefProperties.forEach(resource::removeAll);
+        externalRefProperties.forEach(resource::removeAll);
+
+        dto.getReferences().forEach(ref -> {
+            switch (ref.getReferenceType()) {
+                case BROADER -> MapperUtils.addOptionalUriProperty(resource, SKOS.broader, ref.getConceptURI());
+                case NARROWER -> MapperUtils.addOptionalUriProperty(resource, SKOS.narrower, ref.getConceptURI());
+                case RELATED -> MapperUtils.addOptionalUriProperty(resource, SKOS.related, ref.getConceptURI());
+                case IS_PART_OF -> MapperUtils.addOptionalUriProperty(resource, DCTerms.isPartOf, ref.getConceptURI());
+                case HAS_PART -> MapperUtils.addOptionalUriProperty(resource, DCTerms.hasPart, ref.getConceptURI());
+                case BROAD_MATCH -> MapperUtils.addOptionalUriProperty(resource, SKOS.broadMatch, ref.getConceptURI());
+                case NARROW_MATCH ->
+                        MapperUtils.addOptionalUriProperty(resource, SKOS.narrowMatch, ref.getConceptURI());
+                case CLOSE_MATCH -> MapperUtils.addOptionalUriProperty(resource, SKOS.closeMatch, ref.getConceptURI());
+                case RELATED_MATCH ->
+                        MapperUtils.addOptionalUriProperty(resource, SKOS.relatedMatch, ref.getConceptURI());
+                case EXACT_MATCH -> MapperUtils.addOptionalUriProperty(resource, SKOS.exactMatch, ref.getConceptURI());
+            }
+        });
     }
 
     private static void mapLinks(ModelWrapper model, LinkDTO link, Set<String> languages, Resource resource) {
@@ -162,18 +270,39 @@ public class ConceptMapper {
         resource.addProperty(RDFS.seeAlso, linkResource);
     }
 
+    private static List<Resource> getTermSubjects(Resource conceptResource) {
+        return termProperties.stream()
+                .flatMap(prop -> conceptResource.listProperties(prop)
+                        .mapWith(Statement::getObject)
+                        .toList().stream())
+                .map(RDFNode::asResource)
+                .toList();
+    }
+
     private static void mapTerm(ModelWrapper model, TermDTO term, Resource resource) {
-        var termIdentifier = "term-" + UUID.randomUUID();
-        var termResource = model.createResourceWithId(termIdentifier);
-        termResource.addProperty(RDF.type, SKOSXL.Label);
-        termResource.addProperty(SKOSXL.literalForm, ResourceFactory.createLangLiteral(term.getLabel(), term.getLanguage()));
-        MapperUtils.addLiteral(termResource, Term.homographNumber, term.getHomographNumber());
+        Resource termResource;
+        String language;
+
+        if (term.getIdentifier() == null) {
+            termResource = model.createResourceWithId("term-" + UUID.randomUUID());
+            termResource.addProperty(RDF.type, SKOSXL.Label);
+            language = term.getLanguage();
+        } else {
+            termResource = model.getResourceById(term.getIdentifier());
+            language = termResource.getProperty(SKOSXL.literalForm).getLanguage();
+        }
+
+        termResource.removeAll(SuomiMeta.publicationStatus);
+        termResource.removeAll(SKOSXL.literalForm);
+
+        termResource.addProperty(SKOSXL.literalForm, ResourceFactory.createLangLiteral(term.getLabel(), language));
+        MapperUtils.updateLiteral(termResource, Term.homographNumber, term.getHomographNumber());
         MapperUtils.addStatus(termResource, term.getStatus());
-        MapperUtils.addOptionalStringProperty(termResource, Term.termInfo, term.getTermInfo());
-        MapperUtils.addOptionalStringProperty(termResource, Term.scope, term.getScope());
-        MapperUtils.addOptionalStringProperty(termResource, SKOS.historyNote, term.getHistoryNote());
-        MapperUtils.addOptionalStringProperty(termResource, SKOS.changeNote, term.getChangeNote());
-        MapperUtils.addOptionalStringProperty(termResource, Term.termStyle, term.getTermStyle());
+        MapperUtils.updateStringProperty(termResource, Term.termInfo, term.getTermInfo());
+        MapperUtils.updateStringProperty(termResource, Term.scope, term.getScope());
+        MapperUtils.updateStringProperty(termResource, SKOS.historyNote, term.getHistoryNote());
+        MapperUtils.updateStringProperty(termResource, SKOS.changeNote, term.getChangeNote());
+        MapperUtils.updateStringProperty(termResource, Term.termStyle, term.getTermStyle());
         addOptionalEnumProperty(termResource, Term.termFamily, term.getTermFamily());
         addOptionalEnumProperty(termResource, Term.termConjugation, term.getTermConjugation());
         addOptionalEnumProperty(termResource, Term.termEquivalency, term.getTermEquivalency());
@@ -182,15 +311,83 @@ public class ConceptMapper {
         switch (term.getTermType()) {
             case RECOMMENDED -> MapperUtils.addOptionalUriProperty(resource, SKOS.prefLabel, termResource.getURI());
             case SYNONYM -> MapperUtils.addOptionalUriProperty(resource, SKOS.altLabel, termResource.getURI());
-            case NOT_RECOMMENDED -> MapperUtils.addOptionalUriProperty(resource, Term.notRecommendedSynonym, termResource.getURI());
+            case NOT_RECOMMENDED ->
+                    MapperUtils.addOptionalUriProperty(resource, Term.notRecommendedSynonym, termResource.getURI());
             case SEARCH_TERM -> MapperUtils.addOptionalUriProperty(resource, SKOS.hiddenLabel, termResource.getURI());
         }
     }
 
+    private static Set<TermDTO> mapTermDTO(Resource resource, ModelWrapper model) {
+
+        var terms = new HashSet<TermDTO>();
+        termProperties.forEach(property -> {
+            var termRef = MapperUtils.propertyToString(resource, property);
+
+            if (termRef == null) {
+                return;
+            }
+            var termResource = model.getResource(termRef);
+            var label = termResource.getProperty(SKOSXL.literalForm).getObject().asLiteral();
+
+            var term = new TermDTO();
+            term.setIdentifier(termResource.getLocalName());
+            term.setTermType(TermType.getByPropertyName(property.getLocalName()));
+            term.setStatus(MapperUtils.getStatus(termResource));
+            term.setLanguage(label.getLanguage());
+            term.setHomographNumber(MapperUtils.getLiteral(termResource, Term.homographNumber, Integer.class));
+
+            term.setLabel(label.getString());
+            term.setTermInfo(MapperUtils.propertyToString(termResource, Term.termInfo));
+            term.setChangeNote(MapperUtils.propertyToString(termResource, SKOS.changeNote));
+            term.setHistoryNote(MapperUtils.propertyToString(termResource, SKOS.historyNote));
+            term.setScope(MapperUtils.propertyToString(termResource, Term.scope));
+
+            term.setTermConjugation(getEnumValue(termResource, Term.termConjugation, TermConjugation.class));
+            term.setTermEquivalency(getEnumValue(termResource, Term.termEquivalency, TermEquivalency.class));
+            term.setWordClass(getEnumValue(termResource, Term.wordClass, WordClass.class));
+            term.setTermStyle(MapperUtils.propertyToString(termResource, Term.termStyle));
+            term.setTermFamily(getEnumValue(termResource, Term.termFamily, TermFamily.class));
+
+            terms.add(term);
+        });
+
+        return terms;
+    }
+
     private static void addOptionalEnumProperty(Resource resource, Property property, Enum<?> e) {
+        resource.removeAll(property);
         if (e == null) {
             return;
         }
         MapperUtils.addOptionalStringProperty(resource, property, e.name());
+    }
+
+    private static List<LocalizedValueDTO> listToLocalizedValues(Resource resource, Property property) {
+        if (!resource.hasProperty(property)) {
+            return List.of();
+        }
+        return resource.getProperty(property)
+                .getList().asJavaList().stream()
+                .map(RDFNode::asLiteral)
+                .map(o -> new LocalizedValueDTO(o.getLanguage(), o.getString()))
+                .toList();
+    }
+
+    private static List<String> listToValues(Resource resource, Property property) {
+        if (!resource.hasProperty(property)) {
+            return List.of();
+        }
+        return resource.getProperty(property)
+                .getList().asJavaList().stream()
+                .map(s -> s.asLiteral().getString())
+                .toList();
+    }
+
+    private static <E extends Enum<E>> E getEnumValue(Resource resource, Property property, Class<E> e) {
+        var value = MapperUtils.propertyToString(resource, property);
+        if (value == null) {
+            return null;
+        }
+        return Enum.valueOf(e, value);
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapper.java
@@ -1,0 +1,196 @@
+package fi.vm.yti.terminology.api.v2.mapper;
+
+import fi.vm.yti.common.dto.LinkDTO;
+import fi.vm.yti.common.dto.ResourceCommonInfoDTO;
+import fi.vm.yti.common.util.MapperUtils;
+import fi.vm.yti.common.util.ModelWrapper;
+import fi.vm.yti.security.YtiUser;
+import fi.vm.yti.terminology.api.v2.dto.*;
+import fi.vm.yti.terminology.api.v2.enums.ReferenceType;
+import fi.vm.yti.terminology.api.v2.opensearch.IndexConcept;
+import fi.vm.yti.terminology.api.v2.property.Term;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.sparql.vocabulary.FOAF;
+import org.apache.jena.vocabulary.*;
+
+import java.util.*;
+import java.util.function.Consumer;
+
+public class ConceptMapper {
+
+    private ConceptMapper() {
+        // only static methods
+    }
+
+    public static void dtoToModel(ModelWrapper model, ConceptDTO dto, String identifier, YtiUser user) {
+        var modelResource = model.getModelResource();
+        var languages = MapperUtils.arrayPropertyToSet(modelResource, DCTerms.language);
+
+        var conceptResource = model.createResourceWithId(identifier)
+                .addProperty(SKOS.inScheme, ResourceFactory.createResource(modelResource.getURI()));
+
+        MapperUtils.addStatus(conceptResource, dto.getStatus());
+
+        MapperUtils.addLocalizedProperty(languages, dto.getDefinition(), conceptResource, SKOS.definition);
+        MapperUtils.addLocalizedProperty(languages, dto.getSubjectArea(), conceptResource, Term.subjectArea);
+
+        MapperUtils.addOptionalStringProperty(conceptResource, SKOS.changeNote, dto.getChangeNote());
+        MapperUtils.addOptionalStringProperty(conceptResource, SKOS.historyNote, dto.getHistoryNote());
+        MapperUtils.addOptionalStringProperty(conceptResource, Term.conceptClass, dto.getConceptClass());
+
+        addLocalizedListProperty(conceptResource, SKOS.example, dto.getExamples());
+        addLocalizedListProperty(conceptResource, SKOS.note, dto.getNotes());
+        addListProperty(conceptResource, SKOS.editorialNote, dto.getEditorialNotes());
+        addListProperty(conceptResource, Term.source, dto.getSources());
+
+        dto.getTerms().forEach(term -> mapTerm(model, term, conceptResource));
+        dto.getReferences().forEach(ref -> mapReferences(ref, conceptResource));
+        dto.getLinks().forEach(link -> mapLinks(model, link, languages, conceptResource));
+
+        MapperUtils.addCreationMetadata(conceptResource, user);
+    }
+
+    public static ConceptInfoDTO modelToDTO(ModelWrapper model, String conceptIdentifier, Consumer<ResourceCommonInfoDTO> mapUser) {
+        var resource = model.getResourceById(conceptIdentifier);
+        var dto = new ConceptInfoDTO();
+
+        dto.setIdentifier(resource.getLocalName());
+        dto.setDefinition(MapperUtils.localizedPropertyToMap(resource, SKOS.definition));
+
+        dto.setExamples(List.of());
+        dto.setNotes(List.of());
+        dto.setSubjectArea(MapperUtils.localizedPropertyToMap(resource, Term.subjectArea));
+
+        dto.setReferences(mapReferences(model, resource));
+
+        dto.setLinks(List.of());
+        dto.setSources(List.of());
+
+        dto.setChangeNote(null);
+        dto.setHistoryNote(null);
+        dto.setEditorialNotes(List.of());
+
+        dto.setConceptClass(MapperUtils.propertyToString(resource, Term.conceptClass));
+
+        if (mapUser != null) {
+            mapUser.accept(dto);
+        }
+        return dto;
+    }
+
+    private static Set<ConceptReferenceInfoDTO> mapReferences(ModelWrapper model, Resource resource) {
+        var references = new HashSet<ConceptReferenceInfoDTO>();
+
+        var refProperties = List.of(SKOS.broader, SKOS.narrower, SKOS.related, DCTerms.hasPart, DCTerms.isPartOf);
+
+        refProperties.forEach(prop -> {
+            var ref = MapperUtils.propertyToString(resource, prop);
+
+            if (ref != null) {
+                var dto = new ConceptReferenceInfoDTO();
+                dto.setConceptURI(ref);
+
+                var label = new HashMap<String, String>();
+                model.listStatements(ResourceFactory.createResource(ref), SKOS.prefLabel, (RDFNode) null)
+                        .forEach(s -> {
+                            var r = s.getObject().asResource().getProperty(SKOSXL.literalForm);
+                            label.put(r.getLanguage(), r.getString());
+                        });
+                dto.setReferenceType(ReferenceType.getByPropertyName(prop.getLocalName()));
+                dto.setLabel(label);
+                references.add(dto);
+            }
+        });
+
+
+
+        return references;
+    }
+
+    public static IndexConcept toIndexDocument(ModelWrapper model, String identifier) {
+        var resource = model.getResourceById(identifier);
+
+        var indexConcept = new IndexConcept();
+        indexConcept.setId(resource.getURI());
+        return indexConcept;
+    }
+
+    private static void addLocalizedListProperty(Resource resource, Property property, List<LocalizedValueDTO> values) {
+        if (values.isEmpty()) {
+            return;
+        }
+        var list = resource.getModel().createList(values.stream()
+                .map(e -> ResourceFactory.createLangLiteral(e.getValue(), e.getLanguage()))
+                .iterator());
+        resource.addProperty(property, list);
+    }
+
+    private static void addListProperty(Resource resource, Property property, List<String> values) {
+        if (values.isEmpty()) {
+            return;
+        }
+        var list = resource.getModel().createList(values.stream()
+                .map(ResourceFactory::createStringLiteral)
+                .iterator());
+        resource.addProperty(property, list);
+    }
+
+    private static void mapReferences(ConceptReferenceDTO ref, Resource resource) {
+        switch (ref.getReferenceType()) {
+            case BROADER -> MapperUtils.addOptionalUriProperty(resource, SKOS.broader, ref.getConceptURI());
+            case NARROWER -> MapperUtils.addOptionalUriProperty(resource, SKOS.narrower, ref.getConceptURI());
+            case RELATED -> MapperUtils.addOptionalUriProperty(resource, SKOS.related, ref.getConceptURI());
+            case IS_PART_OF -> MapperUtils.addOptionalUriProperty(resource, DCTerms.isPartOf, ref.getConceptURI());
+            case HAS_PART -> MapperUtils.addOptionalUriProperty(resource, DCTerms.hasPart, ref.getConceptURI());
+            case BROAD_MATCH -> MapperUtils.addOptionalUriProperty(resource, SKOS.broadMatch, ref.getConceptURI());
+            case NARROW_MATCH -> MapperUtils.addOptionalUriProperty(resource, SKOS.narrowMatch, ref.getConceptURI());
+            case CLOSE_MATCH -> MapperUtils.addOptionalUriProperty(resource, SKOS.closeMatch, ref.getConceptURI());
+            case RELATED_MATCH -> MapperUtils.addOptionalUriProperty(resource, SKOS.relatedMatch, ref.getConceptURI());
+            case EXACT_MATCH -> MapperUtils.addOptionalUriProperty(resource, SKOS.exactMatch, ref.getConceptURI());
+        }
+    }
+
+    private static void mapLinks(ModelWrapper model, LinkDTO link, Set<String> languages, Resource resource) {
+        var linkResource = model.createResource();
+        MapperUtils.addLocalizedProperty(languages, link.getName(), linkResource, DCTerms.title);
+        MapperUtils.addLocalizedProperty(languages, link.getDescription(), linkResource, DCTerms.description);
+        linkResource.addProperty(FOAF.homepage, link.getUri());
+
+        resource.addProperty(RDFS.seeAlso, linkResource);
+    }
+
+    private static void mapTerm(ModelWrapper model, TermDTO term, Resource resource) {
+        var termIdentifier = "term-" + UUID.randomUUID();
+        var termResource = model.createResourceWithId(termIdentifier);
+        termResource.addProperty(RDF.type, SKOSXL.Label);
+        termResource.addProperty(SKOSXL.literalForm, ResourceFactory.createLangLiteral(term.getLabel(), term.getLanguage()));
+        MapperUtils.addLiteral(termResource, Term.homographNumber, term.getHomographNumber());
+        MapperUtils.addStatus(termResource, term.getStatus());
+        MapperUtils.addOptionalStringProperty(termResource, Term.termInfo, term.getTermInfo());
+        MapperUtils.addOptionalStringProperty(termResource, Term.scope, term.getScope());
+        MapperUtils.addOptionalStringProperty(termResource, SKOS.historyNote, term.getHistoryNote());
+        MapperUtils.addOptionalStringProperty(termResource, SKOS.changeNote, term.getChangeNote());
+        MapperUtils.addOptionalStringProperty(termResource, Term.termStyle, term.getTermStyle());
+        addOptionalEnumProperty(termResource, Term.termFamily, term.getTermFamily());
+        addOptionalEnumProperty(termResource, Term.termConjugation, term.getTermConjugation());
+        addOptionalEnumProperty(termResource, Term.termEquivalency, term.getTermEquivalency());
+        addOptionalEnumProperty(termResource, Term.wordClass, term.getWordClass());
+
+        switch (term.getTermType()) {
+            case RECOMMENDED -> MapperUtils.addOptionalUriProperty(resource, SKOS.prefLabel, termResource.getURI());
+            case SYNONYM -> MapperUtils.addOptionalUriProperty(resource, SKOS.altLabel, termResource.getURI());
+            case NOT_RECOMMENDED -> MapperUtils.addOptionalUriProperty(resource, Term.notRecommendedSynonym, termResource.getURI());
+            case SEARCH_TERM -> MapperUtils.addOptionalUriProperty(resource, SKOS.hiddenLabel, termResource.getURI());
+        }
+    }
+
+    private static void addOptionalEnumProperty(Resource resource, Property property, Enum<?> e) {
+        if (e == null) {
+            return;
+        }
+        MapperUtils.addOptionalStringProperty(resource, property, e.name());
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/mapper/TerminologyMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/mapper/TerminologyMapper.java
@@ -97,14 +97,14 @@ public class TerminologyMapper {
 
         var index = new IndexTerminology();
         index.setPrefix(model.getPrefix());
-        index.setUri(model.getGraphURI());
+        index.setUri(model.getModelResource().getURI());
         index.setId(model.getGraphURI());
         index.setLanguages(MapperUtils.arrayPropertyToList(terminologyResource, DCTerms.language));
         index.setLabel(MapperUtils.localizedPropertyToMap(terminologyResource, SKOS.prefLabel));
         index.setDescription(MapperUtils.localizedPropertyToMap(terminologyResource, RDFS.comment));
         index.setStatus(MapperUtils.getStatus(terminologyResource));
         index.setModified(terminologyResource.getProperty(DCTerms.modified).getString());
-        index.setCreated(terminologyResource.getProperty(DCTerms.modified).getString());
+        index.setCreated(terminologyResource.getProperty(DCTerms.created).getString());
 
         var organizations = MapperUtils.arrayPropertyToSet(terminologyResource, DCTerms.contributor)
                 .stream()
@@ -138,6 +138,7 @@ public class TerminologyMapper {
         MapperUtils.updateLocalizedProperty(dto.getLanguages(), dto.getDescription(), modelResource, RDFS.comment);
         MapperUtils.updateStringProperty(modelResource, SuomiMeta.contact, dto.getContact());
         MapperUtils.updateStringProperty(modelResource, Term.terminologyType, dto.getGraphType().name());
+        MapperUtils.updateStringProperty(modelResource, SuomiMeta.publicationStatus, MapperUtils.getStatusUri(dto.getStatus()));
 
         addOrganizations(dto, modelResource);
         addGroups(dto, categories, modelResource);

--- a/src/main/java/fi/vm/yti/terminology/api/v2/mapper/TerminologyMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/mapper/TerminologyMapper.java
@@ -1,16 +1,31 @@
 package fi.vm.yti.terminology.api.v2.mapper;
 
-import fi.vm.yti.common.dto.MetaDataDTO;
+import fi.vm.yti.common.Constants;
+import fi.vm.yti.common.dto.OrganizationDTO;
+import fi.vm.yti.common.dto.ResourceCommonInfoDTO;
+import fi.vm.yti.common.dto.ServiceCategoryDTO;
+import fi.vm.yti.common.enums.GraphType;
 import fi.vm.yti.common.properties.DCAP;
+import fi.vm.yti.common.properties.SuomiMeta;
 import fi.vm.yti.common.util.MapperUtils;
+import fi.vm.yti.common.util.ModelWrapper;
+import fi.vm.yti.security.YtiUser;
+import fi.vm.yti.terminology.api.v2.dto.TerminologyDTO;
 import fi.vm.yti.terminology.api.v2.dto.TerminologyInfoDTO;
 import fi.vm.yti.terminology.api.v2.opensearch.IndexTerminology;
-import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
-import org.apache.jena.rdf.model.Model;
+import fi.vm.yti.terminology.api.v2.property.Term;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
 import org.apache.jena.vocabulary.SKOS;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 public class TerminologyMapper {
 
@@ -18,36 +33,131 @@ public class TerminologyMapper {
         // only static methods
     }
 
-    public static Model dtoToModel(MetaDataDTO dto, String graph) {
+    public static ModelWrapper dtoToModel(TerminologyDTO dto, String graph, List<ServiceCategoryDTO> categories, YtiUser user) {
         var model = ModelFactory.createDefaultModel();
         var resource = model.createResource(graph)
+                .addProperty(RDF.type, SKOS.ConceptScheme)
                 .addProperty(DCAP.preferredXMLNamespacePrefix, dto.getPrefix())
-                .addProperty(RDF.type, SKOS.ConceptScheme);
+                .addProperty(DCAP.preferredXMLNamespace, graph)
+                .addProperty(Term.terminologyType, dto.getGraphType().name());
 
+        dto.getLanguages().forEach(lang -> resource.addProperty(DCTerms.language, lang));
+
+        MapperUtils.addStatus(resource, dto.getStatus());
+        MapperUtils.addCreationMetadata(resource, user);
+
+        MapperUtils.addOptionalStringProperty(resource, SuomiMeta.contact, dto.getContact());
         MapperUtils.addLocalizedProperty(dto.getLanguages(), dto.getLabel(), resource, SKOS.prefLabel);
+        MapperUtils.addLocalizedProperty(dto.getLanguages(), dto.getDescription(), resource, RDFS.comment);
 
-        return model;
+        addOrganizations(dto, resource);
+        addGroups(dto, categories, resource);
+
+        return new ModelWrapper(model, graph);
     }
 
-    public static TerminologyInfoDTO modelToDTO(Model model) {
+    public static TerminologyInfoDTO modelToDTO(ModelWrapper model,
+                                                List<ServiceCategoryDTO> categories,
+                                                List<OrganizationDTO> organizations,
+                                                Consumer<ResourceCommonInfoDTO> userMapper) {
         var dto = new TerminologyInfoDTO();
-        var terminologyURI = TerminologyURI.createTerminologyURI(model);
-        var resource = model.getResource(terminologyURI.getModelResourceURI());
-        dto.setPrefix(terminologyURI.getPrefix());
-        dto.setUri(terminologyURI.getGraphURI());
+        var resource = model.getModelResource();
+
+        dto.setPrefix(model.getPrefix());
+        dto.setUri(model.getGraphURI());
         dto.setLabel(MapperUtils.localizedPropertyToMap(resource, SKOS.prefLabel));
+        dto.setDescription(MapperUtils.localizedPropertyToMap(resource, RDFS.comment));
+        dto.setContact(MapperUtils.propertyToString(resource, SuomiMeta.contact));
+        dto.setModelType(GraphType.valueOf(MapperUtils.propertyToString(resource, Term.terminologyType)));
+        dto.setLanguages(MapperUtils.arrayPropertyToSet(resource, DCTerms.language));
+        dto.setStatus(MapperUtils.getStatus(resource));
+
+        var groups = MapperUtils.arrayPropertyToSet(resource, DCTerms.isPartOf);
+
+        dto.setGroups(categories.stream()
+                .filter(c -> groups.contains(c.getId()))
+                .collect(Collectors.toSet()));
+
+        var contributors = MapperUtils.arrayPropertyToSet(resource, DCTerms.contributor)
+                .stream()
+                .map(c -> c.replace(Constants.URN_UUID, ""))
+                .collect(Collectors.toSet());
+
+        dto.setOrganizations(organizations.stream()
+                .filter(o -> contributors.contains(o.getId()))
+                .collect(Collectors.toSet()));
+
+        MapperUtils.mapCreationInfo(dto, resource, userMapper);
+
         return dto;
     }
 
-    public static IndexTerminology toIndexDocument(Model model) {
-        var terminologyURI = TerminologyURI.createTerminologyURI(model);
-        var terminologyResource = model.getResource(terminologyURI.getGraphURI());
+    public static IndexTerminology toIndexDocument(ModelWrapper model, List<ServiceCategoryDTO> categories) {
+        var terminologyResource = model.getModelResource();
 
         var index = new IndexTerminology();
-        index.setUri(terminologyURI.getGraphURI());
-        index.setId(terminologyURI.getGraphURI());
-        index.setLabel(MapperUtils.localizedPropertyToMap(terminologyResource, RDFS.label));
+        index.setPrefix(model.getPrefix());
+        index.setUri(model.getGraphURI());
+        index.setId(model.getGraphURI());
+        index.setLanguages(MapperUtils.arrayPropertyToList(terminologyResource, DCTerms.language));
+        index.setLabel(MapperUtils.localizedPropertyToMap(terminologyResource, SKOS.prefLabel));
+        index.setDescription(MapperUtils.localizedPropertyToMap(terminologyResource, RDFS.comment));
+        index.setStatus(MapperUtils.getStatus(terminologyResource));
+        index.setModified(terminologyResource.getProperty(DCTerms.modified).getString());
+        index.setCreated(terminologyResource.getProperty(DCTerms.modified).getString());
 
+        var organizations = MapperUtils.arrayPropertyToSet(terminologyResource, DCTerms.contributor)
+                .stream()
+                .map(o -> o.replace(Constants.URN_UUID, ""))
+                .map(UUID::fromString)
+                .toList();
+        index.setOrganizations(organizations);
+
+        var addedGroups = MapperUtils.arrayPropertyToSet(terminologyResource, DCTerms.isPartOf);
+
+        index.setGroups(categories.stream()
+                .filter(c -> addedGroups.contains(c.getId()))
+                .map(ServiceCategoryDTO::getIdentifier)
+                .toList());
         return index;
+    }
+
+    public static void toUpdateModel(ModelWrapper model,
+                                     TerminologyDTO dto,
+                                     List<ServiceCategoryDTO> categories,
+                                     YtiUser user) {
+        var modelResource = model.getModelResource();
+
+        modelResource.removeAll(DCTerms.language);
+        modelResource.removeAll(DCTerms.contributor);
+        modelResource.removeAll(DCTerms.isPartOf);
+
+        dto.getLanguages().forEach(lang -> modelResource.addProperty(DCTerms.language, lang));
+
+        MapperUtils.updateLocalizedProperty(dto.getLanguages(), dto.getLabel(), modelResource, SKOS.prefLabel);
+        MapperUtils.updateLocalizedProperty(dto.getLanguages(), dto.getDescription(), modelResource, RDFS.comment);
+        MapperUtils.updateStringProperty(modelResource, SuomiMeta.contact, dto.getContact());
+        MapperUtils.updateStringProperty(modelResource, Term.terminologyType, dto.getGraphType().name());
+
+        addOrganizations(dto, modelResource);
+        addGroups(dto, categories, modelResource);
+
+        MapperUtils.addUpdateMetadata(modelResource, user);
+    }
+
+    private static void addGroups(TerminologyDTO dto, List<ServiceCategoryDTO> categories, Resource resource) {
+        categories.stream()
+                .filter(cat -> dto.getGroups().contains(cat.getIdentifier()))
+                .forEach(cat -> resource.addProperty(
+                        DCTerms.isPartOf,
+                        ResourceFactory.createResource(cat.getId())
+                ));
+    }
+
+    private static void addOrganizations(TerminologyDTO dto, Resource resource) {
+        dto.getOrganizations().forEach(org -> resource.addProperty(
+                DCTerms.contributor,
+                ResourceFactory.createResource(Constants.URN_UUID + org)
+        ));
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/IndexConcept.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/IndexConcept.java
@@ -1,0 +1,45 @@
+package fi.vm.yti.terminology.api.v2.opensearch;
+
+import fi.vm.yti.common.opensearch.IndexBase;
+
+import java.util.List;
+import java.util.Map;
+
+public class IndexConcept extends IndexBase {
+    private Map<String, String> definition;
+    private Map<String, List<String>> altLabel;
+    private Map<String, List<String>> searchTerm;
+    private Map<String, List<String>> notRecommendedSynonym;
+
+    public Map<String, String> getDefinition() {
+        return definition;
+    }
+
+    public void setDefinition(Map<String, String> definition) {
+        this.definition = definition;
+    }
+
+    public Map<String, List<String>> getAltLabel() {
+        return altLabel;
+    }
+
+    public void setAltLabel(Map<String, List<String>> altLabel) {
+        this.altLabel = altLabel;
+    }
+
+    public Map<String, List<String>> getSearchTerm() {
+        return searchTerm;
+    }
+
+    public void setSearchTerm(Map<String, List<String>> searchTerm) {
+        this.searchTerm = searchTerm;
+    }
+
+    public Map<String, List<String>> getNotRecommendedSynonym() {
+        return notRecommendedSynonym;
+    }
+
+    public void setNotRecommendedSynonym(Map<String, List<String>> notRecommendedSynonym) {
+        this.notRecommendedSynonym = notRecommendedSynonym;
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/IndexTerminology.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/IndexTerminology.java
@@ -1,6 +1,6 @@
 package fi.vm.yti.terminology.api.v2.opensearch;
 
-import fi.vm.yti.common.opensearch.IndexBase;
+import fi.vm.yti.common.opensearch.IndexMetaData;
 
-public class IndexTerminology extends IndexBase {
+public class IndexTerminology extends IndexMetaData {
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/property/Term.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/property/Term.java
@@ -25,4 +25,8 @@ public class Term {
     public static final Property termEquivalency = ResourceFactory.createProperty(URI, "termEquivalency");
     public static final Property wordClass = ResourceFactory.createProperty(URI, "wordClass");
     public static final Property notRecommendedSynonym = ResourceFactory.createProperty(URI, "notRecommendedSynonym");
+
+    public static String getNamespace() {
+        return URI;
+    }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/property/Term.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/property/Term.java
@@ -12,4 +12,17 @@ public class Term {
     }
 
     public static final Property terminologyType = ResourceFactory.createProperty(URI, "terminologyType");
+    public static final Property conceptClass = ResourceFactory.createProperty(URI, "conceptClass");
+    public static final Property subjectArea = ResourceFactory.createProperty(URI, "subjectArea");
+
+    public static final Property source = ResourceFactory.createProperty(URI, "source");
+    public static final Property homographNumber = ResourceFactory.createProperty(URI, "homographNumber");
+    public static final Property termInfo = ResourceFactory.createProperty(URI, "termInfo");
+    public static final Property scope = ResourceFactory.createProperty(URI, "scope");
+    public static final Property termStyle = ResourceFactory.createProperty(URI, "termStyle");
+    public static final Property termFamily = ResourceFactory.createProperty(URI, "termFamily");
+    public static final Property termConjugation = ResourceFactory.createProperty(URI, "termConjugation");
+    public static final Property termEquivalency = ResourceFactory.createProperty(URI, "termEquivalency");
+    public static final Property wordClass = ResourceFactory.createProperty(URI, "wordClass");
+    public static final Property notRecommendedSynonym = ResourceFactory.createProperty(URI, "notRecommendedSynonym");
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/property/Term.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/property/Term.java
@@ -1,0 +1,15 @@
+package fi.vm.yti.terminology.api.v2.property;
+
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.ResourceFactory;
+
+public class Term {
+
+    private static final String URI = "https://iri.suomi.fi/model/term/";
+
+    private Term() {
+        // property class
+    }
+
+    public static final Property terminologyType = ResourceFactory.createProperty(URI, "terminologyType");
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/repository/TerminologyRepository.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/repository/TerminologyRepository.java
@@ -3,6 +3,7 @@ package fi.vm.yti.terminology.api.v2.repository;
 import fi.vm.yti.common.Constants;
 import fi.vm.yti.common.repository.BaseRepository;
 import fi.vm.yti.common.util.ModelWrapper;
+import fi.vm.yti.terminology.api.v2.property.Term;
 import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
 import org.apache.jena.rdfconnection.RDFConnection;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,8 +24,7 @@ public class TerminologyRepository extends BaseRepository {
     public ModelWrapper fetch(String graphURI) {
         var model = new ModelWrapper(super.fetch(graphURI), graphURI);
         model.setNsPrefixes(Constants.PREFIXES);
-        model.setNsPrefix("term", "https://iri.suomi.fi/model/term/");
-        model.setNsPrefix("skos-xl", "http://www.w3.org/2008/05/skos-xl#");
+        model.setNsPrefix("term", Term.getNamespace());
         model.setNsPrefix(model.getPrefix(), model.getModelResource().getNameSpace());
         return model;
     }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/repository/TerminologyRepository.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/repository/TerminologyRepository.java
@@ -1,5 +1,6 @@
 package fi.vm.yti.terminology.api.v2.repository;
 
+import fi.vm.yti.common.Constants;
 import fi.vm.yti.common.repository.BaseRepository;
 import fi.vm.yti.common.util.ModelWrapper;
 import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
@@ -20,7 +21,12 @@ public class TerminologyRepository extends BaseRepository {
 
     @Override
     public ModelWrapper fetch(String graphURI) {
-        return new ModelWrapper(super.fetch(graphURI), graphURI);
+        var model = new ModelWrapper(super.fetch(graphURI), graphURI);
+        model.setNsPrefixes(Constants.PREFIXES);
+        model.setNsPrefix("term", "https://iri.suomi.fi/model/term/");
+        model.setNsPrefix("skos-xl", "http://www.w3.org/2008/05/skos-xl#");
+        model.setNsPrefix(model.getPrefix(), model.getModelResource().getNameSpace());
+        return model;
     }
 
     public ModelWrapper fetchByPrefix(String prefix) {

--- a/src/main/java/fi/vm/yti/terminology/api/v2/repository/TerminologyRepository.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/repository/TerminologyRepository.java
@@ -1,6 +1,8 @@
 package fi.vm.yti.terminology.api.v2.repository;
 
 import fi.vm.yti.common.repository.BaseRepository;
+import fi.vm.yti.common.util.ModelWrapper;
+import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
 import org.apache.jena.rdfconnection.RDFConnection;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
@@ -14,5 +16,15 @@ public class TerminologyRepository extends BaseRepository {
                 RDFConnection.connect(endpoint + "/terminology/sparql"),
                 RDFConnection.connect(endpoint + "/terminology/update")
         );
+    }
+
+    @Override
+    public ModelWrapper fetch(String graphURI) {
+        return new ModelWrapper(super.fetch(graphURI), graphURI);
+    }
+
+    public ModelWrapper fetchByPrefix(String prefix) {
+        var graphURI = TerminologyURI.createTerminologyURI(prefix).getGraphURI();
+        return fetch(graphURI);
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/service/ConceptService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/service/ConceptService.java
@@ -1,0 +1,81 @@
+package fi.vm.yti.terminology.api.v2.service;
+
+import fi.vm.yti.common.dto.ResourceCommonInfoDTO;
+import fi.vm.yti.common.exception.ResourceExistsException;
+import fi.vm.yti.common.service.AuditService;
+import fi.vm.yti.common.service.GroupManagementService;
+import fi.vm.yti.terminology.api.v2.dto.ConceptDTO;
+import fi.vm.yti.terminology.api.v2.dto.ConceptInfoDTO;
+import fi.vm.yti.terminology.api.v2.mapper.ConceptMapper;
+import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
+import fi.vm.yti.terminology.api.v2.security.TerminologyAuthorizationManager;
+import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
+import org.apache.commons.lang3.NotImplementedException;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.function.Consumer;
+
+import static fi.vm.yti.security.AuthorizationException.check;
+
+@Service
+public class ConceptService {
+
+    private final TerminologyRepository repository;
+    private final TerminologyAuthorizationManager authorizationManager;
+    private final IndexService indexService;
+    private final AuditService auditService;
+    private final GroupManagementService groupManagementService;
+
+    public ConceptService(TerminologyRepository repository,
+                          TerminologyAuthorizationManager authorizationManager,
+                          IndexService indexService,
+                          GroupManagementService groupManagementService) {
+        this.repository = repository;
+        this.authorizationManager = authorizationManager;
+        this.indexService = indexService;
+        this.groupManagementService = groupManagementService;
+
+        this.auditService = new AuditService("CONCEPT");
+    }
+
+    public ConceptInfoDTO get(String prefix, String conceptIdentifier) {
+        var model = repository.fetchByPrefix(prefix);
+
+        Consumer<ResourceCommonInfoDTO> mapUser = null;
+        if (authorizationManager.hasRightsToTerminology(prefix, model)) {
+            mapUser = groupManagementService.mapUser();
+        }
+        return ConceptMapper.modelToDTO(model, conceptIdentifier, mapUser);
+    }
+
+    public URI create(String prefix, ConceptDTO dto) throws URISyntaxException {
+        var model = repository.fetchByPrefix(prefix);
+        var user = authorizationManager.getUser();
+        check(authorizationManager.hasRightsToTerminology(prefix, model));
+
+        var resourceURI = TerminologyURI.createConceptURI(prefix, dto.getIdentifier()).getResourceURI();
+
+        if (repository.resourceExistsInGraph(model.getGraphURI(), resourceURI)) {
+            throw new ResourceExistsException(dto.getIdentifier(), model.getGraphURI());
+        }
+
+        ConceptMapper.dtoToModel(model, dto, dto.getIdentifier(), user);
+
+        repository.put(model.getGraphURI(), model);
+        indexService.addConceptToIndex(ConceptMapper.toIndexDocument(model, dto.getIdentifier()));
+        auditService.log(AuditService.ActionType.CREATE, resourceURI, user);
+
+        return new URI(resourceURI);
+    }
+
+    public void update(String prefix, String conceptIdentifier, ConceptDTO concept) {
+        throw new NotImplementedException();
+    }
+
+    public void delete(String prefix, String conceptIdentifier) {
+        throw new NotImplementedException();
+    }
+
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/service/IndexService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/service/IndexService.java
@@ -1,9 +1,16 @@
 package fi.vm.yti.terminology.api.v2.service;
 
+import fi.vm.yti.common.Constants;
 import fi.vm.yti.common.opensearch.OpenSearchClientWrapper;
 import fi.vm.yti.common.opensearch.OpenSearchInitializer;
 import fi.vm.yti.common.opensearch.OpenSearchUtil;
+import fi.vm.yti.common.service.FrontendService;
+import fi.vm.yti.common.util.ModelWrapper;
+import fi.vm.yti.terminology.api.v2.mapper.TerminologyMapper;
 import fi.vm.yti.terminology.api.v2.opensearch.IndexTerminology;
+import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
+import org.apache.jena.arq.querybuilder.SelectBuilder;
+import org.apache.jena.arq.querybuilder.WhereBuilder;
 import org.opensearch.client.opensearch._types.mapping.TypeMapping;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,17 +26,20 @@ public class IndexService extends OpenSearchInitializer {
     public static final String CONCEPT_INDEX = "concepts_v2";
 
     private final OpenSearchClientWrapper client;
+    private final TerminologyRepository repository;
+    private final FrontendService frontendService;
 
-    public IndexService(OpenSearchClientWrapper client) {
+    public IndexService(OpenSearchClientWrapper client,
+                        TerminologyRepository repository,
+                        FrontendService frontendService) {
         super(client);
         this.client = client;
+        this.repository = repository;
+        this.frontendService = frontendService;
     }
 
     public void initIndexes() {
-        InitIndexesFunction fn = () -> {
-            initTerminologyIndex();
-            initConceptIndex();
-        };
+        InitIndexesFunction fn = this::initTerminologyIndex;
 
         var indexConfig = Map.of(
                 TERMINOLOGY_INDEX, getTerminologyMappings(),
@@ -39,11 +49,11 @@ public class IndexService extends OpenSearchInitializer {
     }
 
     public void addTerminologyToIndex(IndexTerminology indexTerminology) {
-        client.putToIndex(TERMINOLOGY_INDEX, indexTerminology.getId(), indexTerminology);
+        client.putToIndex(TERMINOLOGY_INDEX, indexTerminology);
     }
 
     public void updateTerminologyToIndex(IndexTerminology indexTerminology) {
-        client.updateToIndex(TERMINOLOGY_INDEX, indexTerminology.getId(), indexTerminology);
+        client.updateToIndex(TERMINOLOGY_INDEX, indexTerminology);
     }
 
     public void deleteTerminologyFromIndex(String id) {
@@ -51,11 +61,31 @@ public class IndexService extends OpenSearchInitializer {
     }
 
     private void initTerminologyIndex() {
-        LOG.info("Init terminologies");
+        LOG.info("Init terminologies index");
+
+        var selectBuilder = new SelectBuilder();
+        selectBuilder.addPrefixes(Constants.PREFIXES);
+        var exprFactory = selectBuilder.getExprFactory();
+        var expr = exprFactory.strstarts(exprFactory.str("?g"), Constants.TERMINOLOGY_NAMESPACE);
+        selectBuilder.addFilter(expr);
+        selectBuilder.addGraph("?g", new WhereBuilder());
+
+        var categories = frontendService.getServiceCategories();
+
+        repository.querySelect(selectBuilder.build(), (var row) -> {
+            var graph = row.get("g").toString();
+            LOG.info("Indexing terminology {} metadata", graph);
+
+            var model = repository.fetch(graph);
+            var index = TerminologyMapper.toIndexDocument(model, categories);
+            client.putToIndex(TERMINOLOGY_INDEX, index);
+
+            initConceptIndex(model);
+        });
     }
 
-    private void initConceptIndex() {
-        LOG.info("Init concepts");
+    private void initConceptIndex(ModelWrapper model) {
+        LOG.info("Init concepts for terminology {}", model.getGraphURI());
     }
 
     private TypeMapping getTerminologyMappings() {

--- a/src/main/java/fi/vm/yti/terminology/api/v2/service/IndexService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/service/IndexService.java
@@ -7,6 +7,7 @@ import fi.vm.yti.common.opensearch.OpenSearchUtil;
 import fi.vm.yti.common.service.FrontendService;
 import fi.vm.yti.common.util.ModelWrapper;
 import fi.vm.yti.terminology.api.v2.mapper.TerminologyMapper;
+import fi.vm.yti.terminology.api.v2.opensearch.IndexConcept;
 import fi.vm.yti.terminology.api.v2.opensearch.IndexTerminology;
 import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
 import org.apache.jena.arq.querybuilder.SelectBuilder;
@@ -58,6 +59,18 @@ public class IndexService extends OpenSearchInitializer {
 
     public void deleteTerminologyFromIndex(String id) {
         client.removeFromIndex(TERMINOLOGY_INDEX, id);
+    }
+
+    public void addConceptToIndex(IndexConcept indexConcept) {
+        client.putToIndex(CONCEPT_INDEX, indexConcept);
+    }
+
+    public void updateConceptToIndex(IndexConcept indexConcept) {
+        client.updateToIndex(CONCEPT_INDEX, indexConcept);
+    }
+
+    public void deleteConceptFromIndex(String id) {
+        client.removeFromIndex(CONCEPT_INDEX, id);
     }
 
     private void initTerminologyIndex() {

--- a/src/main/java/fi/vm/yti/terminology/api/v2/service/IndexService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/service/IndexService.java
@@ -6,12 +6,14 @@ import fi.vm.yti.common.opensearch.OpenSearchInitializer;
 import fi.vm.yti.common.opensearch.OpenSearchUtil;
 import fi.vm.yti.common.service.FrontendService;
 import fi.vm.yti.common.util.ModelWrapper;
+import fi.vm.yti.terminology.api.v2.mapper.ConceptMapper;
 import fi.vm.yti.terminology.api.v2.mapper.TerminologyMapper;
 import fi.vm.yti.terminology.api.v2.opensearch.IndexConcept;
 import fi.vm.yti.terminology.api.v2.opensearch.IndexTerminology;
 import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
 import org.apache.jena.arq.querybuilder.SelectBuilder;
 import org.apache.jena.arq.querybuilder.WhereBuilder;
+import org.apache.jena.vocabulary.SKOS;
 import org.opensearch.client.opensearch._types.mapping.TypeMapping;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -99,6 +101,12 @@ public class IndexService extends OpenSearchInitializer {
 
     private void initConceptIndex(ModelWrapper model) {
         LOG.info("Init concepts for terminology {}", model.getGraphURI());
+
+        model.listSubjectsWithProperty(SKOS.inScheme, model.getModelResource()).forEach(concept -> {
+            LOG.debug("Indexing concept {}", concept.getURI());
+            var index = ConceptMapper.toIndexDocument(model, concept.getLocalName());
+            client.putToIndex(CONCEPT_INDEX, index);
+        });
     }
 
     private TypeMapping getTerminologyMappings() {

--- a/src/main/java/fi/vm/yti/terminology/api/v2/service/IndexService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/service/IndexService.java
@@ -2,15 +2,14 @@ package fi.vm.yti.terminology.api.v2.service;
 
 import fi.vm.yti.common.opensearch.OpenSearchClientWrapper;
 import fi.vm.yti.common.opensearch.OpenSearchInitializer;
+import fi.vm.yti.common.opensearch.OpenSearchUtil;
 import fi.vm.yti.terminology.api.v2.opensearch.IndexTerminology;
-import org.opensearch.client.opensearch._types.mapping.*;
+import org.opensearch.client.opensearch._types.mapping.TypeMapping;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import java.util.List;
-import java.util.Map;
 
-import static fi.vm.yti.common.opensearch.OpenSearchUtil.*;
+import java.util.Map;
 
 @Service
 public class IndexService extends OpenSearchInitializer {
@@ -43,6 +42,14 @@ public class IndexService extends OpenSearchInitializer {
         client.putToIndex(TERMINOLOGY_INDEX, indexTerminology.getId(), indexTerminology);
     }
 
+    public void updateTerminologyToIndex(IndexTerminology indexTerminology) {
+        client.updateToIndex(TERMINOLOGY_INDEX, indexTerminology.getId(), indexTerminology);
+    }
+
+    public void deleteTerminologyFromIndex(String id) {
+        client.removeFromIndex(TERMINOLOGY_INDEX, id);
+    }
+
     private void initTerminologyIndex() {
         LOG.info("Init terminologies");
     }
@@ -53,31 +60,8 @@ public class IndexService extends OpenSearchInitializer {
 
     private TypeMapping getTerminologyMappings() {
         return new TypeMapping.Builder()
-                .dynamicTemplates(getTerminologyDynamicTemplates())
-                .properties(getTerminologyProperties())
+                .dynamicTemplates(OpenSearchUtil.getMetaDataDynamicTemplates())
+                .properties(OpenSearchUtil.getMetaDataProperties())
                 .build();
     }
-
-    private List<Map<String, DynamicTemplate>> getTerminologyDynamicTemplates() {
-        return List.of(
-                getDynamicTemplate("label", "label.*"),
-                getDynamicTemplate("description", "description.*")
-        );
-    }
-
-    private Map<String, Property> getTerminologyProperties() {
-        return Map.ofEntries(
-                Map.entry("id", getKeywordProperty()),
-                Map.entry("status", getKeywordProperty()),
-                Map.entry("type", getKeywordProperty()),
-                Map.entry("prefix", getKeywordProperty()),
-                Map.entry("contributor", getKeywordProperty()),
-                Map.entry("language", getKeywordProperty()),
-                Map.entry("uri", getKeywordProperty()),
-                Map.entry("created", getDateProperty()),
-                Map.entry("contentModified", getDateProperty())
-        );
-    }
-
-
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/service/TerminologyService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/service/TerminologyService.java
@@ -70,6 +70,7 @@ public class TerminologyService {
 
     public void update(String prefix, TerminologyDTO dto) {
         var model = terminologyRepository.fetchByPrefix(prefix);
+
         check(authorizationManager.hasRightsToTerminology(prefix, model));
 
         var user = authorizationManager.getUser();

--- a/src/main/java/fi/vm/yti/terminology/api/v2/service/TerminologyService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/service/TerminologyService.java
@@ -69,11 +69,11 @@ public class TerminologyService {
     }
 
     public void update(String prefix, TerminologyDTO dto) {
-        var model = terminologyRepository.fetchByPrefix(dto.getPrefix());
+        var model = terminologyRepository.fetchByPrefix(prefix);
         check(authorizationManager.hasRightsToTerminology(prefix, model));
 
         var user = authorizationManager.getUser();
-        var graphURI = TerminologyURI.createTerminologyURI(dto.getPrefix()).getGraphURI();
+        var graphURI = TerminologyURI.createTerminologyURI(prefix).getGraphURI();
         var categories = frontendService.getServiceCategories();
 
         TerminologyMapper.toUpdateModel(model, dto, categories, user);

--- a/src/main/java/fi/vm/yti/terminology/api/v2/service/TerminologyService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/service/TerminologyService.java
@@ -1,82 +1,102 @@
 package fi.vm.yti.terminology.api.v2.service;
 
-import fi.vm.yti.common.dto.*;
-import fi.vm.yti.common.service.AbstractGraphService;
+import fi.vm.yti.common.dto.ResourceCommonInfoDTO;
 import fi.vm.yti.common.service.AuditService;
-import fi.vm.yti.security.AuthenticatedUserProvider;
+import fi.vm.yti.common.service.FrontendService;
+import fi.vm.yti.common.service.GroupManagementService;
+import fi.vm.yti.terminology.api.v2.dto.TerminologyDTO;
+import fi.vm.yti.terminology.api.v2.dto.TerminologyInfoDTO;
 import fi.vm.yti.terminology.api.v2.mapper.TerminologyMapper;
 import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
 import fi.vm.yti.terminology.api.v2.security.TerminologyAuthorizationManager;
 import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
-import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.stereotype.Service;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.function.Consumer;
 
 import static fi.vm.yti.security.AuthorizationException.check;
 
 @Service
-public class TerminologyService extends AbstractGraphService<TerminologyRepository> {
+public class TerminologyService {
 
     private final TerminologyRepository terminologyRepository;
     private final TerminologyAuthorizationManager authorizationManager;
-    private final AuthenticatedUserProvider userProvider;
     private final IndexService indexService;
     private final AuditService auditService;
+    private final FrontendService frontendService;
+    private final GroupManagementService groupManagementService;
 
     public TerminologyService(TerminologyRepository terminologyRepository,
                               TerminologyAuthorizationManager authorizationManager,
-                              AuthenticatedUserProvider userProvider,
-                              IndexService indexService) {
-        super(terminologyRepository);
-
+                              IndexService indexService,
+                              FrontendService frontendService,
+                              GroupManagementService groupManagementService) {
         this.terminologyRepository = terminologyRepository;
         this.authorizationManager = authorizationManager;
         this.indexService = indexService;
-        this.userProvider = userProvider;
+        this.frontendService = frontendService;
+        this.groupManagementService = groupManagementService;
 
         this.auditService = new AuditService("TERMINOLOGY");
     }
 
-    @Override
-    public MetaDataInfoDTO get(String prefix) {
-        var graphURI = TerminologyURI.createTerminologyURI(prefix).getGraphURI();
-        var model = terminologyRepository.fetch(graphURI);
-        return TerminologyMapper.modelToDTO(model);
+    public TerminologyInfoDTO get(String prefix) {
+        var model = terminologyRepository.fetchByPrefix(prefix);
+        Consumer<ResourceCommonInfoDTO> mapUser = null;
+        if (authorizationManager.hasRightsToTerminology(prefix, model)) {
+            mapUser = groupManagementService.mapUser();
+        }
+        return TerminologyMapper.modelToDTO(model,
+                frontendService.getServiceCategories(),
+                frontendService.getOrganizations("en", true),
+                mapUser);
     }
 
-    @Override
-    public MetaDataInfoDTO get(String identifier, String version) {
-        throw new NotImplementedException("Version not supported");
-    }
-
-    @Override
-    public URI create(MetaDataDTO dto) throws URISyntaxException {
+    public URI create(TerminologyDTO dto) throws URISyntaxException {
         check(authorizationManager.hasRightToAnyOrganization(dto.getOrganizations()));
+        var user = authorizationManager.getUser();
+
+        var categories = frontendService.getServiceCategories();
         var graphURI = TerminologyURI.createTerminologyURI(dto.getPrefix()).getGraphURI();
-        var model = TerminologyMapper.dtoToModel(dto, graphURI);
+        var model = TerminologyMapper.dtoToModel(dto, graphURI, categories, user);
         terminologyRepository.put(graphURI, model);
 
-        indexService.addTerminologyToIndex(TerminologyMapper.toIndexDocument(model));
-        auditService.log(AuditService.ActionType.CREATE, graphURI, userProvider.getUser());
+        indexService.addTerminologyToIndex(TerminologyMapper.toIndexDocument(model, categories));
+        auditService.log(AuditService.ActionType.CREATE, graphURI, user);
         return new URI(graphURI);
     }
 
-    @Override
-    public void update(String prefix, MetaDataDTO dto) {
-        throw new NotImplementedException("Update terminology not implemented yet");
+    public void update(String prefix, TerminologyDTO dto) {
+        var model = terminologyRepository.fetchByPrefix(dto.getPrefix());
+        check(authorizationManager.hasRightsToTerminology(prefix, model));
+
+        var user = authorizationManager.getUser();
+        var graphURI = TerminologyURI.createTerminologyURI(dto.getPrefix()).getGraphURI();
+        var categories = frontendService.getServiceCategories();
+
+        TerminologyMapper.toUpdateModel(model, dto, categories, user);
+
+        terminologyRepository.put(graphURI, model);
+        indexService.updateTerminologyToIndex(TerminologyMapper.toIndexDocument(model, categories));
+        auditService.log(AuditService.ActionType.UPDATE, graphURI, user);
     }
 
-    @Override
-    public void delete(String identifier) {
-        check(authorizationManager.isSuperUser());
-        var graphURI = TerminologyURI.createTerminologyURI(identifier).getGraphURI();
+    public void delete(String prefix) {
+        var model = terminologyRepository.fetchByPrefix(prefix);
+        check(authorizationManager.hasRightsToTerminology(prefix, model));
+
+        var graphURI = TerminologyURI.createTerminologyURI(prefix).getGraphURI();
+
         terminologyRepository.delete(graphURI);
+
+        indexService.deleteTerminologyFromIndex(graphURI);
+        auditService.log(AuditService.ActionType.DELETE, graphURI, authorizationManager.getUser());
     }
 
-    @Override
-    public void delete(String identifier, String version) {
-        throw new NotImplementedException("Version not supported");
+    public boolean exists(String prefix) {
+        var graphURI = TerminologyURI.createTerminologyURI(prefix).getGraphURI();
+        return terminologyRepository.graphExists(graphURI);
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/validator/ConceptValidator.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/validator/ConceptValidator.java
@@ -1,0 +1,74 @@
+package fi.vm.yti.terminology.api.v2.validator;
+
+import fi.vm.yti.common.validator.BaseValidator;
+import fi.vm.yti.terminology.api.v2.dto.ConceptDTO;
+import fi.vm.yti.terminology.api.v2.dto.TermDTO;
+import fi.vm.yti.terminology.api.v2.enums.TermType;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.HashMap;
+import java.util.Set;
+
+public class ConceptValidator extends BaseValidator implements
+        ConstraintValidator<ValidConcept, ConceptDTO> {
+    @Override
+    public void initialize(ValidConcept constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(ConceptDTO value, ConstraintValidatorContext context) {
+        checkConceptData(context, value);
+
+        var handledLangs = new HashMap<String, String>();
+        value.getTerms().stream()
+                .filter(t -> t.getTermType().equals(TermType.RECOMMENDED))
+                .forEach(r -> {
+                    if (handledLangs.containsKey(r.getLanguage())) {
+                        addConstraintViolation(context, "too-many-recommended-terms", "terms");
+                    }
+                    handledLangs.put(r.getLanguage(), "");
+                });
+
+        if (handledLangs.isEmpty()) {
+            addConstraintViolation(context, "should-have-one-recommended-term", "terms");
+        }
+        checkTermData(context, value.getTerms());
+        return !isConstraintViolationAdded();
+    }
+
+    private void checkConceptData(ConstraintValidatorContext context, ConceptDTO dto) {
+        checkCommonTextArea(context, dto.getChangeNote(), "changeNote");
+        checkCommonTextArea(context, dto.getHistoryNote(), "historyNote");
+        dto.getDefinition().forEach((key, value) -> checkCommonTextArea(context, value, "definition"));
+        dto.getSubjectArea().forEach((key, value) -> checkCommonTextField(context, value, "subjectArea"));
+        dto.getExamples().forEach(e -> checkCommonTextArea(context, e.getValue(), "examples"));
+        dto.getNotes().forEach(e -> checkCommonTextArea(context, e.getValue(), "notes"));
+        dto.getEditorialNotes().forEach(e -> checkCommonTextArea(context, e, "editorialNotes"));
+        dto.getLinks().forEach(link -> {
+            checkRequiredLocalizedValue(context, link.getName(), "links.name");
+            checkNotNull(context, link.getUri(), "links.uri");
+            link.getDescription().forEach((description, value) -> checkCommonTextArea(context, value, "links.description"));
+        });
+        dto.getSources().forEach(s -> checkCommonTextArea(context, s, "sources"));
+        checkNotNull(context, dto.getStatus(), "status");
+        dto.getReferences().forEach(r -> {
+            checkNotNull(context, r.getConceptURI(), "references.conceptURI");
+            checkNotNull(context, r.getReferenceType(), "references.referenceType");
+        });
+    }
+
+    private void checkTermData(ConstraintValidatorContext context, Set<TermDTO> terms) {
+        terms.forEach(term -> {
+            checkCommonTextArea(context, term.getChangeNote(), "changeNote");
+            checkCommonTextArea(context, term.getHistoryNote(), "usageHistory");
+            checkCommonTextArea(context, term.getTermInfo(), "termInfo");
+            checkNotNull(context, term.getLabel(), "label");
+            checkCommonTextArea(context, term.getScope(), "scope");
+            checkNotNull(context, term.getLanguage(), "language");
+            checkNotNull(context, term.getStatus(), "status");
+            checkCommonTextField(context, term.getTermStyle(), "termStyle");
+        });
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/validator/ConceptValidator.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/validator/ConceptValidator.java
@@ -1,44 +1,59 @@
 package fi.vm.yti.terminology.api.v2.validator;
 
 import fi.vm.yti.common.validator.BaseValidator;
+import fi.vm.yti.common.validator.ValidationConstants;
 import fi.vm.yti.terminology.api.v2.dto.ConceptDTO;
 import fi.vm.yti.terminology.api.v2.dto.TermDTO;
 import fi.vm.yti.terminology.api.v2.enums.TermType;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
-import java.util.HashMap;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class ConceptValidator extends BaseValidator implements
         ConstraintValidator<ValidConcept, ConceptDTO> {
+
+    boolean update;
+
     @Override
     public void initialize(ValidConcept constraintAnnotation) {
-        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.update = constraintAnnotation.update();
     }
 
     @Override
     public boolean isValid(ConceptDTO value, ConstraintValidatorContext context) {
+        setConstraintViolationAdded(false);
         checkConceptData(context, value);
-
-        var handledLangs = new HashMap<String, String>();
-        value.getTerms().stream()
-                .filter(t -> t.getTermType().equals(TermType.RECOMMENDED))
-                .forEach(r -> {
-                    if (handledLangs.containsKey(r.getLanguage())) {
-                        addConstraintViolation(context, "too-many-recommended-terms", "terms");
-                    }
-                    handledLangs.put(r.getLanguage(), "");
-                });
-
-        if (handledLangs.isEmpty()) {
-            addConstraintViolation(context, "should-have-one-recommended-term", "terms");
-        }
+        checkRecommendedTerms(value.getTerms(), context);
         checkTermData(context, value.getTerms());
         return !isConstraintViolationAdded();
     }
 
+    private void checkRecommendedTerms(Set<TermDTO> terms, ConstraintValidatorContext context) {
+        var recommendedTerms = terms.stream()
+                .filter(t -> t.getTermType().equals(TermType.RECOMMENDED))
+                .toList();
+
+        if (recommendedTerms.isEmpty()) {
+            addConstraintViolation(context, "missing-recommended-term", "terms");
+        }
+
+        recommendedTerms.stream()
+                .collect(Collectors.groupingBy(TermDTO::getLanguage))
+                .forEach((key, value) -> {
+                    if (value.size() > 1) {
+                        addConstraintViolation(context, "too-many-recommended-terms-" + key, "terms");
+                    }
+                });
+    }
+
     private void checkConceptData(ConstraintValidatorContext context, ConceptDTO dto) {
+        if (update && dto.getIdentifier() != null) {
+            addConstraintViolation(context, ValidationConstants.MSG_NOT_ALLOWED_UPDATE, "identifier");
+        } else {
+            checkResourceIdentifier(context, dto.getIdentifier(), update);
+        }
         checkCommonTextArea(context, dto.getChangeNote(), "changeNote");
         checkCommonTextArea(context, dto.getHistoryNote(), "historyNote");
         dto.getDefinition().forEach((key, value) -> checkCommonTextArea(context, value, "definition"));
@@ -48,25 +63,31 @@ public class ConceptValidator extends BaseValidator implements
         dto.getEditorialNotes().forEach(e -> checkCommonTextArea(context, e, "editorialNotes"));
         dto.getLinks().forEach(link -> {
             checkRequiredLocalizedValue(context, link.getName(), "links.name");
-            checkNotNull(context, link.getUri(), "links.uri");
+            checkHasValue(context, link.getUri(), "links.uri");
             link.getDescription().forEach((description, value) -> checkCommonTextArea(context, value, "links.description"));
         });
+        checkCommonTextField(context, dto.getConceptClass(), "conceptClass");
         dto.getSources().forEach(s -> checkCommonTextArea(context, s, "sources"));
         checkNotNull(context, dto.getStatus(), "status");
         dto.getReferences().forEach(r -> {
-            checkNotNull(context, r.getConceptURI(), "references.conceptURI");
+            checkHasValue(context, r.getConceptURI(), "references.conceptURI");
             checkNotNull(context, r.getReferenceType(), "references.referenceType");
         });
     }
 
     private void checkTermData(ConstraintValidatorContext context, Set<TermDTO> terms) {
         terms.forEach(term -> {
+            if (!update && term.getIdentifier() != null) {
+                addConstraintViolation(context, ValidationConstants.MSG_NOT_ALLOWED_UPDATE, "identifier");
+            }
             checkCommonTextArea(context, term.getChangeNote(), "changeNote");
             checkCommonTextArea(context, term.getHistoryNote(), "usageHistory");
             checkCommonTextArea(context, term.getTermInfo(), "termInfo");
-            checkNotNull(context, term.getLabel(), "label");
+            checkHasValue(context, term.getLabel(), "label");
+            checkCommonTextField(context, term.getLabel(), "label");
             checkCommonTextArea(context, term.getScope(), "scope");
-            checkNotNull(context, term.getLanguage(), "language");
+            checkHasValue(context, term.getLanguage(), "language");
+            checkCommonTextField(context, term.getLanguage(), "language");
             checkNotNull(context, term.getStatus(), "status");
             checkCommonTextField(context, term.getTermStyle(), "termStyle");
         });

--- a/src/main/java/fi/vm/yti/terminology/api/v2/validator/TerminologyValidator.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/validator/TerminologyValidator.java
@@ -1,10 +1,10 @@
 package fi.vm.yti.terminology.api.v2.validator;
 
 import fi.vm.yti.common.Constants;
-import fi.vm.yti.common.dto.MetaDataDTO;
 import fi.vm.yti.common.enums.GraphType;
 import fi.vm.yti.common.validator.MetaDataValidator;
 import fi.vm.yti.common.validator.ValidationConstants;
+import fi.vm.yti.terminology.api.v2.dto.TerminologyDTO;
 import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
@@ -14,7 +14,7 @@ import java.util.Arrays;
 
 @Component
 public class TerminologyValidator extends MetaDataValidator<TerminologyRepository> implements
-        ConstraintValidator<ValidTerminology, MetaDataDTO> {
+        ConstraintValidator<ValidTerminology, TerminologyDTO> {
 
     boolean update;
 
@@ -28,7 +28,7 @@ public class TerminologyValidator extends MetaDataValidator<TerminologyRepositor
     }
 
     @Override
-    public boolean isValid(MetaDataDTO value, ConstraintValidatorContext context) {
+    public boolean isValid(TerminologyDTO value, ConstraintValidatorContext context) {
         setConstraintViolationAdded(false);
 
         checkModelPrefix(context, value, update);
@@ -44,8 +44,7 @@ public class TerminologyValidator extends MetaDataValidator<TerminologyRepositor
         return !isConstraintViolationAdded();
     }
 
-
-    private void checkGraphType(ConstraintValidatorContext context, MetaDataDTO value) {
+    private void checkGraphType(ConstraintValidatorContext context, TerminologyDTO value) {
         if (value.getGraphType() != null
             && !Arrays.asList(GraphType.TERMINOLOGICAL_VOCABULARY, GraphType.OTHER_VOCABULARY).contains(value.getGraphType())) {
                 addConstraintViolation(context, ValidationConstants.MSG_VALUE_INVALID, "graphType");

--- a/src/main/java/fi/vm/yti/terminology/api/v2/validator/ValidConcept.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/validator/ValidConcept.java
@@ -22,5 +22,7 @@ public @interface ValidConcept {
 
     Class<?>[] groups() default {};
 
+    boolean update() default false;
+
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/validator/ValidConcept.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/validator/ValidConcept.java
@@ -1,0 +1,26 @@
+package fi.vm.yti.terminology.api.v2.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({
+        ElementType.METHOD,
+        ElementType.FIELD,
+        ElementType.CONSTRUCTOR,
+        ElementType.PARAMETER,
+        ElementType.TYPE_USE
+})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ConceptValidator.class)
+public @interface ValidConcept {
+    String message() default "Invalid data";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/test/java/fi/vm/yti/terminology/api/v2/TestUtils.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/TestUtils.java
@@ -1,12 +1,18 @@
 package fi.vm.yti.terminology.api.v2;
 
-import fi.vm.yti.common.dto.OrganizationDTO;
-import fi.vm.yti.common.dto.ResourceCommonInfoDTO;
-import fi.vm.yti.common.dto.ServiceCategoryDTO;
-import fi.vm.yti.common.dto.UserDTO;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.vm.yti.common.dto.*;
+import fi.vm.yti.common.enums.Status;
 import fi.vm.yti.common.util.ModelWrapper;
 import fi.vm.yti.security.Role;
 import fi.vm.yti.security.YtiUser;
+import fi.vm.yti.terminology.api.v2.dto.ConceptDTO;
+import fi.vm.yti.terminology.api.v2.dto.ConceptReferenceDTO;
+import fi.vm.yti.terminology.api.v2.dto.LocalizedValueDTO;
+import fi.vm.yti.terminology.api.v2.dto.TermDTO;
+import fi.vm.yti.terminology.api.v2.enums.*;
+import fi.vm.yti.terminology.api.v2.mapper.ConceptMapper;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFLanguages;
@@ -67,4 +73,69 @@ public class TestUtils {
         dto.setCreator(creator);
         dto.setModifier(modifier);
     };
+
+    public static String asJsonString(Object obj) throws JsonProcessingException {
+        return new ObjectMapper().writeValueAsString(obj);
+    }
+
+    public static ConceptDTO getConceptData() {
+        var dto = new ConceptDTO();
+        dto.setConceptClass("conceptClass");
+        dto.setChangeNote("change");
+        dto.setDefinition(Map.of("en", "definition"));
+        dto.setStatus(Status.VALID);
+        dto.setExamples(List.of(new LocalizedValueDTO("en", "example")));
+        dto.setIdentifier("concept-1");
+        dto.setNotes(List.of(new LocalizedValueDTO("en", "note")));
+        dto.setEditorialNotes(List.of("editorial"));
+        dto.setHistoryNote("history");
+        dto.setSubjectArea(Map.of("en", "subject area"));
+        dto.setSources(List.of("source"));
+
+        var link = new LinkDTO();
+        link.setName(Map.of("en", "link"));
+        link.setDescription(Map.of("en", "link description"));
+        link.setUri("https://dvv.fi");
+        dto.setLinks(List.of(link));
+
+        var references = new ArrayList<ConceptReferenceDTO>();
+        ConceptMapper.internalRefProperties.forEach(prop -> {
+            var ref = new ConceptReferenceDTO();
+            ref.setConceptURI("https://iri.suomi.fi/terminology/test/concept-1000");
+            ref.setReferenceType(ReferenceType.getByPropertyName(prop.getLocalName()));
+            references.add(ref);
+        });
+
+        ConceptMapper.externalRefProperties.forEach(prop -> {
+            var ref = new ConceptReferenceDTO();
+            ref.setConceptURI("https://iri.suomi.fi/terminology/external/concept-123");
+            ref.setReferenceType(ReferenceType.getByPropertyName(prop.getLocalName()));
+            references.add(ref);
+        });
+
+        dto.setReferences(references);
+
+        dto.setTerms(Set.of(getTermDTO()));
+
+        return dto;
+    }
+
+    public static TermDTO getTermDTO() {
+        var term = new TermDTO();
+        term.setTermType(TermType.RECOMMENDED);
+        term.setHomographNumber(1);
+        term.setLabel("term label");
+        term.setChangeNote("change");
+        term.setHistoryNote("history");
+        term.setLanguage("en");
+        term.setStatus(Status.VALID);
+        term.setScope("scope");
+        term.setTermInfo("info");
+        term.setTermFamily(TermFamily.NEUTRAL);
+        term.setTermConjugation(TermConjugation.SINGULAR);
+        term.setWordClass(WordClass.VERB);
+        term.setTermStyle("style");
+        term.setTermEquivalency(TermEquivalency.BROADER);
+        return term;
+    }
 }

--- a/src/test/java/fi/vm/yti/terminology/api/v2/TestUtils.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/TestUtils.java
@@ -1,0 +1,70 @@
+package fi.vm.yti.terminology.api.v2;
+
+import fi.vm.yti.common.dto.OrganizationDTO;
+import fi.vm.yti.common.dto.ResourceCommonInfoDTO;
+import fi.vm.yti.common.dto.ServiceCategoryDTO;
+import fi.vm.yti.common.dto.UserDTO;
+import fi.vm.yti.common.util.ModelWrapper;
+import fi.vm.yti.security.Role;
+import fi.vm.yti.security.YtiUser;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFLanguages;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class TestUtils {
+
+    public static ModelWrapper getModelFromFile(String filepath, String graphURI) {
+        var model = ModelFactory.createDefaultModel();
+        var stream = TestUtils.class.getResourceAsStream(filepath);
+        assertNotNull(stream);
+        RDFDataMgr.read(model, stream, RDFLanguages.TURTLE);
+        return new ModelWrapper(model, graphURI);
+    }
+
+    public static final YtiUser mockUser = new YtiUser("test@localhost",
+            "test",
+            "tester",
+            UUID.randomUUID(),
+            false,
+            false,
+            LocalDateTime.of(2001, 1, 1, 0,0),
+            LocalDateTime.of(2001, 1, 1, 0,0),
+            new HashMap<>(Map.of(UUID.randomUUID(), Set.of(Role.TERMINOLOGY_EDITOR))),
+            "",
+            "");
+
+    public static final UUID organizationId = UUID.fromString("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63");
+
+    public static final List<ServiceCategoryDTO> categoryDTOs = List.of(
+            new ServiceCategoryDTO(
+                    "http://urn.fi/URN:NBN:fi:au:ptvl:v1096",
+                    Map.of("en", "Sample category P10"),
+                    "P10"
+            ),
+            new ServiceCategoryDTO(
+                    "http://urn.fi/URN:NBN:fi:au:ptvl:v1097",
+                    Map.of("en", "Sample category P11"),
+                    "P11"
+            ));
+
+    public static final List<OrganizationDTO> organizationDTOs = List.of(new OrganizationDTO(
+            organizationId.toString(),
+            Map.of("en", "Test organization"),
+            null)
+    );
+
+    public static Consumer<ResourceCommonInfoDTO> mapUser = (var dto) -> {
+        var creator = new UserDTO("123");
+        var modifier = new UserDTO("123");
+        creator.setName("creator fake-user");
+        modifier.setName("modifier fake-user");
+        dto.setCreator(creator);
+        dto.setModifier(modifier);
+    };
+}

--- a/src/test/java/fi/vm/yti/terminology/api/v2/endpoint/ConceptControllerTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/endpoint/ConceptControllerTest.java
@@ -1,0 +1,282 @@
+package fi.vm.yti.terminology.api.v2.endpoint;
+
+import fi.vm.yti.common.repository.CommonRepository;
+import fi.vm.yti.common.service.GroupManagementService;
+import fi.vm.yti.common.validator.ValidationConstants;
+import fi.vm.yti.terminology.api.v2.dto.ConceptDTO;
+import fi.vm.yti.terminology.api.v2.dto.ConceptInfoDTO;
+import fi.vm.yti.terminology.api.v2.dto.ConceptReferenceDTO;
+import fi.vm.yti.terminology.api.v2.dto.LocalizedValueDTO;
+import fi.vm.yti.terminology.api.v2.enums.ReferenceType;
+import fi.vm.yti.terminology.api.v2.exception.TerminologyExceptionHandlerAdvice;
+import fi.vm.yti.terminology.api.v2.service.ConceptService;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static fi.vm.yti.terminology.api.v2.TestUtils.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = ConceptController.class)
+@ActiveProfiles("test")
+class ConceptControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private CommonRepository commonRepository;
+
+    @MockBean
+    private GroupManagementService groupManagementService;
+
+    @MockBean
+    private ConceptService conceptService;
+
+    @Autowired
+    ConceptController conceptController;
+
+    @BeforeEach
+    public void setup() {
+        this.mvc = MockMvcBuilders
+                .standaloneSetup(this.conceptController)
+                .setControllerAdvice(new TerminologyExceptionHandlerAdvice())
+                .build();
+    }
+
+    @Test
+    void shouldValidateAndCreate() throws Exception {
+        var conceptDTO = getConceptData();
+
+        URI conceptURI = new URI("https://iri.suomi.fi/terminology/test/concept-1");
+        when(conceptService.create(eq("test"), any(ConceptDTO.class))).thenReturn(conceptURI);
+
+        this.mvc
+                .perform(post("/v2/concept/test")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(conceptDTO)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", conceptURI.toString()));
+
+        verify(conceptService).create(eq("test"), any(ConceptDTO.class));
+        verifyNoMoreInteractions(this.conceptService);
+    }
+
+    @Test
+    void shouldValidateAndUpdate() throws Exception {
+        var conceptDTO = getConceptData();
+        conceptDTO.setIdentifier(null);
+
+        this.mvc
+                .perform(put("/v2/concept/test/concept-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(conceptDTO)))
+                .andExpect(status().isNoContent());
+
+        verify(conceptService).update(eq("test"), eq("concept-1"), any(ConceptDTO.class));
+        verifyNoMoreInteractions(this.conceptService);
+    }
+
+    @Test
+    void shouldGetConcept() throws Exception {
+
+        when(conceptService.get("test", "concept-1")).thenReturn(new ConceptInfoDTO());
+
+        this.mvc
+                .perform(get("/v2/concept/test/concept-1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldDeleteConcept() throws Exception {
+        this.mvc
+                .perform(delete("/v2/concept/test/concept-1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+
+        verify(conceptService).delete("test", "concept-1");
+    }
+
+    @Test
+    void shouldCheckConceptExists() throws Exception {
+        this.mvc
+                .perform(get("/v2/concept/test/concept-1/exists")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        verify(conceptService).exists("test", "concept-1");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidConceptCreateData")
+    void shouldInvalidateConceptOnCreation(ConceptWithError data) throws Exception {
+
+        this.mvc
+                .perform(post("/v2/concept/test")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(data.dto)))
+                .andExpect(content().string(containsString(data.error())))
+                .andExpect(status().isBadRequest());
+
+        verifyNoMoreInteractions(this.conceptService);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidConceptUpdateData")
+    void shouldInvalidateConceptOnUpdate(ConceptWithError data) throws Exception {
+        this.mvc
+                .perform(put("/v2/concept/test/concept-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(data.dto)))
+                .andExpect(content().string(containsString(data.error())))
+                .andExpect(status().isBadRequest());
+
+        verifyNoMoreInteractions(this.conceptService);
+    }
+
+    public static ArrayList<ConceptWithError> provideInvalidConceptCreateData() {
+        var args = new ArrayList<ConceptWithError>();
+
+        var dto = getConceptData();
+        dto.setIdentifier(null);
+        args.add(new ConceptWithError("should-have-value", dto));
+
+        args.addAll(provideInvalidConceptData());
+
+        return args;
+    }
+
+    public static ArrayList<ConceptWithError> provideInvalidConceptUpdateData() {
+        var args = new ArrayList<ConceptWithError>();
+
+        var dto = getConceptData();
+        args.add(new ConceptWithError("not-allowed-update", dto));
+
+        provideInvalidConceptData().forEach(data -> {
+            data.dto.setIdentifier(null);
+            args.add(data);
+        });
+        return args;
+    }
+
+    public static ArrayList<ConceptWithError> provideInvalidConceptData() {
+        var args = new ArrayList<ConceptWithError>();
+
+        var longTextArea = RandomStringUtils.randomAlphabetic(ValidationConstants.TEXT_AREA_MAX_LENGTH + 1);
+        var longTextField = RandomStringUtils.randomAlphabetic(ValidationConstants.TEXT_FIELD_MAX_LENGTH + 1);
+
+        // check concept data
+        var dto = getConceptData();
+        dto.setNotes(List.of(new LocalizedValueDTO("en", longTextArea)));
+        args.add(new ConceptWithError("value-over-character-limit", dto));
+
+        dto = getConceptData();
+        dto.setExamples(List.of(new LocalizedValueDTO("en", longTextArea)));
+        args.add(new ConceptWithError("value-over-character-limit", dto));
+
+        dto = getConceptData();
+        dto.setSources(List.of(longTextArea));
+        args.add(new ConceptWithError("value-over-character-limit", dto));
+
+        dto = getConceptData();
+        dto.setEditorialNotes(List.of(longTextArea));
+        args.add(new ConceptWithError("value-over-character-limit", dto));
+
+        dto = getConceptData();
+        dto.setHistoryNote(longTextArea);
+        args.add(new ConceptWithError("value-over-character-limit", dto));
+
+        dto = getConceptData();
+        dto.setChangeNote(longTextArea);
+        args.add(new ConceptWithError("value-over-character-limit", dto));
+
+        dto = getConceptData();
+        dto.setConceptClass(longTextField);
+        args.add(new ConceptWithError("value-over-character-limit", dto));
+
+        dto = getConceptData();
+        dto.setSubjectArea(Map.of("en", longTextField));
+        args.add(new ConceptWithError("value-over-character-limit", dto));
+
+        dto = getConceptData();
+        var ref = new ConceptReferenceDTO();
+        ref.setReferenceType(ReferenceType.BROADER);
+        dto.setReferences(List.of(ref));
+        args.add(new ConceptWithError("should-have-value", dto));
+
+        // check term data
+
+        dto = getConceptData();
+        var term = getTermDTO();
+        term.setLanguage("");
+        dto.setTerms(Set.of(term));
+        args.add(new ConceptWithError("should-have-value", dto));
+
+        dto = getConceptData();
+        term = getTermDTO();
+        term.setLabel(longTextField);
+        dto.setTerms(Set.of(term));
+        args.add(new ConceptWithError("value-over-character-limit", dto));
+
+        dto = getConceptData();
+        term = getTermDTO();
+        term.setLabel("");
+        dto.setTerms(Set.of(term));
+        args.add(new ConceptWithError("should-have-value", dto));
+
+        dto = getConceptData();
+        term = getTermDTO();
+        term.setTermStyle(longTextField);
+        dto.setTerms(Set.of(term));
+        args.add(new ConceptWithError("value-over-character-limit", dto));
+
+        dto = getConceptData();
+        term = getTermDTO();
+        term.setScope(longTextArea);
+        dto.setTerms(Set.of(term));
+        args.add(new ConceptWithError("value-over-character-limit", dto));
+
+        dto = getConceptData();
+        term = getTermDTO();
+        term.setTermInfo(longTextArea);
+        dto.setTerms(Set.of(term));
+        args.add(new ConceptWithError("value-over-character-limit", dto));
+
+        dto = getConceptData();
+        term = getTermDTO();
+        term.setHistoryNote(longTextArea);
+        dto.setTerms(Set.of(term));
+        args.add(new ConceptWithError("value-over-character-limit", dto));
+
+        dto = getConceptData();
+        term = getTermDTO();
+        term.setChangeNote(longTextArea);
+        dto.setTerms(Set.of(term));
+        args.add(new ConceptWithError("value-over-character-limit", dto));
+
+        return args;
+    }
+
+    record ConceptWithError(String error, ConceptDTO dto) {}
+}

--- a/src/test/java/fi/vm/yti/terminology/api/v2/endpoint/DataWithError.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/endpoint/DataWithError.java
@@ -1,6 +1,0 @@
-package fi.vm.yti.terminology.api.v2.endpoint;
-
-import fi.vm.yti.common.dto.MetaDataDTO;
-
-public record DataWithError(String errorMessage, MetaDataDTO data) {
-}

--- a/src/test/java/fi/vm/yti/terminology/api/v2/endpoint/TerminologyControllerTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/endpoint/TerminologyControllerTest.java
@@ -2,6 +2,7 @@ package fi.vm.yti.terminology.api.v2.endpoint;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.vm.yti.common.dto.MetaDataDTO;
 import fi.vm.yti.common.dto.OrganizationDTO;
 import fi.vm.yti.common.dto.ServiceCategoryDTO;
 import fi.vm.yti.common.enums.GraphType;
@@ -135,20 +136,6 @@ class TerminologyControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(asJsonString(data.data())))
                 .andExpect(content().string(containsString(data.errorMessage())))
-                .andExpect(status().isBadRequest());
-
-        verifyNoMoreInteractions(this.terminologyService);
-    }
-
-    @Test
-    void shouldInvalidateOnUpdateNotExists() throws Exception {
-        var dto = getValidTerminologyMetadata();
-        dto.setPrefix(null);
-        this.mvc
-                .perform(put("/v2/terminology/test-not-exists")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(asJsonString(dto)))
-                .andExpect(content().string(containsString("graph-not-found")))
                 .andExpect(status().isBadRequest());
 
         verifyNoMoreInteractions(this.terminologyService);
@@ -309,4 +296,5 @@ class TerminologyControllerTest {
         return terminologyDTO;
     }
 
+    record DataWithError(String errorMessage, MetaDataDTO data) {}
 }

--- a/src/test/java/fi/vm/yti/terminology/api/v2/endpoint/TerminologyControllerTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/endpoint/TerminologyControllerTest.java
@@ -141,6 +141,20 @@ class TerminologyControllerTest {
     }
 
     @Test
+    void shouldInvalidateOnUpdateNotExists() throws Exception {
+        var dto = getValidTerminologyMetadata();
+        dto.setPrefix(null);
+        this.mvc
+                .perform(put("/v2/terminology/test-not-exists")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(dto)))
+                .andExpect(content().string(containsString("graph-not-found")))
+                .andExpect(status().isBadRequest());
+
+        verifyNoMoreInteractions(this.terminologyService);
+    }
+
+    @Test
     void shouldGetTerminologyData() throws Exception {
         var dto = new TerminologyInfoDTO();
         dto.setPrefix("test");
@@ -180,6 +194,7 @@ class TerminologyControllerTest {
 
     private static Stream<Arguments> provideInvalidEditData() {
         var args = provideInvalidData();
+        args.forEach(a -> a.data().setPrefix(null));
 
         var dto = getValidTerminologyMetadata();
 

--- a/src/test/java/fi/vm/yti/terminology/api/v2/endpoint/TerminologyControllerTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/endpoint/TerminologyControllerTest.java
@@ -2,8 +2,6 @@ package fi.vm.yti.terminology.api.v2.endpoint;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import fi.vm.yti.common.dto.MetaDataDTO;
-import fi.vm.yti.common.dto.MetaDataInfoDTO;
 import fi.vm.yti.common.dto.OrganizationDTO;
 import fi.vm.yti.common.dto.ServiceCategoryDTO;
 import fi.vm.yti.common.enums.GraphType;
@@ -13,6 +11,8 @@ import fi.vm.yti.common.repository.CommonRepository;
 import fi.vm.yti.common.service.FrontendService;
 import fi.vm.yti.common.service.GroupManagementService;
 import fi.vm.yti.common.validator.ValidationConstants;
+import fi.vm.yti.terminology.api.v2.dto.TerminologyDTO;
+import fi.vm.yti.terminology.api.v2.dto.TerminologyInfoDTO;
 import fi.vm.yti.terminology.api.v2.exception.TerminologyExceptionHandlerAdvice;
 import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
 import fi.vm.yti.terminology.api.v2.service.TerminologyService;
@@ -95,7 +95,7 @@ class TerminologyControllerTest {
                         .content(asJsonString(terminologyDTO)))
                 .andExpect(status().isCreated());
 
-        verify(terminologyService).create(any(MetaDataDTO.class));
+        verify(terminologyService).create(any(TerminologyDTO.class));
         verifyNoMoreInteractions(this.terminologyService);
     }
 
@@ -110,7 +110,7 @@ class TerminologyControllerTest {
                         .content(asJsonString(terminologyDTO)))
                 .andExpect(status().isNoContent());
 
-        verify(terminologyService).update(eq("test"), any(MetaDataDTO.class));
+        verify(terminologyService).update(eq("test"), any(TerminologyDTO.class));
         verifyNoMoreInteractions(this.terminologyService);
     }
 
@@ -142,7 +142,7 @@ class TerminologyControllerTest {
 
     @Test
     void shouldGetTerminologyData() throws Exception {
-        var dto = new MetaDataInfoDTO();
+        var dto = new TerminologyInfoDTO();
         dto.setPrefix("test");
         dto.setLabel(Map.of("en", "Test terminology"));
 
@@ -279,8 +279,8 @@ class TerminologyControllerTest {
         return args;
     }
 
-    private static MetaDataDTO getValidTerminologyMetadata() {
-        var terminologyDTO = new MetaDataDTO();
+    private static TerminologyDTO getValidTerminologyMetadata() {
+        var terminologyDTO = new TerminologyDTO();
 
         terminologyDTO.setOrganizations(Set.of(ORGANIZATION_ID));
         terminologyDTO.setGraphType(GraphType.TERMINOLOGICAL_VOCABULARY);

--- a/src/test/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapperTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapperTest.java
@@ -1,0 +1,300 @@
+package fi.vm.yti.terminology.api.v2.mapper;
+
+import fi.vm.yti.common.dto.LinkDTO;
+import fi.vm.yti.common.enums.Status;
+import fi.vm.yti.common.util.MapperUtils;
+import fi.vm.yti.terminology.api.v2.TestUtils;
+import fi.vm.yti.terminology.api.v2.dto.ConceptDTO;
+import fi.vm.yti.terminology.api.v2.dto.ConceptReferenceDTO;
+import fi.vm.yti.terminology.api.v2.dto.LocalizedValueDTO;
+import fi.vm.yti.terminology.api.v2.dto.TermDTO;
+import fi.vm.yti.terminology.api.v2.enums.*;
+import fi.vm.yti.terminology.api.v2.property.Term;
+import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.sparql.vocabulary.FOAF;
+import org.apache.jena.vocabulary.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static fi.vm.yti.terminology.api.v2.TestUtils.getConceptData;
+import static fi.vm.yti.terminology.api.v2.TestUtils.mockUser;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConceptMapperTest {
+    @Test
+    void testMapConceptToModel() {
+        var graphURI = TerminologyURI.createTerminologyURI("test").getGraphURI();
+        var model = TestUtils.getModelFromFile("/terminology-metadata.ttl", graphURI);
+
+        var concept = getConceptData();
+
+        ConceptMapper.dtoToModel(model, concept, mockUser);
+
+        var conceptResource = model.getResourceById(concept.getIdentifier());
+
+        assertEquals(graphURI + concept.getIdentifier(), conceptResource.getURI());
+        assertEquals(concept.getConceptClass(), conceptResource.getProperty(Term.conceptClass).getString());
+        assertEquals(concept.getDefinition(), Map.of("en", "definition"));
+        assertEquals(concept.getChangeNote(), conceptResource.getProperty(SKOS.changeNote).getString());
+        assertEquals(concept.getHistoryNote(), conceptResource.getProperty(SKOS.historyNote).getString());
+
+        assertEquals(concept.getEditorialNotes(), getList(conceptResource, SKOS.editorialNote));
+        assertEquals(concept.getSources(), getList(conceptResource, Term.source));
+
+        assertEquals(concept.getStatus(), MapperUtils.getStatus(conceptResource));
+        assertEquals(concept.getSubjectArea(), Map.of("en", "subject area"));
+
+        var examples = getLocalizedList(conceptResource, SKOS.example);
+        assertEquals(concept.getExamples().size(), examples.size());
+        assertEquals(concept.getExamples().get(0), examples.get(0));
+
+        var notes = getLocalizedList(conceptResource, SKOS.note);
+        assertEquals(concept.getNotes().size(), notes.size());
+        assertEquals(concept.getNotes().get(0), notes.get(0));
+
+        var link = conceptResource.getProperty(RDFS.seeAlso).getObject().asResource();
+        var expectedLink = concept.getLinks().get(0);
+        assertEquals(expectedLink.getName(), MapperUtils.localizedPropertyToMap(link, DCTerms.title));
+        assertEquals(expectedLink.getDescription(), MapperUtils.localizedPropertyToMap(link, DCTerms.description));
+        assertEquals(expectedLink.getUri(), link.getProperty(FOAF.homepage).getString());
+
+        ConceptMapper.internalRefProperties.forEach(prop -> assertEquals(graphURI + "concept-1000",
+                conceptResource.getProperty(prop).getObject().toString()));
+
+        ConceptMapper.externalRefProperties.forEach(prop ->
+                assertEquals("https://iri.suomi.fi/terminology/external/concept-123",
+                        conceptResource.getProperty(prop).getObject().toString()));
+    }
+
+    @Test
+    void testMapTermToModel() {
+        var graphURI = TerminologyURI.createTerminologyURI("test").getGraphURI();
+        var model = TestUtils.getModelFromFile("/terminology-metadata.ttl", graphURI);
+
+        var concept = getConceptData();
+
+        ConceptMapper.dtoToModel(model, concept, mockUser);
+
+        var conceptResource = model.getResourceById(concept.getIdentifier());
+
+        var term = concept.getTerms().iterator().next();
+        var termResource = conceptResource.getProperty(SKOS.prefLabel).getResource();
+
+        assertEquals(SKOSXL.Label, termResource.getProperty(RDF.type).getObject().asResource());
+
+        var label = termResource.getProperty(SKOSXL.literalForm);
+        assertEquals(term.getLabel(), label.getString());
+        assertEquals(term.getLanguage(), label.getLanguage());
+
+        assertEquals(term.getHomographNumber(), MapperUtils.getLiteral(termResource, Term.homographNumber, Integer.class));
+        assertEquals(term.getChangeNote(), MapperUtils.propertyToString(termResource, SKOS.changeNote));
+        assertEquals(term.getHistoryNote(), MapperUtils.propertyToString(termResource, SKOS.historyNote));
+        assertEquals(term.getScope(), MapperUtils.propertyToString(termResource, Term.scope));
+        assertEquals(term.getTermInfo(), MapperUtils.propertyToString(termResource, Term.termInfo));
+        assertEquals(term.getTermStyle(), MapperUtils.propertyToString(termResource, Term.termStyle));
+        assertEquals(term.getStatus(), MapperUtils.getStatus(termResource));
+
+        assertEquals(term.getTermConjugation(), TermConjugation.valueOf(MapperUtils.propertyToString(termResource, Term.termConjugation)));
+        assertEquals(term.getTermEquivalency(), TermEquivalency.valueOf(MapperUtils.propertyToString(termResource, Term.termEquivalency)));
+        assertEquals(term.getTermFamily(), TermFamily.valueOf(MapperUtils.propertyToString(termResource, Term.termFamily)));
+        assertEquals(term.getWordClass(), WordClass.valueOf(MapperUtils.propertyToString(termResource, Term.wordClass)));
+    }
+
+    @Test
+    void testMapUpdateConcept() {
+        var graphURI = TerminologyURI.createTerminologyURI("test").getGraphURI();
+        var model = TestUtils.getModelFromFile("/terminology-with-concepts.ttl", graphURI);
+
+        var dto = new ConceptDTO();
+        dto.setStatus(Status.VALID);
+        dto.setDefinition(Map.of("fi", "New definition"));
+        dto.setNotes(List.of(
+                new LocalizedValueDTO("fi", "note fi"),
+                new LocalizedValueDTO("en", "note en")
+        ));
+        dto.setExamples(List.of());
+        dto.setConceptClass("new class");
+        dto.setChangeNote("new change");
+        dto.setHistoryNote("new history");
+
+        var link = new LinkDTO();
+        link.setName(Map.of("fi", "link 2"));
+        link.setUri("https://dvv.fi/updated");
+        dto.setLinks(List.of(link));
+
+        var prefLabel = new TermDTO();
+        prefLabel.setTermType(TermType.RECOMMENDED);
+        prefLabel.setIdentifier("term-614007ae-5d84-45d8-b473-6359c3cbc5ca");
+        prefLabel.setLabel("pref term label");
+        prefLabel.setTermFamily(TermFamily.FEMININE);
+
+        var altLabel = new TermDTO();
+        altLabel.setTermType(TermType.SYNONYM);
+        altLabel.setIdentifier("term-f04ce627-c799-4e9a-9b0c-71b65f69130b");
+        altLabel.setStatus(Status.VALID);
+        altLabel.setLabel("modified alt label");
+
+        var searchTerm = new TermDTO();
+        searchTerm.setTermType(TermType.SEARCH_TERM);
+        searchTerm.setStatus(Status.DRAFT);
+        searchTerm.setLanguage("en");
+        searchTerm.setLabel("new search term");
+
+        dto.setTerms(Set.of(prefLabel, altLabel, searchTerm));
+
+        var ref1 = new ConceptReferenceDTO();
+        ref1.setReferenceType(ReferenceType.RELATED);
+        ref1.setConceptURI("https://iri.suomi.fi/terminology/test/concept-1000");
+
+        var ref2 = new ConceptReferenceDTO();
+        ref2.setReferenceType(ReferenceType.BROAD_MATCH);
+        ref2.setConceptURI("https://iri.suomi.fi/terminology/external/concept-300");
+
+        dto.setReferences(List.of(ref1, ref2));
+
+        ConceptMapper.dtoToUpdateModel(model, "concept-1", dto, mockUser);
+
+        var updatedResource = model.getResourceById("concept-1");
+
+        assertEquals(Status.VALID, MapperUtils.getStatus(updatedResource));
+        assertEquals(Map.of("fi", "New definition"), MapperUtils.localizedPropertyToMap(updatedResource, SKOS.definition));
+        assertFalse(updatedResource.hasProperty(Term.subjectArea));
+        assertEquals("new history", MapperUtils.propertyToString(updatedResource, SKOS.historyNote));
+        assertEquals("new change", MapperUtils.propertyToString(updatedResource, SKOS.changeNote));
+        assertEquals("new class", MapperUtils.propertyToString(updatedResource, Term.conceptClass));
+
+        var linkResource = updatedResource.getProperty(RDFS.seeAlso).getResource();
+        assertEquals(Map.of("fi", "link 2"), MapperUtils.localizedPropertyToMap(linkResource, DCTerms.title));
+        assertEquals("https://dvv.fi/updated", MapperUtils.propertyToString(linkResource, FOAF.homepage));
+
+        var prefLabels = updatedResource.listProperties(SKOS.prefLabel).toList();
+        assertEquals(1, prefLabels.size());
+        checkLabel("pref term label", "fi", prefLabels.get(0));
+
+        var altLabels = updatedResource.listProperties(SKOS.altLabel).toList();
+        assertEquals(1, altLabels.size());
+        checkLabel("modified alt label", "fi", altLabels.get(0));
+
+        var hiddenLabels = updatedResource.listProperties(SKOS.hiddenLabel).toList();
+        checkLabel("new search term", "en", hiddenLabels.get(0));
+
+        // Other alt label, search term and not recommended synonym should not exists in the model
+        assertFalse(model.getResourceById("term-ce6c2547-261f-46e1-9cba-662f886df7f6;").listProperties().hasNext());
+        assertFalse(model.getResourceById("term-47d79614-d8f5-4c42-8967-a860c3451f5b").listProperties().hasNext());
+        assertFalse(model.getResourceById("term-45f21a97-4bae-42ee-b7c5-c1d871ee9c2a").listProperties().hasNext());
+
+        var related = updatedResource.listProperties(SKOS.related).toList();
+        var broadMatch = updatedResource.listProperties(SKOS.broadMatch).toList();
+
+        assertEquals(1, related.size());
+        assertEquals(1, broadMatch.size());
+
+        assertEquals(0, updatedResource.listProperties(SKOS.broader).toList().size());
+        assertEquals("https://iri.suomi.fi/terminology/test/concept-1000", related.get(0).getObject().toString());
+        assertEquals("https://iri.suomi.fi/terminology/external/concept-300", broadMatch.get(0).getObject().toString());
+    }
+
+    @Test
+    void testMapConceptToDTO() {
+        var graphURI = TerminologyURI.createTerminologyURI("test").getGraphURI();
+        var model = TestUtils.getModelFromFile("/terminology-with-concepts.ttl", graphURI);
+
+        var dto = ConceptMapper.modelToDTO(model, "concept-1", TestUtils.mapUser);
+
+        assertEquals("concept-1", dto.getIdentifier());
+        assertEquals("change", dto.getChangeNote());
+        assertEquals("history", dto.getHistoryNote());
+        assertEquals(Status.DRAFT, dto.getStatus());
+        assertEquals("subject area", dto.getSubjectArea().get("fi"));
+        assertEquals("concept class", dto.getConceptClass());
+        assertEquals(graphURI + "concept-1", dto.getUri());
+        assertEquals(Map.of("fi", "def"), dto.getDefinition());
+        assertEquals(new LocalizedValueDTO("fi", "note"), dto.getNotes().get(0));
+        assertEquals(new LocalizedValueDTO("fi", "example"), dto.getExamples().get(0));
+
+        var link = dto.getLinks().get(0);
+        assertEquals("link 1", link.getName().get("fi"));
+        assertEquals("description", link.getDescription().get("fi"));
+        assertEquals("https://dvv.fi", link.getUri());
+
+        var ref = dto.getReferences().iterator().next();
+        assertEquals(graphURI + "concept-2", ref.getConceptURI());
+        assertEquals(ReferenceType.BROADER, ref.getReferenceType());
+        assertEquals("Suositettava termi", ref.getLabel().get("fi"));
+    }
+
+    @Test
+    void testMapTermToDTO() {
+        var graphURI = TerminologyURI.createTerminologyURI("test").getGraphURI();
+        var model = TestUtils.getModelFromFile("/terminology-with-concepts.ttl", graphURI);
+
+        var dto = ConceptMapper.modelToDTO(model, "concept-1", TestUtils.mapUser);
+
+        assertEquals(4, dto.getTerms().size());
+
+        var termOpt = dto.getTerms().stream()
+                .filter(t -> t.getIdentifier().equals("term-614007ae-5d84-45d8-b473-6359c3cbc5ca"))
+                .findFirst();
+        assertTrue(termOpt.isPresent());
+
+        var term = termOpt.get();
+
+        assertEquals("Suositettava termi", term.getLabel());
+        assertEquals("info", term.getTermInfo());
+        assertEquals("term style", term.getTermStyle());
+        assertEquals("term change", term.getChangeNote());
+        assertEquals("term history", term.getHistoryNote());
+        assertEquals("fi", term.getLanguage());
+        assertEquals("scope", term.getScope());
+        assertEquals(2, term.getHomographNumber());
+        assertEquals(Status.DRAFT, term.getStatus());
+        assertEquals(TermConjugation.SINGULAR, term.getTermConjugation());
+        assertEquals(TermFamily.NEUTRAL, term.getTermFamily());
+        assertEquals(WordClass.ADJECTIVE, term.getWordClass());
+        assertEquals(TermEquivalency.BROADER, term.getTermEquivalency());
+    }
+
+    @Test
+    void mapToIndexDocument() {
+        var conceptURI = TerminologyURI.createConceptURI("test", "concept-1");
+        var model = TestUtils.getModelFromFile("/terminology-with-concepts.ttl", conceptURI.getGraphURI());
+
+        var dto = ConceptMapper.toIndexDocument(model, "concept-1");
+
+        assertEquals(conceptURI.getResourceURI(), dto.getUri());
+        assertEquals(conceptURI.getResourceURI(), dto.getId());
+        assertEquals(Status.DRAFT, dto.getStatus());
+        assertEquals("Suositettava termi", dto.getLabel().get("fi"));
+        assertEquals("def", dto.getDefinition().get("fi"));
+        assertEquals(List.of("synonyymi 2", "synonyymi 1"), dto.getAltLabel().get("fi"));
+        assertEquals(List.of("ei suositettava"), dto.getNotRecommendedSynonym().get("fi"));
+        assertEquals(List.of("hakutermi"), dto.getSearchTerm().get("fi"));
+        assertEquals("2024-05-06T05:00:00.000Z", dto.getCreated());
+        assertEquals("2024-05-07T04:00:00.000Z", dto.getModified());
+    }
+
+    private static List<String> getList(Resource conceptResource, Property property) {
+        return conceptResource.getProperty(property).getList()
+                .asJavaList().stream()
+                .map(r -> r.asLiteral().getString())
+                .toList();
+    }
+
+    private static List<LocalizedValueDTO> getLocalizedList(Resource conceptResource, Property property) {
+        return conceptResource.getProperty(property).getList()
+                .asJavaList().stream()
+                .map(r -> new LocalizedValueDTO(r.asLiteral().getLanguage(), r.asLiteral().getString()))
+                .toList();
+    }
+
+    private static void checkLabel(String expectedValue, String expectedLanguage, Statement stmt) {
+        assertEquals(expectedValue, stmt.getProperty(SKOSXL.literalForm).getString());
+        assertEquals(expectedLanguage, stmt.getProperty(SKOSXL.literalForm).getLanguage());
+    }
+}

--- a/src/test/java/fi/vm/yti/terminology/api/v2/mapper/TerminologyMapperTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/mapper/TerminologyMapperTest.java
@@ -1,0 +1,171 @@
+package fi.vm.yti.terminology.api.v2.mapper;
+
+import fi.vm.yti.common.Constants;
+import fi.vm.yti.common.enums.GraphType;
+import fi.vm.yti.common.enums.Status;
+import fi.vm.yti.common.properties.SuomiMeta;
+import fi.vm.yti.common.util.MapperUtils;
+import fi.vm.yti.terminology.api.v2.TestUtils;
+import fi.vm.yti.terminology.api.v2.dto.TerminologyDTO;
+import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
+import org.apache.jena.vocabulary.DCTerms;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
+import org.apache.jena.vocabulary.SKOS;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TerminologyMapperTest {
+
+    private static final String groupId_P10 = "http://urn.fi/URN:NBN:fi:au:ptvl:v1096";
+    private static final String groupId_P11 = "http://urn.fi/URN:NBN:fi:au:ptvl:v1097";
+
+    @Test
+    void mapDtoToModel() {
+        var dto = new TerminologyDTO();
+        var uri = TerminologyURI.createTerminologyURI("test");
+        dto.setPrefix(uri.getPrefix());
+        dto.setGraphType(GraphType.TERMINOLOGICAL_VOCABULARY);
+        dto.setLabel(Map.of("en", "Test terminology"));
+        dto.setDescription(Map.of("en", "Test terminology description"));
+        dto.setOrganizations(Set.of(TestUtils.organizationId));
+        dto.setGroups(Set.of("P10"));
+        dto.setContact("yhteentoimivuus@dvv.fi");
+        dto.setLanguages(Set.of("en", "fi"));
+
+        var model = TerminologyMapper.dtoToModel(dto, uri.getGraphURI(), TestUtils.categoryDTOs, TestUtils.mockUser);
+
+        var resource = model.getModelResource();
+
+        var group = resource.getProperty(DCTerms.isPartOf).getObject();
+        var organization = resource.getProperty(DCTerms.contributor).getObject();
+
+        assertEquals("test", model.getPrefix());
+        assertEquals(SKOS.ConceptScheme, resource.getProperty(RDF.type).getObject());
+        assertEquals("Test terminology", MapperUtils.localizedPropertyToMap(resource, SKOS.prefLabel).get("en"));
+        assertEquals("Test terminology description", MapperUtils.localizedPropertyToMap(resource, RDFS.comment).get("en"));
+        assertTrue(group.isResource());
+        assertTrue(organization.isResource());
+        assertEquals(Constants.URN_UUID + TestUtils.organizationId, organization.toString());
+        assertEquals(groupId_P10, group.toString());
+        assertEquals("yhteentoimivuus@dvv.fi", MapperUtils.propertyToString(resource, SuomiMeta.contact));
+        assertTrue(MapperUtils.arrayPropertyToSet(resource, DCTerms.language).containsAll(List.of("en", "fi")));
+    }
+
+    @Test
+    void mapDtoToUpdateModel() {
+        var graphURI = TerminologyURI.createTerminologyURI("test").getGraphURI();
+        var model = TestUtils.getModelFromFile("/terminology-metadata.ttl", graphURI);
+        var newOrganization = UUID.randomUUID();
+        var modifiedOrig = getDate(MapperUtils.propertyToString(model.getModelResource(), DCTerms.modified));
+
+        var dto = new TerminologyDTO();
+        dto.setGraphType(GraphType.OTHER_VOCABULARY);
+        dto.setLabel(Map.of("en", "Test terminology modified"));
+        dto.setDescription(Map.of("en", "Test terminology description modified"));
+        dto.setOrganizations(Set.of(newOrganization));
+        dto.setGroups(Set.of("P10", "P11"));
+        dto.setContact("new_email@dvv.fi");
+        dto.setLanguages(Set.of("en"));
+
+        var user = TestUtils.mockUser;
+
+        TerminologyMapper.toUpdateModel(model, dto, TestUtils.categoryDTOs, user);
+
+        var resource = model.getModelResource();
+
+        var organization = resource.listProperties(DCTerms.contributor).toList();
+        var group = resource.listProperties(DCTerms.isPartOf).toList();
+
+        assertEquals("test", model.getPrefix());
+        assertEquals(SKOS.ConceptScheme, resource.getProperty(RDF.type).getObject());
+        assertEquals("Test terminology modified", MapperUtils.localizedPropertyToMap(resource, SKOS.prefLabel).get("en"));
+        assertEquals("Test terminology description modified", MapperUtils.localizedPropertyToMap(resource, RDFS.comment).get("en"));
+        assertEquals("new_email@dvv.fi", MapperUtils.propertyToString(resource, SuomiMeta.contact));
+
+        assertEquals(1, organization.size());
+        organization.forEach(o -> assertTrue(o.getObject().isResource()));
+        var newOrganizations = organization.stream()
+                .filter(o -> o.getObject().toString().equals(Constants.URN_UUID + newOrganization))
+                .findFirst();
+        assertTrue(newOrganizations.isPresent());
+
+        assertEquals(2, group.size());
+        group.forEach(g -> assertTrue(g.getObject().isResource()));
+        var newGroups = group.stream().map(g -> g.getObject().toString()).toList();
+        assertTrue(newGroups.containsAll(List.of(groupId_P10, groupId_P11)));
+
+        var languages = MapperUtils.arrayPropertyToSet(resource, DCTerms.language);
+        assertEquals(1, languages.size());
+        assertTrue(languages.contains("en"));
+
+        assertEquals(user.getId().toString(), MapperUtils.propertyToString(resource, SuomiMeta.modifier));
+        var modified = getDate(MapperUtils.propertyToString(resource, DCTerms.modified));
+
+        assertTrue(modified.isAfter(modifiedOrig));
+    }
+
+    @Test
+    void mapModelToDto() {
+        var graphURI = TerminologyURI.createTerminologyURI("test").getGraphURI();
+        var model = TestUtils.getModelFromFile("/terminology-metadata.ttl", graphURI);
+
+        var userMapper = TestUtils.mapUser;
+
+        var dto = TerminologyMapper.modelToDTO(model, TestUtils.categoryDTOs, TestUtils.organizationDTOs, userMapper);
+
+        assertEquals("test", dto.getPrefix());
+        assertEquals(graphURI, dto.getUri());
+        assertEquals(GraphType.TERMINOLOGICAL_VOCABULARY, dto.getModelType());
+        assertEquals(Status.DRAFT, dto.getStatus());
+        assertEquals("Label fi", dto.getLabel().get("fi"));
+        assertEquals("Label en", dto.getLabel().get("en"));
+        assertEquals("Description fi", dto.getDescription().get("fi"));
+        assertEquals("Description en", dto.getDescription().get("en"));
+        assertTrue(dto.getLanguages().containsAll(Set.of("fi", "en")));
+        assertEquals("2024-04-26T11:45:00.000Z", dto.getCreated());
+        assertEquals("2024-04-26T11:46:00.000Z", dto.getModified());
+        assertEquals("modifier fake-user", dto.getModifier().getName());
+        assertEquals("creator fake-user", dto.getCreator().getName());
+        assertEquals("yhteentoimivuus@dvv.fi", dto.getContact());
+
+        var group = dto.getGroups().iterator().next();
+        var organization = dto.getOrganizations().iterator().next();
+
+        assertEquals("Sample category P10", group.getLabel().get("en"));
+        assertEquals("P10", group.getIdentifier());
+        assertEquals("Test organization", organization.getLabel().get("en"));
+        assertEquals(TestUtils.organizationId.toString(), organization.getId());
+    }
+
+    @Test
+    void mapIndexDto() {
+        var graphURI = TerminologyURI.createTerminologyURI("test").getGraphURI();
+        var model = TestUtils.getModelFromFile("/terminology-metadata.ttl", graphURI);
+
+        var indexDTO = TerminologyMapper.toIndexDocument(model, TestUtils.categoryDTOs);
+
+        assertEquals("Label fi", indexDTO.getLabel().get("fi"));
+        assertEquals("Description fi", indexDTO.getDescription().get("fi"));
+        assertEquals(graphURI, indexDTO.getId());
+        assertEquals("test", indexDTO.getPrefix());
+        assertEquals(graphURI, indexDTO.getUri());
+        assertEquals(Status.DRAFT, indexDTO.getStatus());
+        assertTrue(indexDTO.getGroups().contains("P10"));
+        assertTrue(indexDTO.getLanguages().containsAll(Set.of("fi", "en")));
+        assertTrue(indexDTO.getOrganizations().contains(TestUtils.organizationId));
+    }
+
+    private static LocalDateTime getDate(String date) {
+        // strip milliseconds from date string
+        return LocalDateTime.parse(date.split("\\.")[0]);
+    }
+}

--- a/src/test/java/fi/vm/yti/terminology/api/v2/mapper/TerminologyMapperTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/mapper/TerminologyMapperTest.java
@@ -75,6 +75,7 @@ class TerminologyMapperTest {
         dto.setGroups(Set.of("P10", "P11"));
         dto.setContact("new_email@dvv.fi");
         dto.setLanguages(Set.of("en"));
+        dto.setStatus(Status.VALID);
 
         var user = TestUtils.mockUser;
 
@@ -90,6 +91,7 @@ class TerminologyMapperTest {
         assertEquals("Test terminology modified", MapperUtils.localizedPropertyToMap(resource, SKOS.prefLabel).get("en"));
         assertEquals("Test terminology description modified", MapperUtils.localizedPropertyToMap(resource, RDFS.comment).get("en"));
         assertEquals("new_email@dvv.fi", MapperUtils.propertyToString(resource, SuomiMeta.contact));
+        assertEquals(Status.VALID, MapperUtils.getStatus(resource));
 
         assertEquals(1, organization.size());
         organization.forEach(o -> assertTrue(o.getObject().isResource()));

--- a/src/test/java/fi/vm/yti/terminology/api/v2/service/ConceptServiceTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/service/ConceptServiceTest.java
@@ -1,0 +1,258 @@
+package fi.vm.yti.terminology.api.v2.service;
+
+import fi.vm.yti.common.enums.Status;
+import fi.vm.yti.common.exception.ResourceExistsException;
+import fi.vm.yti.common.exception.ResourceNotFoundException;
+import fi.vm.yti.common.properties.SuomiMeta;
+import fi.vm.yti.common.service.GroupManagementService;
+import fi.vm.yti.common.util.MapperUtils;
+import fi.vm.yti.common.util.ModelWrapper;
+import fi.vm.yti.security.AuthorizationException;
+import fi.vm.yti.terminology.api.v2.TestUtils;
+import fi.vm.yti.terminology.api.v2.dto.ConceptDTO;
+import fi.vm.yti.terminology.api.v2.opensearch.IndexConcept;
+import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
+import fi.vm.yti.terminology.api.v2.security.TerminologyAuthorizationManager;
+import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.net.URISyntaxException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@Import({
+        ConceptService.class,
+})
+class ConceptServiceTest {
+
+    @MockBean
+    TerminologyRepository repository;
+
+    @MockBean
+    TerminologyAuthorizationManager authorizationManager;
+
+    @MockBean
+    IndexService indexService;
+
+    @MockBean
+    GroupManagementService groupManagementService;
+
+    @Captor
+    ArgumentCaptor<Model> modelCaptor;
+
+    @Captor
+    ArgumentCaptor<IndexConcept> indexCaptor;
+
+    @Autowired
+    ConceptService conceptService;
+
+    @BeforeEach
+    void setUp() {
+        when(authorizationManager.getUser()).thenReturn(TestUtils.mockUser);
+        when(authorizationManager.hasRightsToTerminology(eq("test"), any(ModelWrapper.class))).thenReturn(true);
+    }
+
+    @Test
+    void testGetConcept() {
+        var conceptURI = TerminologyURI.createConceptURI("test", "concept-1");
+        var model = TestUtils.getModelFromFile("/terminology-with-concepts.ttl", conceptURI.getGraphURI());
+
+        when(authorizationManager.hasRightsToTerminology(eq(conceptURI.getPrefix()), any(Model.class))).thenReturn(true);
+        when(repository.fetchByPrefix(conceptURI.getPrefix())).thenReturn(model);
+        when(groupManagementService.mapUser()).thenReturn(TestUtils.mapUser);
+
+        var dto = conceptService.get(conceptURI.getPrefix(), conceptURI.getResourceId());
+
+        // only authenticated user should see this information
+        assertFalse(dto.getEditorialNotes().isEmpty());
+        assertNotNull(dto.getCreator().getName());
+        assertNotNull(dto.getModifier().getName());
+    }
+
+    @Test
+    void testGetConceptNotAuthenticated() {
+        var conceptURI = TerminologyURI.createConceptURI("test", "concept-1");
+        var model = TestUtils.getModelFromFile("/terminology-with-concepts.ttl", conceptURI.getGraphURI());
+
+        when(authorizationManager.hasRightsToTerminology(eq(conceptURI.getPrefix()), any(Model.class))).thenReturn(false);
+        when(repository.fetchByPrefix(conceptURI.getPrefix())).thenReturn(model);
+        when(groupManagementService.mapUser()).thenReturn(TestUtils.mapUser);
+
+        var dto = conceptService.get(conceptURI.getPrefix(), conceptURI.getResourceId());
+
+        // only authenticated user should see this information
+        assertTrue(dto.getEditorialNotes().isEmpty());
+        assertNull(dto.getCreator().getName());
+        assertNull(dto.getModifier().getName());
+    }
+
+    @Test
+    void testGetConceptNotFound() {
+        var conceptURI = TerminologyURI.createConceptURI("test", "concept-1");
+        var model = TestUtils.getModelFromFile("/terminology-with-concepts.ttl", conceptURI.getGraphURI());
+        when(repository.fetchByPrefix(conceptURI.getPrefix())).thenReturn(model);
+
+        assertThrows(ResourceNotFoundException.class, () -> conceptService.get("test", "foo"));
+    }
+
+    @Test
+    void testCreateConcept() throws URISyntaxException {
+        var conceptURI = TerminologyURI.createConceptURI("test", "concept-1");
+        var model = new ModelWrapper(ModelFactory.createDefaultModel(), conceptURI.getGraphURI());
+
+        when(repository.fetchByPrefix(conceptURI.getPrefix())).thenReturn(model);
+        when(repository.resourceExistsInGraph(conceptURI.getGraphURI(), conceptURI.getResourceURI())).thenReturn(false);
+
+        var dto = new ConceptDTO();
+        dto.setIdentifier(conceptURI.getResourceId());
+        dto.setStatus(Status.DRAFT);
+
+        conceptService.create(conceptURI.getPrefix(), dto);
+
+        verify(repository).put(eq(conceptURI.getGraphURI()), modelCaptor.capture());
+        verify(indexService).addConceptToIndex(indexCaptor.capture());
+
+        var updatedModel = modelCaptor.getValue();
+
+        assertTrue(updatedModel.getResource(conceptURI.getResourceURI()).listProperties().hasNext());
+        assertEquals(conceptURI.getResourceURI(), indexCaptor.getValue().getId());
+    }
+
+    @Test
+    void testCreateConceptExists() {
+        var conceptURI = TerminologyURI.createConceptURI("test", "concept-1");
+        var model = new ModelWrapper(ModelFactory.createDefaultModel(), conceptURI.getGraphURI());
+
+        when(repository.fetchByPrefix(conceptURI.getPrefix())).thenReturn(model);
+        when(repository.resourceExistsInGraph(conceptURI.getGraphURI(), conceptURI.getResourceURI())).thenReturn(true);
+
+        var dto = new ConceptDTO();
+        dto.setIdentifier(conceptURI.getResourceId());
+
+        assertThrows(ResourceExistsException.class, () -> conceptService.create("test", dto));
+
+        verify(repository, times(0)).put(eq("test"), any(Model.class));
+        verifyNoMoreInteractions(indexService);
+    }
+
+    @Test
+    void testCreateConceptGraphNotExists() {
+        var prefix = "test123";
+        var conceptURI = TerminologyURI.createConceptURI(prefix, "concept-1");
+
+        when(repository.fetchByPrefix(prefix)).thenThrow(ResourceNotFoundException.class);
+        when(repository.resourceExistsInGraph(conceptURI.getGraphURI(), conceptURI.getResourceURI())).thenReturn(false);
+
+        var dto = new ConceptDTO();
+        dto.setIdentifier(conceptURI.getResourceId());
+
+        assertThrows(ResourceNotFoundException.class, () -> conceptService.create(prefix, dto));
+
+        verify(repository, times(0)).put(eq(prefix), any(Model.class));
+        verifyNoMoreInteractions(indexService);
+    }
+
+    @Test
+    void testCreateConceptNotAuthorized() {
+        when(authorizationManager.hasRightsToTerminology(eq("test"), any(Model.class))).thenReturn(false);
+
+        var dto = new ConceptDTO();
+        dto.setIdentifier("concept-1");
+
+        assertThrows(AuthorizationException.class, () -> conceptService.create("test", dto));
+
+        verify(repository, times(0)).put(eq("test"), any(Model.class));
+    }
+
+    @Test
+    void testUpdateConcept() {
+        var conceptURI = TerminologyURI.createConceptURI("test", "concept-1");
+        var model = new ModelWrapper(ModelFactory.createDefaultModel(), conceptURI.getGraphURI());
+
+        model.createResourceWithId(conceptURI.getResourceId())
+                        .addProperty(SuomiMeta.publicationStatus, MapperUtils.getStatusUri(Status.DRAFT));
+
+        when(repository.fetchByPrefix(conceptURI.getPrefix())).thenReturn(model);
+        when(repository.resourceExistsInGraph(conceptURI.getGraphURI(), conceptURI.getResourceURI())).thenReturn(true);
+
+        var dto = new ConceptDTO();
+        dto.setIdentifier(conceptURI.getResourceId());
+        dto.setStatus(Status.VALID);
+
+        conceptService.update(conceptURI.getPrefix(), conceptURI.getResourceId(), dto);
+
+        verify(repository).put(eq(conceptURI.getGraphURI()), modelCaptor.capture());
+        verify(indexService).updateConceptToIndex(indexCaptor.capture());
+
+        var updatedResource = modelCaptor.getValue().getResource(conceptURI.getResourceURI());
+
+        assertEquals(Status.VALID, MapperUtils.getStatus(updatedResource));
+        assertEquals(conceptURI.getResourceURI(), indexCaptor.getValue().getId());
+    }
+
+    @Test
+    void testUpdateConceptNotExists() {
+        var prefix = "test";
+        var conceptURI = TerminologyURI.createConceptURI(prefix, "concept-1");
+        var model = new ModelWrapper(ModelFactory.createDefaultModel(), conceptURI.getGraphURI());
+
+        when(repository.fetchByPrefix(conceptURI.getPrefix())).thenReturn(model);
+        when(repository.resourceExistsInGraph(conceptURI.getGraphURI(), conceptURI.getResourceURI())).thenReturn(false);
+
+        var dto = new ConceptDTO();
+        dto.setIdentifier(conceptURI.getResourceId());
+
+        assertThrows(ResourceNotFoundException.class, () -> conceptService.update(prefix, "concept-1", dto));
+
+        verify(repository, times(0)).put(eq(prefix), any(Model.class));
+        verifyNoMoreInteractions(indexService);
+    }
+
+    @Test
+    void testUpdateConceptNotAuthorized() {
+        when(authorizationManager.hasRightsToTerminology(eq("test"), any(Model.class))).thenReturn(false);
+
+        var dto = new ConceptDTO();
+        dto.setIdentifier("concept-1");
+
+        assertThrows(AuthorizationException.class, () -> conceptService.update("test", "concept-1", dto));
+        verify(repository, times(0)).put(eq("test"), any(Model.class));
+    }
+
+    @Test
+    void testDeleteConcept() {
+        var conceptURI = TerminologyURI.createConceptURI("test", "concept-2");
+        var model = TestUtils.getModelFromFile("/terminology-with-concepts.ttl", conceptURI.getGraphURI());
+
+        when(repository.fetchByPrefix(conceptURI.getPrefix())).thenReturn(model);
+        when(repository.resourceExistsInGraph(conceptURI.getGraphURI(), conceptURI.getResourceURI())).thenReturn(true);
+
+        conceptService.delete("test", "concept-2");
+
+        // resource concept-2 should not exists and it should not exists as an object either
+        assertFalse(model.listStatements(null, null, ResourceFactory.createResource(conceptURI.getResourceURI())).hasNext());
+        assertFalse(model.contains(ResourceFactory.createResource(conceptURI.getResourceURI()), null));
+        assertFalse(model.contains(ResourceFactory.createResource(conceptURI.getGraphURI() + "term-4429d6a0-1aba-4964-a2c0-972a13409b2f"), null));
+    }
+
+    @Test
+    void testDeleteConceptNotAuthorized() {
+        when(authorizationManager.hasRightsToTerminology(eq("test"), any(Model.class))).thenReturn(false);
+        assertThrows(AuthorizationException.class, () -> conceptService.delete("test", "concept-1"));
+
+        verify(repository, times(0)).put(eq("test"), any(Model.class));
+    }
+}

--- a/src/test/java/fi/vm/yti/terminology/api/v2/service/TerminologyServiceTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/service/TerminologyServiceTest.java
@@ -1,0 +1,195 @@
+package fi.vm.yti.terminology.api.v2.service;
+
+import fi.vm.yti.common.enums.GraphType;
+import fi.vm.yti.common.enums.Status;
+import fi.vm.yti.common.service.FrontendService;
+import fi.vm.yti.common.service.GroupManagementService;
+import fi.vm.yti.common.util.MapperUtils;
+import fi.vm.yti.security.AuthorizationException;
+import fi.vm.yti.terminology.api.v2.TestUtils;
+import fi.vm.yti.terminology.api.v2.dto.TerminologyDTO;
+import fi.vm.yti.terminology.api.v2.opensearch.IndexTerminology;
+import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
+import fi.vm.yti.terminology.api.v2.security.TerminologyAuthorizationManager;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.vocabulary.DCTerms;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@Import({
+        TerminologyService.class,
+})
+class TerminologyServiceTest {
+
+    @MockBean
+    private TerminologyRepository terminologyRepository;
+
+    @MockBean
+    private TerminologyAuthorizationManager authorizationManager;
+
+    @MockBean
+    private IndexService indexService;
+
+    @MockBean
+    private FrontendService frontendService;
+
+    @MockBean
+    private GroupManagementService groupManagementService;
+    
+    @Autowired
+    TerminologyService terminologyService;
+
+    @Captor
+    ArgumentCaptor<Model> modelCaptor;
+
+    @Captor
+    ArgumentCaptor<IndexTerminology> indexCaptor;
+
+    private static final String GRAPH_URI = "https://iri.suomi.fi/terminology/test/";
+
+    private static final String PREFIX = "test";
+
+    @BeforeEach
+    void setUp() {
+        when(frontendService.getServiceCategories()).thenReturn(TestUtils.categoryDTOs);
+        when(frontendService.getOrganizations(anyString(), anyBoolean())).thenReturn(TestUtils.organizationDTOs);
+        when(authorizationManager.getUser()).thenReturn(TestUtils.mockUser);
+        when(authorizationManager.hasRightToAnyOrganization(argThat(a -> a.contains(TestUtils.organizationId))))
+                .thenReturn(true);
+        when(authorizationManager.hasRightsToTerminology(eq(PREFIX), any(Model.class))).thenReturn(true);
+        when(groupManagementService.mapUser()).thenReturn(TestUtils.mapUser);
+
+        var model = TestUtils.getModelFromFile("/terminology-metadata.ttl", GRAPH_URI);
+        when(terminologyRepository.fetchByPrefix(PREFIX)).thenReturn(model);
+    }
+
+    @Test
+    void testGetData() {
+        var dto = terminologyService.get(PREFIX);
+
+        assertNotNull(dto.getCreator().getName());
+        assertNotNull(dto.getModifier().getName());
+
+        var cat = dto.getGroups().iterator().next();
+        var org = dto.getOrganizations().iterator().next();
+
+        assertEquals("P10", cat.getIdentifier());
+        assertEquals("Sample category P10", cat.getLabel().get("en"));
+        assertEquals("Test organization", org.getLabel().get("en"));
+        assertEquals(TestUtils.organizationId.toString(), org.getId());
+    }
+
+    @Test
+    void testGetDataUnauthorized() {
+        when(authorizationManager.hasRightsToTerminology(eq(PREFIX), any(Model.class))).thenReturn(false);
+        var dto = terminologyService.get(PREFIX);
+
+        assertNull(dto.getCreator().getName());
+        assertNull(dto.getModifier().getName());
+    }
+
+    @Test
+    void testCreate() throws URISyntaxException {
+        terminologyService.create(getValidTerminologyMetadata());
+
+        verify(terminologyRepository).put(eq(GRAPH_URI), modelCaptor.capture());
+        verify(indexService).addTerminologyToIndex(indexCaptor.capture());
+
+        var modelValueResource = modelCaptor.getValue().getResource(GRAPH_URI);
+        var indexValue = indexCaptor.getValue();
+
+        assertTrue(modelValueResource.listProperties().hasNext());
+        assertEquals("http://urn.fi/URN:NBN:fi:au:ptvl:v1096",
+                MapperUtils.propertyToString(modelValueResource, DCTerms.isPartOf));
+        assertEquals(GRAPH_URI, indexValue.getId());
+    }
+
+    @Test
+    void testCreateAuthorization() {
+        var dto = getValidTerminologyMetadata();
+        dto.setOrganizations(Set.of(UUID.randomUUID()));
+
+        assertThrows(AuthorizationException.class, () -> terminologyService.create(dto));
+
+        verifyNoMoreInteractions(terminologyRepository);
+        verifyNoMoreInteractions(indexService);
+    }
+
+    @Test
+    void testUpdate() {
+        var dto = getValidTerminologyMetadata();
+
+        terminologyService.update(PREFIX, dto);
+
+        verify(terminologyRepository).put(eq(GRAPH_URI), modelCaptor.capture());
+        verify(indexService).updateTerminologyToIndex(indexCaptor.capture());
+
+        var modelValue = modelCaptor.getValue();
+        var indexValue = indexCaptor.getValue();
+
+        assertTrue(modelValue.getResource(GRAPH_URI).listProperties().hasNext());
+        assertEquals(GRAPH_URI, indexValue.getId());
+    }
+
+    @Test
+    void testUpdateAuthorization() {
+        var dto = getValidTerminologyMetadata();
+
+        when(authorizationManager.hasRightsToTerminology(eq(PREFIX), any(Model.class))).thenReturn(false);
+
+        assertThrows(AuthorizationException.class, () -> terminologyService.update(PREFIX, dto));
+
+        verify(terminologyRepository, times(0)).put(anyString(), any(Model.class));
+        verifyNoMoreInteractions(indexService);
+    }
+
+    @Test
+    void testDelete() {
+        terminologyService.delete(PREFIX);
+
+        verify(terminologyRepository).delete(GRAPH_URI);
+        verify(indexService).deleteTerminologyFromIndex(GRAPH_URI);
+    }
+
+    @Test
+    void testDeleteAuthorization() {
+        when(authorizationManager.hasRightsToTerminology(eq(PREFIX), any(Model.class))).thenReturn(false);
+
+        assertThrows(AuthorizationException.class, () -> terminologyService.delete(PREFIX));
+
+        verify(terminologyRepository, times(0)).put(eq(GRAPH_URI), any(Model.class));
+        verifyNoMoreInteractions(indexService);
+    }
+
+    private static TerminologyDTO getValidTerminologyMetadata() {
+        var terminologyDTO = new TerminologyDTO();
+
+        terminologyDTO.setOrganizations(Set.of(TestUtils.organizationId));
+        terminologyDTO.setGraphType(GraphType.TERMINOLOGICAL_VOCABULARY);
+        terminologyDTO.setContact("Contact");
+        terminologyDTO.setGroups(Set.of("P10"));
+        terminologyDTO.setLabel(Map.of("en", "Test terminology"));
+        terminologyDTO.setDescription(Map.of("en", "Test description"));
+        terminologyDTO.setLanguages(Set.of("en"));
+        terminologyDTO.setPrefix(PREFIX);
+        terminologyDTO.setStatus(Status.VALID);
+
+        return terminologyDTO;
+    }
+}

--- a/src/test/resources/terminology-metadata.ttl
+++ b/src/test/resources/terminology-metadata.ttl
@@ -1,0 +1,28 @@
+@prefix dcap:       <http://purl.org/ws-mmi-dc/terms/> .
+@prefix dcterms:    <http://purl.org/dc/terms/> .
+@prefix owl:        <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:       <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh:         <http://www.w3.org/ns/shacl#> .
+@prefix skos:       <http://www.w3.org/2004/02/skos/core#> .
+@prefix suomi-meta: <https://iri.suomi.fi/model/suomi-meta/> .
+@prefix xsd:        <http://www.w3.org/2001/XMLSchema#> .
+@prefix term:       <https://iri.suomi.fi/model/term/> .
+
+<https://iri.suomi.fi/terminology/test/>
+        rdf:type                      skos:ConceptScheme;
+        rdfs:comment                  "Description en"@en , "Description fi"@fi;
+        dcterms:contributor           <urn:uuid:7d3a3c00-5a6b-489b-a3ed-63bb58c26a63>;
+        dcterms:created               "2024-04-26T11:45:00.000Z"^^xsd:dateTime;
+        dcterms:isPartOf              <http://urn.fi/URN:NBN:fi:au:ptvl:v1096>;
+        dcterms:language              "en" , "fi";
+        dcterms:modified              "2024-04-26T11:46:00.000Z"^^xsd:dateTime;
+        dcap:preferredXMLNamespace    "https://iri.suomi.fi/terminology/test/";
+        dcap:preferredXMLNamespacePrefix
+                "test";
+        skos:prefLabel                "Label fi"@fi , "Label en"@en;
+        suomi-meta:contact            "yhteentoimivuus@dvv.fi";
+        suomi-meta:creator            "23006bf4-4c09-4438-8224-785fdf108812";
+        suomi-meta:modifier           "23006bf4-4c09-4438-8224-785fdf108812";
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT";
+        term:terminologyType          "TERMINOLOGICAL_VOCABULARY" .

--- a/src/test/resources/terminology-with-concepts.ttl
+++ b/src/test/resources/terminology-with-concepts.ttl
@@ -1,0 +1,100 @@
+@prefix dcap:       <http://purl.org/ws-mmi-dc/terms/> .
+@prefix dcterms:    <http://purl.org/dc/terms/> .
+@prefix foaf:       <http://xmlns.com/foaf/0.1/> .
+@prefix owl:        <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:       <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh:         <http://www.w3.org/ns/shacl#> .
+@prefix skos:       <http://www.w3.org/2004/02/skos/core#> .
+@prefix skos-xl:    <http://www.w3.org/2008/05/skos-xl#> .
+@prefix suomi-meta: <https://iri.suomi.fi/model/suomi-meta/> .
+@prefix term:       <https://iri.suomi.fi/model/term/> .
+@prefix test:       <https://iri.suomi.fi/terminology/test/> .
+@prefix xsd:        <http://www.w3.org/2001/XMLSchema#> .
+
+# Terminology metadata
+
+test:   rdf:type                      skos:ConceptScheme;
+        dcterms:contributor           <urn:uuid:8d610719-105a-48fd-a4ce-ebef26bc5776>;
+        dcterms:isPartOf              <http://urn.fi/URN:NBN:fi:au:ptvl:v1105>;
+        dcterms:language              "en" , "fi";
+        dcap:preferredXMLNamespace    "https://iri.suomi.fi/terminology/test/";
+        dcap:preferredXMLNamespacePrefix
+                "test";
+        skos:prefLabel                "Sanaston nimi modified"@fi , "Test mod"@en;
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID";
+        term:terminologyType          "TERMINOLOGICAL_VOCABULARY" .
+
+# Concept 1 with terms
+
+test:concept-1  rdfs:seeAlso          [ dcterms:description  "description"@fi;
+                                        dcterms:title        "link 1"@fi;
+                                        foaf:homepage        "https://dvv.fi"
+                                      ];
+        dcterms:created               "2024-05-06T05:00:00.000Z"^^xsd:dateTime;
+        dcterms:modified              "2024-05-07T04:00:00.000Z"^^xsd:dateTime;
+        skos:altLabel                 test:term-f04ce627-c799-4e9a-9b0c-71b65f69130b , test:term-ce6c2547-261f-46e1-9cba-662f886df7f6;
+        skos:broader                  test:concept-2;
+        skos:changeNote               "change";
+        skos:definition               "def"@fi;
+        skos:editorialNote            ( "editorial" );
+        skos:example                  ( "example"@fi );
+        skos:hiddenLabel              test:term-45f21a97-4bae-42ee-b7c5-c1d871ee9c2a;
+        skos:historyNote              "history";
+        skos:inScheme                 test:;
+        skos:note                     ( "note"@fi );
+        skos:prefLabel                test:term-614007ae-5d84-45d8-b473-6359c3cbc5ca;
+        suomi-meta:creator            "23006bf4-4c09-4438-8224-785fdf108812";
+        suomi-meta:modifier           "23006bf4-4c09-4438-8224-785fdf108812";
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT";
+        term:conceptClass             "concept class";
+        term:notRecommendedSynonym    test:term-47d79614-d8f5-4c42-8967-a860c3451f5b;
+        term:source                   ( "source" );
+        term:subjectArea              "subject area"@fi .
+
+test:term-614007ae-5d84-45d8-b473-6359c3cbc5ca
+         rdf:type                      skos-xl:Label;
+         skos:changeNote               "term change";
+         skos:historyNote              "term history";
+         skos-xl:literalForm           "Suositettava termi"@fi;
+         suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT";
+         term:homographNumber          2;
+         term:scope                    "scope";
+         term:termConjugation          "SINGULAR";
+         term:termEquivalency          "BROADER";
+         term:termFamily               "NEUTRAL";
+         term:termInfo                 "info";
+         term:termStyle                "term style";
+         term:wordClass                "ADJECTIVE" .
+
+test:term-f04ce627-c799-4e9a-9b0c-71b65f69130b
+        rdf:type                      skos-xl:Label;
+        skos-xl:literalForm           "synonyymi 1"@fi;
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT" .
+
+test:term-ce6c2547-261f-46e1-9cba-662f886df7f6
+        rdf:type                      skos-xl:Label;
+        skos-xl:literalForm           "synonyymi 2"@fi;
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT" .
+
+test:term-47d79614-d8f5-4c42-8967-a860c3451f5b
+        rdf:type                      skos-xl:Label;
+        skos-xl:literalForm           "ei suositettava"@fi;
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT" .
+
+test:term-45f21a97-4bae-42ee-b7c5-c1d871ee9c2a
+        rdf:type                      skos-xl:Label;
+        skos-xl:literalForm           "hakutermi"@fi;
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT" .
+
+# Concept 2 with term
+
+test:concept-2
+        skos:inScheme                 test:;
+        skos:prefLabel                test:term-4429d6a0-1aba-4964-a2c0-972a13409b2f;
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT" .
+
+test:term-4429d6a0-1aba-4964-a2c0-972a13409b2f
+        rdf:type                      skos-xl:Label;
+        skos-xl:literalForm           "Suositettava termi"@fi;
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT" .


### PR DESCRIPTION
- Controller and service layer for concepts
- Concept validation
- Use ModelWrapper from common backend in repository to simplify handling Jena model's resources
- Init OpenSearch indexes on start up and move some functionalities to common library