### PR TITLE
YTI-4055 migration

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/v2/config/SpringAsyncConfig.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/config/SpringAsyncConfig.java
@@ -1,0 +1,23 @@
+package fi.vm.yti.terminology.api.v2.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class SpringAsyncConfig implements AsyncConfigurer {
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+        taskExecutor.setCorePoolSize(15);
+        taskExecutor.setMaxPoolSize(50);
+        taskExecutor.setQueueCapacity(100);
+        taskExecutor.initialize();
+        return new DelegatingSecurityContextAsyncTaskExecutor(taskExecutor);
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/TermDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/TermDTO.java
@@ -4,6 +4,7 @@ import fi.vm.yti.common.enums.Status;
 import fi.vm.yti.terminology.api.v2.enums.*;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import java.util.List;
 import java.util.Objects;
 
 public class TermDTO {
@@ -22,6 +23,8 @@ public class TermDTO {
     private TermConjugation termConjugation;
     private TermEquivalency termEquivalency;
     private WordClass wordClass;
+    private List<String> sources = List.of();
+    private List<String> editorialNotes = List.of();
 
     public String getIdentifier() {
         return identifier;
@@ -141,6 +144,22 @@ public class TermDTO {
 
     public void setTermEquivalency(TermEquivalency termEquivalency) {
         this.termEquivalency = termEquivalency;
+    }
+
+    public List<String> getSources() {
+        return sources;
+    }
+
+    public void setSources(List<String> sources) {
+        this.sources = sources;
+    }
+
+    public List<String> getEditorialNotes() {
+        return editorialNotes;
+    }
+
+    public void setEditorialNotes(List<String> editorialNotes) {
+        this.editorialNotes = editorialNotes;
     }
 
     @Override

--- a/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptCollectionMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptCollectionMapper.java
@@ -130,7 +130,7 @@ public class ConceptCollectionMapper {
             return;
         }
         var list = resource.getModel().createList(values.stream()
-                .map(ResourceFactory::createStringLiteral)
+                .map(ResourceFactory::createResource)
                 .iterator());
         resource.addProperty(property, list);
     }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/Termed.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/Termed.java
@@ -1,0 +1,36 @@
+package fi.vm.yti.terminology.api.v2.migration.v1;
+
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.ResourceFactory;
+
+public class Termed {
+
+    private Termed () {}
+
+    public static final Property status = ResourceFactory.createProperty("http://www.w3.org/2003/06/sw-vocab-status/ns#term_status");
+    public static final Property uri = ResourceFactory.createProperty("http://purl.org/termed/properties/uri");
+    public static final Property lastModifiedDate = ResourceFactory.createProperty("http://purl.org/termed/properties/lastModifiedDate");
+    public static final Property createdDate = ResourceFactory.createProperty("http://purl.org/termed/properties/createdDate");
+    public static final Property lastModifiedBy = ResourceFactory.createProperty("http://purl.org/termed/properties/lastModifiedBy");
+    public static final Property createdBy = ResourceFactory.createProperty("http://purl.org/termed/properties/createdBy");
+    public static final Property type = ResourceFactory.createProperty("http://purl.org/termed/properties/type");
+    public static final Property id = ResourceFactory.createProperty("http://purl.org/termed/properties/id");
+    public static final Property link = ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/term#ExternalLink");
+    public static final Property terminologyType = ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/term/#terminologyType");
+    public static final Property contact = ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/st#contact");
+    public static final Property conceptClass = ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/iow#conceptClass");
+    public static final Property subjectArea = ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/term#subjectArea");
+    public static final Property termFamily = ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/st#termFamily");
+    public static final Property termEquivalency = ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/st#termEquivalency");
+    public static final Property scope = ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/iow#scope");
+    public static final Property homographNumber = ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/st#termHomographNumber");
+    public static final Property termInfo = ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/st#termInfo");
+    public static final Property termConjugation = ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/st#termConjugation");
+    public static final Property termStyle = ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/st#termStyle");
+    public static final Property wordClass = ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/st#termWordClass");
+    public static final Property searchTerm = ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/st#searchTerm");
+    public static final Property notRecommended = ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/st#notRecommendedSynonym");
+    public static final Property targetId = ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/st#targetId");
+    public static final Property targetUri = ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/st#targetUri");
+    public static final Property synonym = ResourceFactory.createProperty("http://uri.suomi.fi/datamodel/ns/st#synonym");
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedDataMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedDataMapper.java
@@ -1,0 +1,196 @@
+package fi.vm.yti.terminology.api.v2.migration.v1;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.vm.yti.common.dto.LinkDTO;
+import fi.vm.yti.common.dto.ServiceCategoryDTO;
+import fi.vm.yti.common.enums.GraphType;
+import fi.vm.yti.common.enums.Status;
+import fi.vm.yti.common.util.MapperUtils;
+import fi.vm.yti.terminology.api.v2.dto.*;
+import fi.vm.yti.terminology.api.v2.enums.*;
+import fi.vm.yti.terminology.api.v2.mapper.ConceptMapper;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.DCTerms;
+import org.apache.jena.vocabulary.SKOS;
+import org.apache.jena.vocabulary.SKOSXL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class TermedDataMapper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TermedDataMapper.class);
+
+    private TermedDataMapper() {}
+
+    public static TerminologyDTO mapTerminology(Resource metaResource, List<ServiceCategoryDTO> allCategories) {
+        var terminologyDTO = new TerminologyDTO();
+
+        var terminologyURI = NodeFactory.createURI(MapperUtils.propertyToString(metaResource, Termed.uri));
+
+        terminologyDTO.setPrefix(terminologyURI.getLocalName());
+        terminologyDTO.setLanguages(MapperUtils.arrayPropertyToSet(metaResource, DCTerms.language));
+        terminologyDTO.setLabel(MapperUtils.localizedPropertyToMap(metaResource, SKOS.prefLabel));
+        terminologyDTO.setDescription(MapperUtils.localizedPropertyToMap(metaResource, DCTerms.description));
+        terminologyDTO.setStatus(Status.valueOf(MapperUtils.propertyToString(metaResource, Termed.status)));
+
+        var organizations = MapperUtils.arrayPropertyToSet(metaResource, DCTerms.contributor).stream()
+                .map(o -> {
+                    var parts = o.split("/");
+                    return UUID.fromString(parts[parts.length - 1]);
+                })
+                .collect(Collectors.toSet());
+        terminologyDTO.setOrganizations(organizations);
+
+        var groups = MapperUtils.arrayPropertyToSet(metaResource, DCTerms.isPartOf);
+
+        var newGroups = new HashSet<String>();
+        groups.forEach(group ->
+                allCategories.stream()
+                        .filter(grp -> grp.getId().equals(group))
+                        .findFirst()
+                        .ifPresent(g -> newGroups.add(g.getIdentifier()))
+        );
+        terminologyDTO.setGroups(newGroups);
+
+        var type = GraphType.TERMINOLOGICAL_VOCABULARY;
+        if (metaResource.hasProperty(Termed.terminologyType)) {
+            type = GraphType.valueOf(MapperUtils.propertyToString(metaResource, Termed.terminologyType));
+        }
+        terminologyDTO.setGraphType(type);
+        terminologyDTO.setContact(MapperUtils.propertyToString(metaResource, Termed.contact));
+        return terminologyDTO;
+    }
+
+    public static ConceptDTO mapConcept(Model oldData, Resource c, ObjectMapper mapper, String defaultLanguage) {
+        var concept = new ConceptDTO();
+        concept.setIdentifier(c.getLocalName());
+        concept.setStatus(Status.valueOf(MapperUtils.propertyToString(c, Termed.status)));
+        concept.setDefinition(MapperUtils.localizedPropertyToMap(c, SKOS.definition));
+
+        var examples = c.listProperties(SKOS.example)
+                .mapWith(e -> new LocalizedValueDTO(e.getLanguage(), e.getString()))
+                .toList();
+        var notes = c.listProperties(SKOS.note)
+                .mapWith(e -> new LocalizedValueDTO(e.getLanguage(), e.getString()))
+                .toList();
+        concept.setExamples(examples);
+        concept.setNotes(notes);
+        concept.setConceptClass(MapperUtils.propertyToString(c, Termed.conceptClass));
+        concept.setHistoryNote(MapperUtils.propertyToString(c, SKOS.historyNote));
+        concept.setChangeNote(MapperUtils.propertyToString(c, SKOS.changeNote));
+
+        var subjectArea = MapperUtils.propertyToString(c, Termed.subjectArea);
+        if (subjectArea != null) {
+            concept.setSubjectArea(Map.of(defaultLanguage, subjectArea));
+        }
+        concept.setEditorialNotes(MapperUtils.arrayPropertyToList(c, SKOS.editorialNote));
+        concept.setSources(MapperUtils.arrayPropertyToList(c, DCTerms.source));
+
+        var links = MapperUtils.arrayPropertyToList(c, Termed.link).stream().map(l -> {
+            try {
+                l = l.replace("\\\"", "\"");
+                l = l.replace("\"{", "{");
+                l = l.replace("}\"", "}");
+                var json = mapper.readTree(l);
+
+                var dto = new LinkDTO();
+                dto.setName(Map.of(defaultLanguage, Optional.of(json.get("name")).map(JsonNode::asText).orElse("")));
+                dto.setDescription(Map.of(defaultLanguage, Optional.of(json.get("description")).map(JsonNode::asText).orElse("")));
+                dto.setUri(Optional.of(json.get("url")).map(JsonNode::asText).orElse(""));
+                return dto;
+            } catch (JsonProcessingException e) {
+                LOG.error("Error parsing links for concept {}, {}", concept.getIdentifier(), l);
+                return null;
+            }
+        }).filter(Objects::nonNull).toList();
+
+        concept.setLinks(links);
+
+        var terms = new HashSet<TermDTO>();
+        MapperUtils.arrayPropertyToList(c, SKOSXL.prefLabel)
+                .forEach(t -> terms.add(getTerm(oldData.getResource(t), TermType.RECOMMENDED)));
+
+        MapperUtils.arrayPropertyToList(c, Termed.synonym)
+                .forEach(t -> terms.add(getTerm(oldData.getResource(t), TermType.SYNONYM)));
+
+        MapperUtils.arrayPropertyToList(c, Termed.notRecommended)
+                .forEach(t -> terms.add(getTerm(oldData.getResource(t), TermType.NOT_RECOMMENDED)));
+
+        MapperUtils.arrayPropertyToList(c, Termed.searchTerm)
+                .forEach(t -> terms.add(getTerm(oldData.getResource(t), TermType.SEARCH_TERM)));
+
+        concept.setTerms(terms);
+
+        var references = new ArrayList<ConceptReferenceDTO>();
+
+        ConceptMapper.internalRefProperties.forEach(prop ->
+                MapperUtils.arrayPropertyToList(c, prop)
+                    .forEach(r -> references.add(getReference(r, ReferenceType.getByPropertyName(prop.getLocalName())))));
+
+        concept.setReferences(references);
+        return concept;
+    }
+
+    private static ConceptReferenceDTO getReference(String uri, ReferenceType referenceType) {
+        var dto = new ConceptReferenceDTO();
+        dto.setConceptURI(uri);
+        dto.setReferenceType(referenceType);
+        return  dto;
+    }
+
+    private static TermDTO getTerm(Resource resource, TermType type) {
+        var dto = new TermDTO();
+        var label = resource.getProperty(SKOSXL.literalForm);
+        dto.setLanguage(label.getLanguage());
+        dto.setLabel(label.getString());
+        dto.setTermType(type);
+        dto.setIdentifier("term-" + MapperUtils.propertyToString(resource, Termed.id));
+        dto.setStatus(Status.valueOf(MapperUtils.propertyToString(resource, Termed.status)));
+        dto.setHistoryNote(MapperUtils.propertyToString(resource, SKOS.historyNote));
+        dto.setChangeNote(MapperUtils.propertyToString(resource, SKOS.changeNote));
+        dto.setTermFamily(getEnumValue(resource, Termed.termFamily, TermFamily.class));
+        dto.setTermConjugation(getEnumValue(resource, Termed.termConjugation, TermConjugation.class));
+
+        var equivalency = MapperUtils.propertyToString(resource, Termed.termEquivalency);
+        if ("~".equals(equivalency)) {
+            dto.setTermEquivalency(TermEquivalency.CLOSE);
+        } else if (">".equals(equivalency)) {
+            dto.setTermEquivalency(TermEquivalency.BROADER);
+        } else if ("<".equals(equivalency)) {
+            dto.setTermEquivalency(TermEquivalency.NARROWER);
+        }
+
+        dto.setScope(MapperUtils.propertyToString(resource, Termed.scope));
+        dto.setTermInfo(MapperUtils.propertyToString(resource, Termed.termInfo));
+        dto.setTermStyle(MapperUtils.propertyToString(resource, Termed.termStyle));
+        dto.setHomographNumber(MapperUtils.getLiteral(resource, Termed.homographNumber, Integer.class));
+        dto.setWordClass(getEnumValue(resource, Termed.wordClass, WordClass.class));
+        dto.setEditorialNotes(MapperUtils.arrayPropertyToList(resource, SKOS.editorialNote));
+        dto.setSources(MapperUtils.arrayPropertyToList(resource, DCTerms.source));
+
+        return dto;
+    }
+
+    private static <E extends Enum<E>> E getEnumValue(Resource resource, Property property, Class<E> e) {
+        var value = MapperUtils.propertyToString(resource, property);
+        if (value == null) {
+            return null;
+        }
+
+        try {
+            return Enum.valueOf(e, value.toUpperCase());
+        } catch (Exception ex) {
+            LOG.error("Invalid enum value {}, {}", value, e);
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedDataMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedDataMapper.java
@@ -28,6 +28,8 @@ public class TermedDataMapper {
 
     private static final Logger LOG = LoggerFactory.getLogger(TermedDataMapper.class);
 
+    public static final String URI_SUOMI_FI = "http://uri.suomi.fi";
+
     private TermedDataMapper() {}
 
     public static TerminologyDTO mapTerminology(Resource metaResource, List<ServiceCategoryDTO> allCategories) {
@@ -102,9 +104,9 @@ public class TermedDataMapper {
                 var json = mapper.readTree(l);
 
                 var dto = new LinkDTO();
-                dto.setName(Map.of(defaultLanguage, Optional.of(json.get("name")).map(JsonNode::asText).orElse("")));
-                dto.setDescription(Map.of(defaultLanguage, Optional.of(json.get("description")).map(JsonNode::asText).orElse("")));
-                dto.setUri(Optional.of(json.get("url")).map(JsonNode::asText).orElse(""));
+                dto.setName(Map.of(defaultLanguage, Optional.ofNullable(json.get("name")).map(JsonNode::asText).orElse("")));
+                dto.setDescription(Map.of(defaultLanguage, Optional.ofNullable(json.get("description")).map(JsonNode::asText).orElse("")));
+                dto.setUri(Optional.ofNullable(json.get("url")).map(JsonNode::asText).orElse(""));
                 return dto;
             } catch (JsonProcessingException e) {
                 LOG.error("Error parsing links for concept {}, {}", concept.getIdentifier(), l);
@@ -139,9 +141,16 @@ public class TermedDataMapper {
         return concept;
     }
 
+    public static String fixURI(String uri) {
+        if (uri == null) {
+            return null;
+        }
+        return uri.replace(URI_SUOMI_FI, "https://iri.suomi.fi");
+    }
+
     private static ConceptReferenceDTO getReference(String uri, ReferenceType referenceType) {
         var dto = new ConceptReferenceDTO();
-        dto.setConceptURI(uri);
+        dto.setConceptURI(fixURI(uri));
         dto.setReferenceType(referenceType);
         return  dto;
     }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedMigrationController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedMigrationController.java
@@ -1,0 +1,33 @@
+package fi.vm.yti.terminology.api.v2.migration.v1;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URISyntaxException;
+
+@RestController
+@RequestMapping("v2/migrate")
+@Tag(name = "Migrate")
+@Hidden
+public class TermedMigrationController {
+
+    private final TermedMigrationService migrationService;
+
+    public TermedMigrationController(TermedMigrationService migrationService) {
+        this.migrationService = migrationService;
+    }
+
+    @PostMapping
+    void migrate(@RequestParam String terminologyId) throws URISyntaxException {
+        migrationService.migrate(terminologyId);
+    }
+
+    @PostMapping("/all")
+    void migrateAll() throws URISyntaxException {
+        migrationService.migrateAll();
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedMigrationService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedMigrationService.java
@@ -1,0 +1,295 @@
+package fi.vm.yti.terminology.api.v2.migration.v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.vm.yti.common.Constants;
+import fi.vm.yti.common.properties.SuomiMeta;
+import fi.vm.yti.common.service.FrontendService;
+import fi.vm.yti.common.util.MapperUtils;
+import fi.vm.yti.security.AuthenticatedUserProvider;
+import fi.vm.yti.security.AuthorizationException;
+import fi.vm.yti.terminology.api.v2.dto.ConceptReferenceDTO;
+import fi.vm.yti.terminology.api.v2.dto.LocalizedValueDTO;
+import fi.vm.yti.terminology.api.v2.dto.TerminologyDTO;
+import fi.vm.yti.terminology.api.v2.enums.ReferenceType;
+import fi.vm.yti.terminology.api.v2.mapper.ConceptMapper;
+import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
+import fi.vm.yti.terminology.api.v2.service.ConceptService;
+import fi.vm.yti.terminology.api.v2.service.TerminologyService;
+import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
+import org.apache.jena.arq.querybuilder.UpdateBuilder;
+import org.apache.jena.arq.querybuilder.WhereBuilder;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.rdf.model.*;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParser;
+import org.apache.jena.vocabulary.DCTerms;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.SKOS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriBuilder;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
+
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class TermedMigrationService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TermedMigrationService.class);
+    private static final String URI_SUOMI_FI = "http://uri.suomi.fi";
+
+    @Value("${terminology.host:https://sanastot.test.yti.cloud.dvv.fi}")
+    String terminologyHost;
+
+    private final TerminologyService terminologyService;
+
+    private final ConceptService conceptService;
+
+    private final FrontendService frontendService;
+
+    private final TerminologyRepository terminologyRepository;
+
+    private final WebClient webClient;
+    private final AuthenticatedUserProvider userProvider;
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    public TermedMigrationService(TerminologyService terminologyService,
+                                  ConceptService conceptService,
+                                  FrontendService frontendService,
+                                  TerminologyRepository terminologyRepository,
+                                  AuthenticatedUserProvider userProvider,
+                                  @Value("${api.url:http://localhost:9102/api}") String termedHost,
+                                  @Value("${api.user:}") String termedUser,
+                                  @Value("${api.pw:}") String termedPassword) {
+        this.terminologyService = terminologyService;
+        this.conceptService = conceptService;
+        this.frontendService = frontendService;
+        this.terminologyRepository = terminologyRepository;
+        this.userProvider = userProvider;
+
+        HttpHeaders defaultHttpHeaders = new HttpHeaders();
+        defaultHttpHeaders.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        defaultHttpHeaders.setBasicAuth(termedUser, termedPassword);
+        this.webClient = WebClient.builder()
+                .defaultHeaders(headers -> headers.addAll(defaultHttpHeaders))
+                .baseUrl(termedHost + "/graphs")
+                .clientConnector(new ReactorClientHttpConnector(
+                                HttpClient.create(ConnectionProvider.builder("terminology").build())
+                        )
+                ).build();
+    }
+
+    public void migrateAll() throws URISyntaxException {
+        var graphs = webClient.get()
+                .uri(UriBuilder::build)
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .block();
+
+        if (graphs != null && !graphs.isEmpty()) {
+            for (var graph : graphs) {
+                // skip graphs without code, e.g. organization and category graphs
+                if (graph.get("code") == null) {
+                    continue;
+                }
+                var id = graph.get("id").asText();
+                LOG.info("Migrate graph {}", id);
+                migrate(id);
+            }
+        }
+    }
+
+    public void migrate(final String terminologyId) throws URISyntaxException {
+        if (!userProvider.getUser().isSuperuser()) {
+            throw new AuthorizationException("Not allowed");
+        }
+
+        var oldData = ModelFactory.createDefaultModel();
+
+        RDFParser.create()
+                .source(terminologyHost + "/terminology-api/api/v1/export/" + terminologyId + "?format=rdf")
+                .lang(Lang.RDFXML)
+                .parse(oldData);
+
+        var terminologyMeta = oldData.listSubjectsWithProperty(RDF.type, SKOS.ConceptScheme);
+
+        if (!terminologyMeta.hasNext()) {
+            LOG.warn("Invalid terminology {}, no metadata available", terminologyId);
+            return;
+        }
+
+        var metaResource = terminologyMeta.next();
+        var allCategories = frontendService.getServiceCategories("fi");
+
+        var terminologyDTO = TermedDataMapper.mapTerminology(metaResource, allCategories);
+
+        var defaultLanguage = terminologyDTO.getLanguages().contains("fi")
+                ? "fi"
+                : terminologyDTO.getLanguages().iterator().next();
+
+        try {
+            terminologyService.delete(terminologyDTO.getPrefix());
+        } catch (Exception e) {
+            // not yet added
+        }
+
+        terminologyService.create(terminologyDTO);
+
+        updateTimestamps(metaResource,terminologyDTO.getPrefix(), null);
+        addTermedId(terminologyDTO.getPrefix(), null, terminologyId);
+
+        handleConcepts(terminologyId, oldData, terminologyDTO, defaultLanguage);
+        handleCollections(oldData);
+    }
+
+    private void handleConcepts(String terminologyId, Model oldData, TerminologyDTO terminologyDTO, String defaultLanguage) {
+        oldData.listSubjectsWithProperty(RDF.type, SKOS.Concept)
+                .filterKeep(c -> c.getURI().startsWith(URI_SUOMI_FI))
+                .forEach(resource -> {
+                    var concept = TermedDataMapper.mapConcept(oldData, resource, mapper, defaultLanguage);
+
+                    // fetch data from termed because export doesn't maintain the order
+                    if (!concept.getNotes().isEmpty() || !concept.getExamples().isEmpty()) {
+                        var conceptTermedId = MapperUtils.propertyToString(resource, Termed.id);
+                        var conceptResult = webClient.get().uri(builder -> builder
+                                .pathSegment(terminologyId, "node-trees")
+                                .queryParam("select", "id,properties.*")
+                                .queryParam("where", "id:" + conceptTermedId)
+                                .build()).retrieve().bodyToMono(JsonNode.class).block();
+
+                        if (conceptResult != null && !conceptResult.isEmpty()) {
+                            JsonNode properties = conceptResult.get(0).get("properties");
+                            concept.setNotes(handleOrder(properties, "note"));
+                            concept.setExamples(handleOrder(properties, "example"));
+                        }
+                    }
+
+                    ConceptMapper.externalRefProperties.forEach(prop ->
+                            MapperUtils.arrayPropertyToList(resource, prop)
+                                    .forEach(r -> {
+                                        var conceptLink = oldData.getResource(r);
+                                        var linkedTerminology = MapperUtils.propertyToString(conceptLink, Termed.targetUri);
+                                        var linkedConcept = MapperUtils.propertyToString(conceptLink, Termed.targetId);
+
+                                        LOG.info("Fetch from termed: /api/graphs/{}/node-trees?select=*&where=id:{}", linkedTerminology, linkedConcept);
+
+                                        var result = webClient.get().uri(builder -> builder
+                                                .pathSegment(linkedTerminology, "node-trees")
+                                                .queryParam("select", "*")
+                                                .queryParam("where", "id:" + linkedConcept)
+                                                .build()).retrieve().bodyToMono(JsonNode.class).block();
+
+                                        if (result != null && !result.isEmpty()) {
+                                            var refDto = new ConceptReferenceDTO();
+                                            refDto.setConceptURI(result.get(0).get("uri").asText()
+                                                    .replace(URI_SUOMI_FI, "https://iri.suomi.fi"));
+                                            refDto.setReferenceType(ReferenceType.getByPropertyName(prop.getLocalName()));
+
+                                            concept.getReferences().add(refDto);
+                                        }
+                                    }));
+                    try {
+                        conceptService.create(terminologyDTO.getPrefix(), concept);
+                        updateTimestamps(resource, terminologyDTO.getPrefix(), concept.getIdentifier());
+                        addTermedId(terminologyDTO.getPrefix(), concept.getIdentifier(), MapperUtils.propertyToString(resource, Termed.id));
+                    } catch (URISyntaxException e) {
+                        LOG.error(e.getMessage(), e);
+                    }
+                });
+    }
+
+    private static void handleCollections(Model oldData) {
+        oldData.listSubjectsWithProperty(RDF.type, SKOS.Collection).forEach(c -> {
+            var label = MapperUtils.localizedPropertyToMap(c, SKOS.prefLabel);
+            var description = MapperUtils.localizedPropertyToMap(c, SKOS.definition);
+            var identifier = NodeFactory.createURI(MapperUtils.propertyToString(c, Termed.uri)).getLocalName();
+            var members = MapperUtils.arrayPropertyToList(c, SKOS.member).stream()
+                    .map(m -> m.replace(URI_SUOMI_FI, "https://iri.suomi.fi"))
+                    .toList();
+
+            // TODO: save collection
+            LOG.info("Collection {}, {}, {}, {}", label, description, identifier, members);
+        });
+    }
+
+    private static List<LocalizedValueDTO> handleOrder(JsonNode properties, String property) {
+        var result = new ArrayList<LocalizedValueDTO>();
+        Optional.of(
+                properties.get(property))
+                .ifPresent(prop -> prop.iterator().forEachRemaining(p -> result.add(
+                        new LocalizedValueDTO(p.get("lang").asText(), p.get("value").asText()))));
+        return result;
+    }
+
+    private void updateTimestamps(Resource oldResource, String prefix, String identifier) {
+        TerminologyURI terminologyURI;
+        Resource subject;
+        if (identifier != null) {
+            terminologyURI = TerminologyURI.createConceptURI(prefix, identifier);
+            subject = ResourceFactory.createResource(terminologyURI.getResourceURI());
+        } else {
+            terminologyURI = TerminologyURI.createTerminologyURI(prefix);
+            subject = ResourceFactory.createResource(terminologyURI.getModelResourceURI());
+        }
+        var graph = NodeFactory.createURI(terminologyURI.getGraphURI());
+        
+        var builder = new UpdateBuilder();
+        builder.addPrefixes(Constants.PREFIXES);
+
+        var created = MapperUtils.getLiteral(oldResource, Termed.createdDate, String.class);
+        var creator = MapperUtils.getLiteral(oldResource, Termed.createdBy, String.class);
+        var modified = MapperUtils.getLiteral(oldResource, Termed.lastModifiedDate, String.class);
+        var modifier = MapperUtils.getLiteral(oldResource, Termed.lastModifiedBy, String.class);
+
+        builder.addDelete(graph, subject, SuomiMeta.creator, "?creator")
+                .addDelete(graph, subject, SuomiMeta.modifier, "?modifier")
+                .addDelete(graph, subject, DCTerms.created, "?created")
+                .addDelete(graph, subject, DCTerms.modified, "?modified")
+                .addInsert(graph, subject, DCTerms.created, created)
+                .addInsert(graph, subject, DCTerms.modified, modified)
+                .addInsert(graph, subject, SuomiMeta.creator, creator)
+                .addInsert(graph, subject, SuomiMeta.modifier, modifier);
+
+        var whereBuilder = new WhereBuilder()
+                .addWhere(subject, SuomiMeta.creator, "?creator")
+                .addWhere(subject, SuomiMeta.modifier, "?modifier")
+                .addWhere(subject, DCTerms.created, "?created")
+                .addWhere(subject, DCTerms.modified, "?modified");
+
+        builder.addGraph(graph, whereBuilder);
+        
+        terminologyRepository.queryUpdate(builder.buildRequest());
+    }
+
+    private void addTermedId(String prefix, String identifier, String termedId) {
+        TerminologyURI terminologyURI;
+        Resource subject;
+        if (identifier != null) {
+            terminologyURI = TerminologyURI.createConceptURI(prefix, identifier);
+            subject = ResourceFactory.createResource(terminologyURI.getResourceURI());
+        } else {
+            terminologyURI = TerminologyURI.createTerminologyURI(prefix);
+            subject = ResourceFactory.createResource(terminologyURI.getModelResourceURI());
+        }
+
+        var builder = new UpdateBuilder();
+        builder.addPrefixes(Constants.PREFIXES);
+        var graph = NodeFactory.createURI(terminologyURI.getGraphURI());
+
+        builder.addInsert(graph, subject, Termed.id, termedId);
+
+        terminologyRepository.queryUpdate(builder.buildRequest());
+    }
+}

--- a/src/test/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapperTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapperTest.java
@@ -236,7 +236,7 @@ class ConceptMapperTest {
 
         var dto = ConceptMapper.modelToDTO(model, "concept-1", TestUtils.mapUser);
 
-        assertEquals(4, dto.getTerms().size());
+        assertEquals(5, dto.getTerms().size());
 
         var termOpt = dto.getTerms().stream()
                 .filter(t -> t.getIdentifier().equals("term-614007ae-5d84-45d8-b473-6359c3cbc5ca"))

--- a/src/test/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapperTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapperTest.java
@@ -223,10 +223,18 @@ class ConceptMapperTest {
         assertEquals("description", link.getDescription().get("fi"));
         assertEquals("https://dvv.fi", link.getUri());
 
-        var ref = dto.getReferences().iterator().next();
-        assertEquals(graphURI + "concept-2", ref.getConceptURI());
-        assertEquals(ReferenceType.BROADER, ref.getReferenceType());
-        assertEquals("Suositettava termi", ref.getLabel().get("fi"));
+        var internalRef = dto.getReferences().stream()
+                .filter(r -> r.getReferenceType().equals(ReferenceType.BROADER))
+                .findFirst();
+        assertTrue(internalRef.isPresent());
+        assertEquals(graphURI + "concept-2", internalRef.get().getConceptURI());
+        assertEquals("Suositettava termi", internalRef.get().getLabel().get("fi"));
+
+        var externalRef = dto.getReferences().stream()
+                .filter(r -> r.getReferenceType().equals(ReferenceType.NARROW_MATCH))
+                .findFirst();
+        assertTrue(externalRef.isPresent());
+        assertEquals(TerminologyURI.createConceptURI("ext", "concept-1").getResourceURI(), externalRef.get().getConceptURI());
     }
 
     @Test

--- a/src/test/java/fi/vm/yti/terminology/api/v2/migration/TermedDataMapperTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/migration/TermedDataMapperTest.java
@@ -5,7 +5,8 @@ import fi.vm.yti.common.dto.ServiceCategoryDTO;
 import fi.vm.yti.common.enums.GraphType;
 import fi.vm.yti.common.enums.Status;
 import fi.vm.yti.terminology.api.v2.TestUtils;
-import fi.vm.yti.terminology.api.v2.enums.TermType;
+import fi.vm.yti.terminology.api.v2.dto.TermDTO;
+import fi.vm.yti.terminology.api.v2.enums.*;
 import fi.vm.yti.terminology.api.v2.migration.v1.TermedDataMapper;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -57,6 +58,13 @@ class TermedDataMapperTest {
         assertEquals(4, dto.getNotes().size());
 
         assertEquals("test definition", dto.getDefinition().get("fi"));
+        assertEquals("c340", dto.getIdentifier());
+        assertEquals("muutos", dto.getChangeNote());
+        assertEquals("luokkakäsite", dto.getConceptClass());
+        assertEquals("käyttö", dto.getHistoryNote());
+        assertEquals(List.of("muistiinpano"), dto.getEditorialNotes());
+        assertEquals(Status.VALID, dto.getStatus());
+        assertEquals(Map.of("fi", "Test aihealue"), dto.getSubjectArea());
 
         var prefTerm = dto.getTerms().stream().filter(t -> t.getTermType().equals(TermType.RECOMMENDED)).findFirst();
         var synonym = dto.getTerms().stream().filter(t -> t.getTermType().equals(TermType.SYNONYM)).findFirst();
@@ -68,10 +76,28 @@ class TermedDataMapperTest {
         assertTrue(searchTerm.isPresent());
         assertEquals(2, notRecommended.size());
 
-        assertEquals("pref term label", prefTerm.get().getLabel());
-        assertEquals("fi", prefTerm.get().getLanguage());
+        var term = prefTerm.get();
+        assertEquals("pref term label", term.getLabel());
+        assertEquals("fi", term.getLanguage());
+        assertEquals("lisätieto", term.getTermInfo());
+        assertEquals("tyyli", term.getTermStyle());
+        assertEquals("term käytönhistoria", term.getHistoryNote());
+        assertEquals("skooppi", term.getScope());
+        assertEquals(TermConjugation.SINGULAR, term.getTermConjugation());
+        assertEquals(TermFamily.MASCULINE, term.getTermFamily());
+        assertEquals(WordClass.ADJECTIVE, term.getWordClass());
+        assertEquals(Status.VALID, term.getStatus());
+        assertEquals(1, term.getHomographNumber());
+        assertEquals("term-9869b1f6-de6a-4d2b-8823-60750def6f30", term.getIdentifier());
+        assertEquals("term muutoshistoria", term.getChangeNote());
+        assertEquals(TermEquivalency.BROADER, term.getTermEquivalency());
+        assertEquals(List.of("term muistiinpano"), term.getEditorialNotes());
+        assertEquals(List.of("lähde 2", "termin lähde"), term.getSources());
 
-        assertEquals(1, dto.getReferences().size());
+        var ref = dto.getReferences().get(0);
+
+        assertEquals("https://iri.suomi.fi/terminology/test/braoder-test", ref.getConceptURI());
+        assertEquals(ReferenceType.BROADER, ref.getReferenceType());
     }
 
     private Model getData() {

--- a/src/test/java/fi/vm/yti/terminology/api/v2/migration/TermedDataMapperTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/migration/TermedDataMapperTest.java
@@ -1,0 +1,85 @@
+package fi.vm.yti.terminology.api.v2.migration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.vm.yti.common.dto.ServiceCategoryDTO;
+import fi.vm.yti.common.enums.GraphType;
+import fi.vm.yti.common.enums.Status;
+import fi.vm.yti.terminology.api.v2.TestUtils;
+import fi.vm.yti.terminology.api.v2.enums.TermType;
+import fi.vm.yti.terminology.api.v2.migration.v1.TermedDataMapper;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFLanguages;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TermedDataMapperTest {
+
+    @Test
+    void testMapTerminology() {
+        var oldData = getData();
+
+        var serviceCategory = new ServiceCategoryDTO("http://urn.fi/URN:NBN:fi:au:ptvl/v1090",
+                Map.of("fi", "Asuminen"), "P10");
+
+        var dto = TermedDataMapper.mapTerminology(oldData.getResource("http://uri.suomi.fi/terminology/test"), List.of(serviceCategory));
+
+        assertNotNull(dto);
+        assertEquals("test", dto.getPrefix());
+        assertEquals(Map.of(
+                "fi", "test fi",
+                "sv", "test sv",
+                "en", "test en"
+            ), dto.getLabel());
+        assertEquals(Status.VALID, dto.getStatus());
+        assertEquals(Set.of(UUID.fromString("7d3a3c00-5a6b-489b-a3ed-63bb58c26a63")), dto.getOrganizations());
+        assertEquals("yhteentoimivuus@dvv.fi", dto.getContact());
+        assertEquals(Set.of("P10"), dto.getGroups());
+        assertEquals(GraphType.OTHER_VOCABULARY, dto.getGraphType());
+    }
+
+    @Test
+    void testMapConcept() {
+        var oldData = getData();
+
+        var dto = TermedDataMapper.mapConcept(oldData, oldData.getResource("http://uri.suomi.fi/terminology/test/c340"),
+                new ObjectMapper(), "fi");
+
+        assertEquals(5, dto.getTerms().size());
+        assertEquals(1, dto.getReferences().size());
+        assertEquals(4, dto.getNotes().size());
+
+        assertEquals("test definition", dto.getDefinition().get("fi"));
+
+        var prefTerm = dto.getTerms().stream().filter(t -> t.getTermType().equals(TermType.RECOMMENDED)).findFirst();
+        var synonym = dto.getTerms().stream().filter(t -> t.getTermType().equals(TermType.SYNONYM)).findFirst();
+        var searchTerm = dto.getTerms().stream().filter(t -> t.getTermType().equals(TermType.SEARCH_TERM)).findFirst();
+        var notRecommended = dto.getTerms().stream().filter(t -> t.getTermType().equals(TermType.NOT_RECOMMENDED)).toList();
+
+        assertTrue(prefTerm.isPresent());
+        assertTrue(synonym.isPresent());
+        assertTrue(searchTerm.isPresent());
+        assertEquals(2, notRecommended.size());
+
+        assertEquals("pref term label", prefTerm.get().getLabel());
+        assertEquals("fi", prefTerm.get().getLanguage());
+
+        assertEquals(1, dto.getReferences().size());
+    }
+
+    private Model getData() {
+        var model = ModelFactory.createDefaultModel();
+        var stream = TestUtils.class.getResourceAsStream("/v1-migration/termed-data.ttl");
+        assertNotNull(stream);
+        RDFDataMgr.read(model, stream, RDFLanguages.TURTLE);
+
+        return model;
+    }
+}

--- a/src/test/java/fi/vm/yti/terminology/api/v2/service/ConceptServiceTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/service/ConceptServiceTest.java
@@ -104,6 +104,7 @@ class ConceptServiceTest {
         when(authorizationManager.hasRightsToTerminology(eq(conceptURI.getPrefix()), any(Model.class))).thenReturn(false);
         when(repository.fetchByPrefix(conceptURI.getPrefix())).thenReturn(model);
         when(groupManagementService.mapUser()).thenReturn(TestUtils.mapUser);
+        when(repository.queryConstruct(any(Query.class))).thenReturn(ModelFactory.createDefaultModel());
 
         var dto = conceptService.get(conceptURI.getPrefix(), conceptURI.getResourceId());
 

--- a/src/test/resources/terminology-with-concepts.ttl
+++ b/src/test/resources/terminology-with-concepts.ttl
@@ -50,6 +50,7 @@ test:concept-1  rdfs:seeAlso          [ dcterms:description  "description"@fi;
         term:conceptClass             "concept class";
         term:notRecommendedSynonym    test:term-47d79614-d8f5-4c42-8967-a860c3451f5b;
         term:source                   ( "source" );
+        skos:narrowMatch              <https://iri.suomi.fi/terminology/ext/concept-1> ;
         term:subjectArea              "subject area"@fi .
 
 test:term-614007ae-5d84-45d8-b473-6359c3cbc5ca

--- a/src/test/resources/v1-migration/termed-data.ttl
+++ b/src/test/resources/v1-migration/termed-data.ttl
@@ -1,0 +1,243 @@
+@prefix iow:   <http://uri.suomi.fi/datamodel/ns/iow#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix termed: <http://purl.org/termed/properties/> .
+@prefix vs:    <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix ptvl:  <http://urn.fi/URN:NBN:fi:au:ptvl/> .
+@prefix dc:    <http://purl.org/dc/elements/1.1/> .
+@prefix ts:    <http://uri.suomi.fi/datamodel/ns/st#> .
+
+<http://uri.suomi.fi/terminology/test>
+        a                        skos:ConceptScheme ;
+        dcterms:contributor      <http://purl.org/termed/graphs/228cce1e-8360-4039-a3f7-725df5643354/types/Organization/nodes/7d3a3c00-5a6b-489b-a3ed-63bb58c26a63> ;
+        dcterms:description      "test"@fi , "test en"@en ;
+        dcterms:isPartOf         ptvl:v1090 ;
+        dcterms:language         "fi" , "sv" , "en" ;
+        termed:code              "terminological-vocabulary-0" ;
+        termed:createdBy         "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:createdDate       "2022-10-14T04:37:22" ;
+        termed:graph             "30508c53-0ef1-4168-9139-6787634ad460" ;
+        termed:id                "4354ac21-9134-4f7e-bcf6-343afc6b8e8c" ;
+        termed:lastModifiedBy    "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:lastModifiedDate  "2024-05-28T12:19:56" ;
+        termed:number            "0" ;
+        termed:type              "TerminologicalVocabulary" ;
+        termed:uri               "http://uri.suomi.fi/terminology/test" ;
+        ts:contact               "yhteentoimivuus@dvv.fi" ;
+        <http://uri.suomi.fi/datamodel/ns/term/#terminologyType>
+                "OTHER_VOCABULARY" ;
+        vs:term_status           "VALID" ;
+        skos:prefLabel           "test sv"@sv , "test fi"@fi , "test en"@en .
+
+<http://uri.suomi.fi/terminology/test/collection-2000>
+        a                        skos:Collection ;
+        termed:code              "collection-2000" ;
+        termed:createdBy         "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:createdDate       "2024-05-02T07:23:46" ;
+        termed:graph             "30508c53-0ef1-4168-9139-6787634ad460" ;
+        termed:id                "ff0b1363-6f3c-4f31-a139-e8bbe8fdd6d1" ;
+        termed:lastModifiedBy    "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:lastModifiedDate  "2024-05-29T13:04:19" ;
+        termed:number            "2000" ;
+        termed:type              "Collection" ;
+        termed:uri               "http://uri.suomi.fi/terminology/test/collection-2000" ;
+        skos:definition          "kuvaus käsitekokoelma"@fi ;
+        skos:member              <http://uri.suomi.fi/terminology/test/c340> ;
+        skos:prefLabel           "test"@en , "test"@sv , "test"@fi .
+
+<http://uri.suomi.fi/terminology/test/term-6000>
+        a                        skosxl:Label ;
+        termed:code              "term-6000" ;
+        termed:createdBy         "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:createdDate       "2024-05-29T10:38:05" ;
+        termed:graph             "30508c53-0ef1-4168-9139-6787634ad460" ;
+        termed:id                "7ed4729a-c4cd-47e8-8364-9513f5c76a97" ;
+        termed:lastModifiedBy    "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:lastModifiedDate  "2024-05-29T10:38:05" ;
+        termed:number            "6000" ;
+        termed:type              "Term" ;
+        termed:uri               "http://uri.suomi.fi/terminology/test/term-6000" ;
+        vs:term_status           "DRAFT" ;
+        skosxl:literalForm       "Test synonyymi"@fi .
+
+<http://uri.suomi.fi/terminology/test/term-fde46718-f2d5-480e-b4bd-66796d759f4f>
+        a                        skosxl:Label ;
+        dcterms:source           "termin lähde" , "lähde 2" ;
+        termed:code              "fde46718-f2d5-480e-b4bd-66796d759f4f" ;
+        termed:createdBy         "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:createdDate       "2024-04-19T08:37:49" ;
+        termed:graph             "30508c53-0ef1-4168-9139-6787634ad460" ;
+        termed:id                "9869b1f6-de6a-4d2b-8823-60750def6f30" ;
+        termed:lastModifiedBy    "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:lastModifiedDate  "2024-05-29T10:38:05" ;
+        termed:number            "4003" ;
+        termed:type              "Term" ;
+        termed:uri               "http://uri.suomi.fi/terminology/test/term-fde46718-f2d5-480e-b4bd-66796d759f4f" ;
+        iow:scope                "skooppi" ;
+        ts:termConjugation       "singular" ;
+        ts:termEquivalency       ">" ;
+        ts:termFamily            "masculine" ;
+        ts:termHomographNumber   "1" ;
+        ts:termInfo              "lisätieto" ;
+        ts:termStyle             "tyyli" ;
+        ts:termWordClass         "adjective" ;
+        vs:term_status           "VALID" ;
+        skos:changeNote          "term muutoshistoria" ;
+        skos:editorialNote       "term muistiinpano" ;
+        skos:historyNote         "term käytönhistoria" ;
+        skosxl:literalForm       "pref term label"@fi .
+
+<http://uri.suomi.fi/terminology/test/concept-link-2000>
+        a                        rdf:Resource ;
+        termed:code              "concept-link-2000" ;
+        termed:createdBy         "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:createdDate       "2024-05-02T06:33:13" ;
+        termed:graph             "30508c53-0ef1-4168-9139-6787634ad460" ;
+        termed:id                "0ab300ec-7b24-4ff4-9ed9-121560f21654" ;
+        termed:lastModifiedBy    "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:lastModifiedDate  "2024-05-29T10:38:05" ;
+        termed:number            "2000" ;
+        termed:type              "ConceptLink" ;
+        termed:uri               "http://uri.suomi.fi/terminology/test/concept-link-2000" ;
+        ts:targetId              "ce86236b-95bd-4608-878d-628e9712b2f9" ;
+        ts:targetUri             "bd988c70-6342-41f9-bffd-bbd5d7b54b83" ;
+        ts:vocabularyLabel       "testi - SOSTI40"@fi ;
+        skos:prefLabel           "\"kokopäiväinen sairauspäiväraha\""@fi .
+
+<http://uri.suomi.fi/terminology/test/c340>
+        a                         skos:Concept ;
+        dcterms:source            "lähde 1" ;
+        termed:code               "c340" ;
+        termed:createdBy          "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:createdDate        "2024-04-19T08:37:49" ;
+        termed:graph              "30508c53-0ef1-4168-9139-6787634ad460" ;
+        termed:id                 "ceb48295-add3-4686-9ab8-01cae4820638" ;
+        termed:lastModifiedBy     "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:lastModifiedDate   "2024-05-29T10:38:05" ;
+        termed:number             "4000" ;
+        termed:type               "Concept" ;
+        skos:broader              <http://uri.suomi.fi/terminology/test/braoder-test> ;
+        termed:uri                "http://uri.suomi.fi/terminology/test/c340" ;
+        iow:conceptClass          "luokkakäsite" ;
+        ts:notRecommendedSynonym  <http://uri.suomi.fi/terminology/test/term-d85cae62-1229-4c4e-920b-dcebdc25153c> , <http://uri.suomi.fi/terminology/test/term-e7cfe61b-962a-40e0-ab4d-c39bf63a4604> ;
+        ts:searchTerm             <http://uri.suomi.fi/terminology/test/term-306c0871-f719-4ca2-a895-d34fc0b3ae6e> ;
+        ts:synonym                <http://uri.suomi.fi/terminology/test/term-6000> ;
+        <http://uri.suomi.fi/datamodel/ns/term#ExternalLink>
+                "\"{\"name\":\"Käsitekaavio\",\"url\":\"https://dvv.fi\",\"description\":\"kuvaus\"}\"" ;
+        <http://uri.suomi.fi/datamodel/ns/term#subjectArea>
+                "Test aihealue" ;
+        vs:term_status            "VALID" ;
+        skos:changeNote           "muutos" ;
+        skos:definition           "test definition"@fi ;
+        skos:editorialNote        "muistiinpano" ;
+        skos:example              "Esimerkki 2"@fi , "Esimerkki 1"@fi ;
+        skos:historyNote          "käyttö" ;
+        skos:narrowMatch          <http://uri.suomi.fi/terminology/test/concept-link-2000> ;
+        skos:note                 "note 1"@fi , "uusi huomautus"@fi , "note 2"@fi , "Käsitekaavio"@fi ;
+        skosxl:prefLabel          <http://uri.suomi.fi/terminology/test/term-fde46718-f2d5-480e-b4bd-66796d759f4f> .
+
+<http://uri.suomi.fi/terminology/test/braoder-test>
+        a                        skos:Concept .
+
+<http://uri.suomi.fi/terminology/test/terminological-vocabulary-0/concept-link-1fca5799-00f2-4457-86e6-4954454c65cf>
+        a                        rdf:Resource ;
+        termed:code              "concept-link-1fca5799-00f2-4457-86e6-4954454c65cf" ;
+        termed:createdBy         "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:createdDate       "2023-03-31T10:51:53" ;
+        termed:graph             "30508c53-0ef1-4168-9139-6787634ad460" ;
+        termed:id                "1fca5799-00f2-4457-86e6-4954454c65cf" ;
+        termed:lastModifiedBy    "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:lastModifiedDate  "2023-03-31T10:51:53" ;
+        termed:number            "1003" ;
+        termed:type              "ConceptLink" ;
+        termed:uri               "http://uri.suomi.fi/terminology/test/terminological-vocabulary-0/concept-link-1fca5799-00f2-4457-86e6-4954454c65cf" ;
+        ts:targetId              "9c7e87ce-3b91-403e-ab51-09005b46c728" ;
+        ts:targetUri             "30508c53-0ef1-4168-9139-6787634ad460" ;
+        ts:vocabularyLabel       "test 20221014"@fi ;
+        skos:prefLabel           "uusi käsite 123"@fi .
+
+<http://uri.suomi.fi/terminology/test/term-d85cae62-1229-4c4e-920b-dcebdc25153c>
+        a                        skosxl:Label ;
+        termed:code              "term-d85cae62-1229-4c4e-920b-dcebdc25153c" ;
+        termed:createdBy         "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:createdDate       "2024-04-19T08:37:49" ;
+        termed:graph             "30508c53-0ef1-4168-9139-6787634ad460" ;
+        termed:id                "d85cae62-1229-4c4e-920b-dcebdc25153c" ;
+        termed:lastModifiedBy    "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:lastModifiedDate  "2024-05-29T10:38:05" ;
+        termed:number            "4001" ;
+        termed:type              "Term" ;
+        termed:uri               "http://uri.suomi.fi/terminology/test/term-d85cae62-1229-4c4e-920b-dcebdc25153c" ;
+        ts:termInfo              "vanhentunut" ;
+        vs:term_status           "VALID" ;
+        skosxl:literalForm       "pref term label"@fi .
+
+<http://uri.suomi.fi/terminology/test/term-e7cfe61b-962a-40e0-ab4d-c39bf63a4604>
+        a                        skosxl:Label ;
+        termed:code              "term-e7cfe61b-962a-40e0-ab4d-c39bf63a4604" ;
+        termed:createdBy         "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:createdDate       "2024-04-19T08:37:49" ;
+        termed:graph             "30508c53-0ef1-4168-9139-6787634ad460" ;
+        termed:id                "e7cfe61b-962a-40e0-ab4d-c39bf63a4604" ;
+        termed:lastModifiedBy    "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:lastModifiedDate  "2024-05-29T10:38:05" ;
+        termed:number            "4002" ;
+        termed:type              "Term" ;
+        termed:uri               "http://uri.suomi.fi/terminology/test/term-e7cfe61b-962a-40e0-ab4d-c39bf63a4604" ;
+        ts:termHomographNumber   "2" ;
+        ts:termInfo              "vanhentunut" ;
+        vs:term_status           "VALID" ;
+        skosxl:literalForm       "test synonym"@fi .
+
+<http://uri.suomi.fi/terminology/test/terminological-vocabulary-0/concept-link-65756450-ac82-4d09-9db8-b90b5774e5c0>
+        a                        rdf:Resource ;
+        termed:code              "concept-link-65756450-ac82-4d09-9db8-b90b5774e5c0" ;
+        termed:createdBy         "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:createdDate       "2023-03-31T10:51:53" ;
+        termed:graph             "30508c53-0ef1-4168-9139-6787634ad460" ;
+        termed:id                "65756450-ac82-4d09-9db8-b90b5774e5c0" ;
+        termed:lastModifiedBy    "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:lastModifiedDate  "2023-03-31T10:51:53" ;
+        termed:number            "1005" ;
+        termed:type              "ConceptLink" ;
+        termed:uri               "http://uri.suomi.fi/terminology/test/terminological-vocabulary-0/concept-link-65756450-ac82-4d09-9db8-b90b5774e5c0" ;
+        ts:targetId              "9c7e87ce-3b91-403e-ab51-09005b46c728" ;
+        ts:targetUri             "30508c53-0ef1-4168-9139-6787634ad460" ;
+        ts:vocabularyLabel       "test 20221014"@fi ;
+        skos:prefLabel           "uusi käsite 123"@fi .
+
+<http://uri.suomi.fi/terminology/test/terminological-vocabulary-0/concept-link-cea29ce1-5a62-4662-83eb-2a8c589918dc>
+        a                        rdf:Resource ;
+        termed:code              "concept-link-cea29ce1-5a62-4662-83eb-2a8c589918dc" ;
+        termed:createdBy         "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:createdDate       "2023-03-31T10:51:53" ;
+        termed:graph             "30508c53-0ef1-4168-9139-6787634ad460" ;
+        termed:id                "cea29ce1-5a62-4662-83eb-2a8c589918dc" ;
+        termed:lastModifiedBy    "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:lastModifiedDate  "2023-03-31T10:51:53" ;
+        termed:number            "1006" ;
+        termed:type              "ConceptLink" ;
+        termed:uri               "http://uri.suomi.fi/terminology/test/terminological-vocabulary-0/concept-link-cea29ce1-5a62-4662-83eb-2a8c589918dc" ;
+        ts:targetId              "9c7e87ce-3b91-403e-ab51-09005b46c728" ;
+        ts:targetUri             "30508c53-0ef1-4168-9139-6787634ad460" ;
+        ts:vocabularyLabel       "test 20221014"@fi ;
+        skos:prefLabel           "uusi käsite 123"@fi .
+
+<http://uri.suomi.fi/terminology/test/term-306c0871-f719-4ca2-a895-d34fc0b3ae6e>
+        a                        skosxl:Label ;
+        termed:code              "term-306c0871-f719-4ca2-a895-d34fc0b3ae6e" ;
+        termed:createdBy         "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:createdDate       "2024-04-19T08:37:49" ;
+        termed:graph             "30508c53-0ef1-4168-9139-6787634ad460" ;
+        termed:id                "306c0871-f719-4ca2-a895-d34fc0b3ae6e" ;
+        termed:lastModifiedBy    "0e9bc795-dd69-4bbe-b3eb-21e67e3f3ff6" ;
+        termed:lastModifiedDate  "2024-05-29T10:38:05" ;
+        termed:number            "4000" ;
+        termed:type              "Term" ;
+        termed:uri               "http://uri.suomi.fi/terminology/test/term-306c0871-f719-4ca2-a895-d34fc0b3ae6e" ;
+        vs:term_status           "VALID" ;
+        skosxl:literalForm       "lapsen vammaistuki"@fi .


### PR DESCRIPTION
Migrate terminologies and concepts from Termed to Fuseki

Other changes:
- Add missing properties for term (sources and editorialNotes)
- Map concept's external references (e.g. narrowMatch)
- Create collection members as resources, not literals
- Handle multiple terms by type
- Use bulk operations when indexing concepts