### PR TITLE
Add support for concept collections

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptCollectionDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptCollectionDTO.java
@@ -1,0 +1,51 @@
+package fi.vm.yti.terminology.api.v2.dto;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class ConceptCollectionDTO {
+    private String identifier;
+
+    private Map<String, String> label;
+
+    private Map<String, String> description = Map.of();
+
+    private Set<String> members = new HashSet<>();
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public Map<String, String> getLabel() {
+        return label;
+    }
+
+    public void setLabel(Map<String, String> label) {
+        this.label = label;
+    }
+
+    public Map<String, String> getDescription() {
+        return description;
+    }
+
+    public void setDescription(Map<String, String> description) {
+        this.description = description;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public Set<String> getMembers() {
+        return members;
+    }
+
+    public void setMembers(Set<String> members) {
+        this.members = members;
+    }
+
+    public void addMember(String identifier) {
+        members.add(identifier);
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptCollectionInfoDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptCollectionInfoDTO.java
@@ -10,7 +10,9 @@ public class ConceptCollectionInfoDTO extends ResourceCommonInfoDTO {
     class Concept {
         private String identifier;
 
-        private Map<String, String> definition = Map.of();
+        private String uri;
+
+        private Map<String, String> label = Map.of();
 
         public String getIdentifier() {
             return identifier;
@@ -20,12 +22,20 @@ public class ConceptCollectionInfoDTO extends ResourceCommonInfoDTO {
             this.identifier = identifier;
         }
 
-        public Map<String, String> getDefinition() {
-            return definition;
+        public String getUri() {
+            return uri;
         }
 
-        public void setDefinition(Map<String, String> definition) {
-            this.definition = definition;
+        public void setUri(String uri) {
+            this.uri = uri;
+        }
+
+        public Map<String, String> getLabel() {
+            return label;
+        }
+
+        public void setLabel(Map<String, String> label) {
+            this.label = label;
         }
     }
 
@@ -59,10 +69,11 @@ public class ConceptCollectionInfoDTO extends ResourceCommonInfoDTO {
         this.members = members;
     }
 
-    public void addMember(String identifier, Map<String, String> definition) {
+    public void addMember(String identifier, String uri, Map<String, String> label) {
         Concept concept = new Concept();
         concept.identifier = identifier;
-        concept.definition = definition;
+        concept.uri = uri;
+        concept.label = label;
         members.add(concept);
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptCollectionInfoDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptCollectionInfoDTO.java
@@ -1,0 +1,68 @@
+package fi.vm.yti.terminology.api.v2.dto;
+
+import fi.vm.yti.common.dto.ResourceCommonInfoDTO;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class ConceptCollectionInfoDTO extends ResourceCommonInfoDTO {
+    class Concept {
+        private String identifier;
+
+        private Map<String, String> definition = Map.of();
+
+        public String getIdentifier() {
+            return identifier;
+        }
+
+        public void setIdentifier(String identifier) {
+            this.identifier = identifier;
+        }
+
+        public Map<String, String> getDefinition() {
+            return definition;
+        }
+
+        public void setDefinition(Map<String, String> definition) {
+            this.definition = definition;
+        }
+    }
+
+    private String identifier;
+
+    private Map<String, String> description = Map.of();
+
+    private Set<Concept> members = new HashSet<>();
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public Map<String, String> getDescription() {
+        return description;
+    }
+
+    public void setDescription(Map<String, String> description) {
+        this.description = description;
+    }
+
+    public Set<Concept> getMembers() {
+        return members;
+    }
+
+    public void setMembers(Set<Concept> members) {
+        this.members = members;
+    }
+
+    public void addMember(String identifier, Map<String, String> definition) {
+        Concept concept = new Concept();
+        concept.identifier = identifier;
+        concept.definition = definition;
+        members.add(concept);
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/ConceptCollectionController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/ConceptCollectionController.java
@@ -1,0 +1,102 @@
+package fi.vm.yti.terminology.api.v2.endpoint;
+
+import fi.vm.yti.terminology.api.v2.dto.ConceptCollectionDTO;
+import fi.vm.yti.terminology.api.v2.dto.ConceptCollectionInfoDTO;
+import fi.vm.yti.terminology.api.v2.service.ConceptCollectionService;
+import fi.vm.yti.terminology.api.v2.validator.ValidConceptCollection;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URISyntaxException;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@RestController
+@RequestMapping("v2/collection")
+@Tag(name = "ConceptCollection")
+@Validated
+public class ConceptCollectionController {
+    private final ConceptCollectionService conceptCollectionService;
+
+    public ConceptCollectionController(ConceptCollectionService conceptCollectionService) {
+        this.conceptCollectionService = conceptCollectionService;
+    }
+
+    @Operation(summary = "Get concept collection information")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Concept collection fetched successfully"),
+            @ApiResponse(responseCode = "404", description = "Concept collection not found",
+                    content = {@Content(mediaType = APPLICATION_JSON_VALUE)}),
+    })
+    @GetMapping(path = "/{prefix}/{collectionIdentifier}", produces = APPLICATION_JSON_VALUE)
+    public ConceptCollectionInfoDTO get(@PathVariable @Parameter(description = "Terminology prefix") String prefix,
+                                        @PathVariable @Parameter(description = "Collection identifier") String collectionIdentifier) {
+        return conceptCollectionService.get(prefix, collectionIdentifier);
+    }
+
+    @Operation(summary = "Create a new concept collection to terminology")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The JSON data for concept collection")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "The URI for the newly created concept collection"),
+            @ApiResponse(responseCode = "400", description = "One or more of the fields in the JSON data was invalid or malformed",
+                    content = {@Content(mediaType = APPLICATION_JSON_VALUE)}),
+            @ApiResponse(responseCode = "401", description = "Current user does not have rights to create concept collection"),
+    })
+    @PostMapping(path = "/{prefix}", consumes = APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> create(@PathVariable String prefix,
+                                         @RequestBody @ValidConceptCollection ConceptCollectionDTO conceptCollection) throws URISyntaxException {
+        var conceptCollectionURI = conceptCollectionService.create(prefix, conceptCollection);
+        return ResponseEntity.created(conceptCollectionURI).build();
+    }
+
+    @Operation(summary = "Modify concept collection")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The JSON data for updated concept collection")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Concept collection updated successfully"),
+            @ApiResponse(responseCode = "400", description = "One or more of the fields in the JSON data was invalid or malformed",
+                    content = {@Content(mediaType = APPLICATION_JSON_VALUE)}),
+            @ApiResponse(responseCode = "401", description = "Current user does not have rights for this terminology"),
+            @ApiResponse(responseCode = "404", description = "Terminology or concept collection was not found", content = {@Content(mediaType = APPLICATION_JSON_VALUE)})
+    })
+    @PutMapping(path = "/{prefix}/{conceptCollectionIdentifier}", consumes = APPLICATION_JSON_VALUE)
+    public ResponseEntity<Void> update(
+            @PathVariable @Parameter(description = "Terminology prefix") String prefix,
+            @PathVariable @Parameter(description = "Concept collection identifier") String conceptCollectionIdentifier,
+            @RequestBody /* @ValidConceptCollection(update = true) */ ConceptCollectionDTO conceptCollection) {
+        conceptCollectionService.update(prefix, conceptCollectionIdentifier, conceptCollection);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Delete concept collection from terminology")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Concept collection deleted successfully"),
+            @ApiResponse(responseCode = "401", description = "Current user does not have rights for this terminology"),
+            @ApiResponse(responseCode = "404", description = "Terminology or concept collection was not found",
+                    content = {@Content(mediaType = APPLICATION_JSON_VALUE)}),
+    })
+    @DeleteMapping("/{prefix}/{conceptCollectionIdentifier}")
+    public ResponseEntity<Void> delete(@PathVariable @Parameter(description = "Terminology prefix") String prefix,
+                                       @PathVariable @Parameter(description = "Concept collection identifier") String conceptCollectionIdentifier) {
+        conceptCollectionService.delete(prefix, conceptCollectionIdentifier);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Check if concept collection with identifier exists in terminology")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Boolean value indicating whether concept collection exist")
+    })
+    @GetMapping("/{prefix}/{conceptCollectionIdentifier}/exists")
+    public Boolean exists(@PathVariable @Parameter(description = "Terminology prefix") String prefix,
+                          @PathVariable @Parameter(description = "Concept collection identifier") String conceptCollectionIdentifier) {
+        return conceptCollectionService.exists(
+                prefix,
+                conceptCollectionIdentifier);
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/ConceptCollectionController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/ConceptCollectionController.java
@@ -69,7 +69,7 @@ public class ConceptCollectionController {
     public ResponseEntity<Void> update(
             @PathVariable @Parameter(description = "Terminology prefix") String prefix,
             @PathVariable @Parameter(description = "Concept collection identifier") String conceptCollectionIdentifier,
-            @RequestBody /* @ValidConceptCollection(update = true) */ ConceptCollectionDTO conceptCollection) {
+            @RequestBody @ValidConceptCollection(update = true) ConceptCollectionDTO conceptCollection) {
         conceptCollectionService.update(prefix, conceptCollectionIdentifier, conceptCollection);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptCollectionMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptCollectionMapper.java
@@ -26,8 +26,7 @@ public class ConceptCollectionMapper {
             YtiUser user) {
         var modelResource = model.getModelResource();
         var conceptCollectionResource = model.createResourceWithId(dto.getIdentifier())
-                .addProperty(SKOS.inScheme,
-                        ResourceFactory.createResource(modelResource.getURI()))
+                .addProperty(SKOS.inScheme, modelResource)
                 .addProperty(RDF.type, SKOS.Collection);
 
         var languages = MapperUtils.arrayPropertyToSet(

--- a/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptCollectionMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptCollectionMapper.java
@@ -1,0 +1,143 @@
+package fi.vm.yti.terminology.api.v2.mapper;
+
+import fi.vm.yti.common.dto.ResourceCommonInfoDTO;
+import fi.vm.yti.common.util.MapperUtils;
+import fi.vm.yti.common.util.ModelWrapper;
+import fi.vm.yti.security.YtiUser;
+import fi.vm.yti.terminology.api.v2.dto.ConceptCollectionDTO;
+import fi.vm.yti.terminology.api.v2.dto.ConceptCollectionInfoDTO;
+import org.apache.jena.rdf.model.*;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFLanguages;
+import org.apache.jena.vocabulary.DCTerms;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
+import org.apache.jena.vocabulary.SKOS;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+public class ConceptCollectionMapper {
+
+    private ConceptCollectionMapper() {
+    }
+
+    public static void dtoToModel(
+            ModelWrapper model,
+            ConceptCollectionDTO dto,
+            YtiUser user) {
+        var modelResource = model.getModelResource();
+        var conceptCollectionResource = model.createResourceWithId(dto.getIdentifier())
+                .addProperty(SKOS.inScheme,
+                        ResourceFactory.createResource(modelResource.getURI()))
+                .addProperty(RDF.type, SKOS.Collection);
+
+        var languages = MapperUtils.arrayPropertyToSet(
+                modelResource,
+                DCTerms.language);
+
+        MapperUtils.addLocalizedProperty(
+                languages,
+                dto.getLabel(),
+                conceptCollectionResource,
+                SKOS.prefLabel);
+        MapperUtils.addLocalizedProperty(
+                languages,
+                dto.getDescription(),
+                conceptCollectionResource,
+                RDFS.comment);
+
+        var memberIdentifiers = dto.getMembers().stream().toList();
+        var conceptURIs = memberIdentifiers.stream()
+                .map(member -> modelResource.getNameSpace() + member)
+                .toList();
+        addListProperty(
+                conceptCollectionResource,
+                SKOS.member,
+                conceptURIs);
+
+        MapperUtils.addCreationMetadata(
+                conceptCollectionResource,
+                user);
+    }
+
+    public static void dtoToUpdateModel(
+            ModelWrapper model,
+            String conceptCollectionIdentifier,
+            ConceptCollectionDTO dto,
+            YtiUser user) {
+        var conceptCollectionResource = model.getResourceById(conceptCollectionIdentifier);
+
+        var languages = MapperUtils.arrayPropertyToSet(
+                model.getModelResource(),
+                DCTerms.language);
+        MapperUtils.addLocalizedProperty(
+                languages,
+                dto.getLabel(),
+                conceptCollectionResource,
+                SKOS.prefLabel);
+        MapperUtils.addLocalizedProperty(
+                languages,
+                dto.getDescription(),
+                conceptCollectionResource,
+                RDFS.comment);
+
+        conceptCollectionResource.removeAll(SKOS.member);
+        dto.getMembers().stream().forEach(conceptIdentifier -> {
+            var conceptResource = model.getResourceById(conceptIdentifier);
+            conceptCollectionResource.addProperty(SKOS.member, conceptResource);
+        });
+
+        MapperUtils.addUpdateMetadata(conceptCollectionResource, user);
+    }
+
+    public static ConceptCollectionInfoDTO modelToDTO(
+            ModelWrapper model,
+            String conceptCollectionIdentifier,
+            Consumer<ResourceCommonInfoDTO> mapUser) {
+        var resource = model.getResourceById(conceptCollectionIdentifier);
+        var dto = new ConceptCollectionInfoDTO();
+
+        dto.setIdentifier(resource.getLocalName());
+        dto.setUri(resource.getURI());
+
+        dto.setLabel(MapperUtils.localizedPropertyToMap(resource, SKOS.prefLabel));
+        dto.setDescription(MapperUtils.localizedPropertyToMap(resource, RDFS.comment));
+
+        MapperUtils.arrayPropertyToSet(
+                        resource,
+                        SKOS.member)
+                .stream()
+                .forEach((conceptUri) -> {
+                    var concept = model.getResourceById(
+                            conceptUri.substring(
+                                    conceptUri.lastIndexOf("/") + 1));
+                    var definition = MapperUtils.localizedPropertyToMap(concept, SKOS.definition);
+                    dto.addMember(
+                            concept.getLocalName(),
+                            definition);
+                });
+
+        MapperUtils.mapCreationInfo(dto, resource, mapUser);
+
+        return dto;
+    }
+
+    public static void mapDeleteConceptCollection(ModelWrapper model, String identifier) {
+        var resource = model.getResourceById(identifier);
+
+        model.removeAll(null, null, resource);
+        model.removeAll(resource, null, null);
+    }
+
+    private static void addListProperty(Resource resource, Property property, List<String> values) {
+        resource.removeAll(property);
+        if (values.isEmpty()) {
+            return;
+        }
+        var list = resource.getModel().createList(values.stream()
+                .map(ResourceFactory::createStringLiteral)
+                .iterator());
+        resource.addProperty(property, list);
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/service/ConceptCollectionService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/service/ConceptCollectionService.java
@@ -1,0 +1,140 @@
+package fi.vm.yti.terminology.api.v2.service;
+
+import fi.vm.yti.common.dto.ResourceCommonInfoDTO;
+import fi.vm.yti.common.exception.ResourceExistsException;
+import fi.vm.yti.common.exception.ResourceNotFoundException;
+import fi.vm.yti.common.service.AuditService;
+import fi.vm.yti.common.service.GroupManagementService;
+import fi.vm.yti.terminology.api.v2.dto.ConceptCollectionDTO;
+import fi.vm.yti.terminology.api.v2.dto.ConceptCollectionInfoDTO;
+import fi.vm.yti.terminology.api.v2.mapper.ConceptCollectionMapper;
+import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
+import fi.vm.yti.terminology.api.v2.security.TerminologyAuthorizationManager;
+import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.function.Consumer;
+
+import static fi.vm.yti.security.AuthorizationException.check;
+
+@Service
+public class ConceptCollectionService {
+    private final TerminologyRepository repository;
+    private final TerminologyAuthorizationManager authorizationManager;
+    private final IndexService indexService;
+    private final AuditService auditService;
+    private final GroupManagementService groupManagementService;
+
+    public ConceptCollectionService(TerminologyRepository repository,
+                                    TerminologyAuthorizationManager authorizationManager,
+                                    IndexService indexService,
+                                    GroupManagementService groupManagementService) {
+        this.repository = repository;
+        this.authorizationManager = authorizationManager;
+        this.indexService = indexService;
+        this.groupManagementService = groupManagementService;
+        this.auditService = new AuditService("CONCEPTCOLLECTION");
+    }
+
+    public ConceptCollectionInfoDTO get(String prefix, String conceptCollectionIdentifier) {
+        var model = repository.fetchByPrefix(prefix);
+
+        var resourceURI = TerminologyURI.createConceptCollectionURI(prefix, conceptCollectionIdentifier).getResourceURI();
+        if (!model.containsId(conceptCollectionIdentifier)) {
+            throw new ResourceNotFoundException(resourceURI);
+        }
+
+        Consumer<ResourceCommonInfoDTO> mapUser = null;
+        if (authorizationManager.hasRightsToTerminology(prefix, model)) {
+            mapUser = groupManagementService.mapUser();
+        }
+
+        return ConceptCollectionMapper.modelToDTO(
+                model,
+                conceptCollectionIdentifier,
+                mapUser);
+    }
+
+    public URI create(String prefix, ConceptCollectionDTO dto) throws URISyntaxException {
+        var model = repository.fetchByPrefix(prefix);
+        var user = authorizationManager.getUser();
+        check(authorizationManager.hasRightsToTerminology(prefix, model));
+
+        var resourceURI = TerminologyURI.createConceptCollectionURI(
+                prefix,
+                dto.getIdentifier()).getResourceURI();
+
+        if (repository.resourceExistsInGraph(model.getGraphURI(), resourceURI)) {
+            throw new ResourceExistsException(dto.getIdentifier(), model.getGraphURI());
+        }
+
+        ConceptCollectionMapper.dtoToModel(model, dto, user);
+
+        repository.put(model.getGraphURI(), model);
+
+        auditService.log(AuditService.ActionType.CREATE, resourceURI, user);
+
+        return new URI(resourceURI);
+    }
+
+    public void update(
+            String prefix,
+            String conceptCollectionIdentifier,
+            ConceptCollectionDTO dto) {
+        var model = repository.fetchByPrefix(prefix);
+        var user = authorizationManager.getUser();
+        check(authorizationManager.hasRightsToTerminology(prefix, model));
+
+        var resourceURI = TerminologyURI.createConceptCollectionURI(
+                        prefix,
+                        conceptCollectionIdentifier)
+                .getResourceURI();
+        if (!repository.resourceExistsInGraph(model.getGraphURI(), resourceURI)) {
+            throw new ResourceNotFoundException(resourceURI);
+        }
+
+        ConceptCollectionMapper.dtoToUpdateModel(
+                model,
+                conceptCollectionIdentifier,
+                dto,
+                user);
+
+        repository.put(model.getGraphURI(), model);
+
+        auditService.log(AuditService.ActionType.UPDATE, resourceURI, user);
+    }
+
+    public void delete(String prefix, String conceptCollectionIdentifier) {
+        var model = repository.fetchByPrefix(prefix);
+        check(authorizationManager.hasRightsToTerminology(prefix, model));
+
+        var resourceURI = TerminologyURI.createConceptCollectionURI(
+                        prefix,
+                        conceptCollectionIdentifier)
+                .getResourceURI();
+
+        if (!repository.resourceExistsInGraph(model.getGraphURI(), resourceURI)) {
+            throw new ResourceNotFoundException(resourceURI);
+        }
+
+        ConceptCollectionMapper.mapDeleteConceptCollection(
+                model,
+                conceptCollectionIdentifier);
+        repository.put(model.getGraphURI(), model);
+
+        auditService.log(
+                AuditService.ActionType.DELETE,
+                resourceURI, authorizationManager.getUser());
+    }
+
+    public boolean exists(String prefix, String conceptCollectionIdentifier) {
+        var u = TerminologyURI.createConceptCollectionURI(
+                prefix,
+                conceptCollectionIdentifier);
+        return repository.resourceExistsInGraph(
+                u.getGraphURI(),
+                u.getResourceURI());
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/util/TerminologyURI.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/util/TerminologyURI.java
@@ -27,6 +27,10 @@ public class TerminologyURI extends GraphURI {
         return new TerminologyURI(prefix, conceptId);
     }
 
+    public static TerminologyURI createConceptCollectionURI(String prefix, String conceptCollectionId) {
+        return new TerminologyURI(prefix, conceptCollectionId);
+    }
+
     private TerminologyURI(String prefix) {
         createModelURI(prefix, null);
     }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/validator/ConceptCollectionValidator.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/validator/ConceptCollectionValidator.java
@@ -1,0 +1,41 @@
+package fi.vm.yti.terminology.api.v2.validator;
+
+import fi.vm.yti.common.validator.BaseValidator;
+import fi.vm.yti.common.validator.ValidationConstants;
+import fi.vm.yti.terminology.api.v2.dto.ConceptCollectionDTO;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class ConceptCollectionValidator extends BaseValidator implements
+        ConstraintValidator<ValidConceptCollection, ConceptCollectionDTO> {
+
+    boolean update;
+
+    @Override
+    public void initialize(ValidConceptCollection constraintAnnotation) {
+        this.update = constraintAnnotation.update();
+    }
+
+    @Override
+    public boolean isValid(ConceptCollectionDTO value, ConstraintValidatorContext context) {
+        setConstraintViolationAdded(false);
+        checkConceptCollectionData(context, value);
+        return !isConstraintViolationAdded();
+    }
+
+    private void checkConceptCollectionData(ConstraintValidatorContext context, ConceptCollectionDTO dto) {
+        if (update && dto.getIdentifier() != null) {
+            addConstraintViolation(context, ValidationConstants.MSG_NOT_ALLOWED_UPDATE, "identifier");
+        } else {
+            checkResourceIdentifier(context, dto.getIdentifier(), update);
+        }
+
+        dto.getLabel().forEach((key, value) -> checkCommonTextArea(context, value, "label"));
+        dto.getDescription().forEach((key, value) -> checkCommonTextArea(context, value, "description"));
+
+        dto.getMembers().forEach(member -> {
+            checkHasValue(context, member, "members");
+            checkNotNull(context, member, "members");
+        });
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/validator/ConceptCollectionValidator.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/validator/ConceptCollectionValidator.java
@@ -30,7 +30,7 @@ public class ConceptCollectionValidator extends BaseValidator implements
             checkResourceIdentifier(context, dto.getIdentifier(), update);
         }
 
-        dto.getLabel().forEach((key, value) -> checkCommonTextArea(context, value, "label"));
+        dto.getLabel().forEach((key, value) -> checkCommonTextField(context, value, "label"));
         dto.getDescription().forEach((key, value) -> checkCommonTextArea(context, value, "description"));
 
         dto.getMembers().forEach(member -> {

--- a/src/main/java/fi/vm/yti/terminology/api/v2/validator/ValidConceptCollection.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/validator/ValidConceptCollection.java
@@ -1,0 +1,28 @@
+package fi.vm.yti.terminology.api.v2.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({
+        ElementType.METHOD,
+        ElementType.FIELD,
+        ElementType.CONSTRUCTOR,
+        ElementType.PARAMETER,
+        ElementType.TYPE_USE
+})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ConceptCollectionValidator.class)
+public @interface ValidConceptCollection {
+    String message() default "Invalid data";
+
+    Class<?>[] groups() default {};
+
+    boolean update() default false;
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/test/java/fi/vm/yti/terminology/api/v2/TestUtils.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/TestUtils.java
@@ -10,6 +10,7 @@ import fi.vm.yti.security.YtiUser;
 import fi.vm.yti.terminology.api.v2.dto.*;
 import fi.vm.yti.terminology.api.v2.enums.*;
 import fi.vm.yti.terminology.api.v2.mapper.ConceptMapper;
+import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFLanguages;
@@ -117,13 +118,17 @@ public class TestUtils {
         return dto;
     }
 
-    public static ConceptCollectionDTO getConceptCollectionData() {
+    public static ConceptCollectionDTO getConceptCollectionData(String prefix) {
         var dto = new ConceptCollectionDTO();
         dto.setIdentifier("collection-1");
         dto.setLabel(Map.of("en", "collection label"));
         dto.setDescription(Map.of("en", "collection description"));
-        dto.addMember("concept-1");
-        dto.addMember("concept-2");
+        dto.addMember(TerminologyURI
+                .createConceptURI(prefix, "concept-1")
+                .getResourceURI());
+        dto.addMember(TerminologyURI
+                .createConceptURI(prefix, "concept-2")
+                .getResourceURI());
 
         return dto;
     }

--- a/src/test/java/fi/vm/yti/terminology/api/v2/TestUtils.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/TestUtils.java
@@ -7,10 +7,7 @@ import fi.vm.yti.common.enums.Status;
 import fi.vm.yti.common.util.ModelWrapper;
 import fi.vm.yti.security.Role;
 import fi.vm.yti.security.YtiUser;
-import fi.vm.yti.terminology.api.v2.dto.ConceptDTO;
-import fi.vm.yti.terminology.api.v2.dto.ConceptReferenceDTO;
-import fi.vm.yti.terminology.api.v2.dto.LocalizedValueDTO;
-import fi.vm.yti.terminology.api.v2.dto.TermDTO;
+import fi.vm.yti.terminology.api.v2.dto.*;
 import fi.vm.yti.terminology.api.v2.enums.*;
 import fi.vm.yti.terminology.api.v2.mapper.ConceptMapper;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -116,6 +113,17 @@ public class TestUtils {
         dto.setReferences(references);
 
         dto.setTerms(Set.of(getTermDTO()));
+
+        return dto;
+    }
+
+    public static ConceptCollectionDTO getConceptCollectionData() {
+        var dto = new ConceptCollectionDTO();
+        dto.setIdentifier("collection-1");
+        dto.setLabel(Map.of("en", "collection label"));
+        dto.setDescription(Map.of("en", "collection description"));
+        dto.addMember("concept-1");
+        dto.addMember("concept-2");
 
         return dto;
     }

--- a/src/test/java/fi/vm/yti/terminology/api/v2/endpoint/ConceptCollectionControllerTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/endpoint/ConceptCollectionControllerTest.java
@@ -111,7 +111,7 @@ public class ConceptCollectionControllerTest {
     void shouldValidateAndUpdate() throws Exception {
         var modelPrefix = "test";
         var conceptCollectionDTO = getConceptCollectionData(modelPrefix);
-        conceptCollectionDTO.setIdentifier("collection-1");
+        conceptCollectionDTO.setIdentifier(null);
 
         this.mvc
                 .perform(put(String.format("/v2/collection/%s/collection-1", modelPrefix))
@@ -162,8 +162,7 @@ public class ConceptCollectionControllerTest {
 
     @ParameterizedTest
     @MethodSource("provideInvalidConceptCollectionCreateData")
-    void shouldInvalidateConceptCollectionOnCreation(
-            ConceptCollectionControllerTest.ConceptCollectionWithError data) throws Exception {
+    void shouldInvalidateConceptCollectionOnCreation(ConceptCollectionWithError data) throws Exception {
 
         this.mvc
                 .perform(post("/v2/collection/test")
@@ -175,23 +174,36 @@ public class ConceptCollectionControllerTest {
         verifyNoMoreInteractions(this.conceptCollectionService);
     }
 
-    public static ArrayList<ConceptCollectionControllerTest.ConceptCollectionWithError> provideInvalidConceptCollectionCreateData() {
-        var args = new ArrayList<ConceptCollectionControllerTest.ConceptCollectionWithError>();
+    @ParameterizedTest
+    @MethodSource("provideInvalidConceptCollectionUpdateData")
+    void shouldInvalidateConceptCollectionOnUpdate(ConceptCollectionWithError data) throws Exception {
+        this.mvc
+                .perform(put("/v2/collection/test/collection-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(data.dto)))
+                .andExpect(content().string(containsString(data.error())))
+                .andExpect(status().isBadRequest());
+
+        verifyNoMoreInteractions(this.conceptCollectionService);
+    }
+
+    public static ArrayList<ConceptCollectionWithError> provideInvalidConceptCollectionCreateData() {
+        var args = new ArrayList<ConceptCollectionWithError>();
 
         var dto = getConceptCollectionData("test");
         dto.setIdentifier(null);
-        args.add(new ConceptCollectionControllerTest.ConceptCollectionWithError("should-have-value", dto));
+        args.add(new ConceptCollectionWithError("should-have-value", dto));
 
         args.addAll(provideInvalidConceptCollectionData());
 
         return args;
     }
 
-    public static ArrayList<ConceptCollectionControllerTest.ConceptCollectionWithError> provideInvalidConceptCollectionUpdateData() {
+    public static ArrayList<ConceptCollectionWithError> provideInvalidConceptCollectionUpdateData() {
         var args = new ArrayList<ConceptCollectionWithError>();
 
         var dto = getConceptCollectionData("test");
-        args.add(new ConceptCollectionControllerTest.ConceptCollectionWithError("not-allowed-update", dto));
+        args.add(new ConceptCollectionWithError("not-allowed-update", dto));
 
         provideInvalidConceptCollectionData().forEach(data -> {
             data.dto.setIdentifier(null);
@@ -200,7 +212,7 @@ public class ConceptCollectionControllerTest {
         return args;
     }
 
-    public static ArrayList<ConceptCollectionControllerTest.ConceptCollectionWithError> provideInvalidConceptCollectionData() {
+    public static ArrayList<ConceptCollectionWithError> provideInvalidConceptCollectionData() {
         var args = new ArrayList<ConceptCollectionWithError>();
 
         var longTextField = RandomStringUtils.randomAlphabetic(ValidationConstants.TEXT_FIELD_MAX_LENGTH + 1);
@@ -208,11 +220,11 @@ public class ConceptCollectionControllerTest {
 
         var dto = getConceptCollectionData("test");
         dto.setLabel(Map.of("en", longTextField));
-        args.add(new ConceptCollectionControllerTest.ConceptCollectionWithError("value-over-character-limit", dto));
+        args.add(new ConceptCollectionWithError("value-over-character-limit", dto));
 
         dto = getConceptCollectionData("test");
         dto.setDescription(Map.of("en", longTextArea));
-        args.add(new ConceptCollectionControllerTest.ConceptCollectionWithError("value-over-character-limit", dto));
+        args.add(new ConceptCollectionWithError("value-over-character-limit", dto));
 
         return args;
     }

--- a/src/test/java/fi/vm/yti/terminology/api/v2/endpoint/ConceptCollectionControllerTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/endpoint/ConceptCollectionControllerTest.java
@@ -1,0 +1,146 @@
+package fi.vm.yti.terminology.api.v2.endpoint;
+
+import fi.vm.yti.common.repository.CommonRepository;
+import fi.vm.yti.common.service.GroupManagementService;
+import fi.vm.yti.terminology.api.v2.dto.ConceptCollectionDTO;
+import fi.vm.yti.terminology.api.v2.dto.ConceptCollectionInfoDTO;
+import fi.vm.yti.terminology.api.v2.dto.ConceptInfoDTO;
+import fi.vm.yti.terminology.api.v2.exception.TerminologyExceptionHandlerAdvice;
+import fi.vm.yti.terminology.api.v2.service.ConceptCollectionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.net.URI;
+import java.util.Set;
+
+import static fi.vm.yti.terminology.api.v2.TestUtils.asJsonString;
+import static fi.vm.yti.terminology.api.v2.TestUtils.getConceptCollectionData;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ConceptCollectionController.class)
+@ActiveProfiles("test")
+public class ConceptCollectionControllerTest {
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private CommonRepository commonRepository;
+
+    @MockBean
+    private GroupManagementService groupManagementService;
+
+    @MockBean
+    private ConceptCollectionService conceptCollectionService;
+
+    @Autowired
+    ConceptCollectionController conceptCollectionController;
+
+    @BeforeEach
+    public void setup() {
+        this.mvc = MockMvcBuilders
+                .standaloneSetup(this.conceptCollectionController)
+                .setControllerAdvice(new TerminologyExceptionHandlerAdvice())
+                .build();
+    }
+
+    @Test
+    void shouldValidateAndCreate() throws Exception {
+        var conceptCollectionDTO = getConceptCollectionData();
+
+        URI conceptCollectionURI = new URI(
+                "https://iri.suomi.fi/terminology/test/collection-1");
+        when(conceptCollectionService.create(
+                eq("test"),
+                any(ConceptCollectionDTO.class))).thenReturn(conceptCollectionURI);
+
+        this.mvc
+                .perform(post("/v2/collection/test")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(conceptCollectionDTO)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(
+                        "Location",
+                        conceptCollectionURI.toString()));
+
+        verify(conceptCollectionService).create(
+                eq("test"),
+                any(ConceptCollectionDTO.class));
+        verify(conceptCollectionService).create(
+                eq("test"),
+                argThat(dto -> {
+                    if (!dto.getIdentifier().equals("collection-1")) {
+                        return false;
+                    }
+                    if (!dto.getMembers().containsAll(
+                            Set.of("concept-1", "concept-2"))) {
+                        return false;
+                    }
+                    return true;
+                }));
+        verifyNoMoreInteractions(this.conceptCollectionService);
+    }
+
+    @Test
+    void shouldValidateAndUpdate() throws Exception {
+        var conceptCollectionDTO = getConceptCollectionData();
+        conceptCollectionDTO.setIdentifier("collection-1");
+
+        this.mvc
+                .perform(put("/v2/collection/test/collection-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(conceptCollectionDTO)))
+                .andExpect(status().isNoContent());
+        verify(conceptCollectionService).update(
+                eq("test"),
+                eq("collection-1"),
+                any(ConceptCollectionDTO.class));
+        verifyNoMoreInteractions(this.conceptCollectionService);
+    }
+
+    @Test
+    void shouldGetConceptCollection() throws Exception {
+        when(conceptCollectionService.get(
+                "test",
+                "collection-1"))
+                .thenReturn(new ConceptCollectionInfoDTO());
+
+        this.mvc
+                .perform(get("/v2/collection/test/collection-1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldDeleteConceptCollection() throws Exception {
+        this.mvc
+                .perform(delete("/v2/collection/test/collection-1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+
+        verify(conceptCollectionService).delete(
+                "test",
+                "collection-1");
+    }
+
+    @Test
+    void shouldCheckConceptCollectionExists() throws Exception {
+        this.mvc
+                .perform(get("/v2/collection/test/collection-1/exists")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        verify(conceptCollectionService).exists("test", "collection-1");
+    }
+}

--- a/src/test/java/fi/vm/yti/terminology/api/v2/service/ConceptCollectionServiceTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/service/ConceptCollectionServiceTest.java
@@ -1,0 +1,280 @@
+package fi.vm.yti.terminology.api.v2.service;
+
+import fi.vm.yti.common.exception.ResourceExistsException;
+import fi.vm.yti.common.exception.ResourceNotFoundException;
+import fi.vm.yti.common.service.GroupManagementService;
+import fi.vm.yti.common.util.ModelWrapper;
+import fi.vm.yti.security.AuthorizationException;
+import fi.vm.yti.terminology.api.v2.TestUtils;
+import fi.vm.yti.terminology.api.v2.dto.ConceptCollectionDTO;
+import fi.vm.yti.terminology.api.v2.opensearch.IndexConcept;
+import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
+import fi.vm.yti.terminology.api.v2.security.TerminologyAuthorizationManager;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.vocabulary.SKOS;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
+
+import java.net.URISyntaxException;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@Import({
+        ConceptCollectionService.class,
+})
+public class ConceptCollectionServiceTest {
+    @MockBean
+    TerminologyRepository repository;
+
+    @MockBean
+    TerminologyAuthorizationManager authorizationManager;
+
+    @MockBean
+    IndexService indexService;
+
+    @MockBean
+    GroupManagementService groupManagementService;
+
+    @Captor
+    ArgumentCaptor<Model> modelCaptor;
+
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+    @Autowired
+    ConceptCollectionService conceptCollectionService;
+
+    @BeforeEach
+    void setUp() {
+        when(authorizationManager.getUser()).thenReturn(TestUtils.mockUser);
+        when(authorizationManager.hasRightsToTerminology(eq("test"), any(ModelWrapper.class))).thenReturn(true);
+    }
+
+    @Test
+    void testGetConceptCollection() {
+        var conceptCollectionURI = TerminologyURI.createConceptCollectionURI(
+                "test",
+                "collection-1");
+        var model = TestUtils.getModelFromFile(
+                "/terminology-with-concept-collections.ttl",
+                conceptCollectionURI.getGraphURI());
+
+        when(authorizationManager.hasRightsToTerminology(eq(conceptCollectionURI.getPrefix()), any(Model.class))).thenReturn(true);
+        when(repository.fetchByPrefix(conceptCollectionURI.getPrefix())).thenReturn(model);
+        when(groupManagementService.mapUser()).thenReturn(TestUtils.mapUser);
+
+        var dto = conceptCollectionService.get(
+                conceptCollectionURI.getPrefix(),
+                conceptCollectionURI.getResourceId());
+
+        assertFalse(dto.getLabel().isEmpty());
+        assertFalse(dto.getDescription().isEmpty());
+
+        // only authenticated user should see this information
+        assertNotNull(dto.getCreator().getName());
+        assertNotNull(dto.getModifier().getName());
+    }
+
+    @Test
+    void testGetConceptCollectionNotAuthenticated() {
+        var conceptCollectionURI = TerminologyURI.createConceptCollectionURI(
+                "test",
+                "collection-1");
+        var model = TestUtils.getModelFromFile(
+                "/terminology-with-concept-collections.ttl",
+                conceptCollectionURI.getGraphURI());
+
+        when(authorizationManager.hasRightsToTerminology(
+                eq(conceptCollectionURI.getPrefix()),
+                any(Model.class)))
+                .thenReturn(false);
+        when(repository.fetchByPrefix(conceptCollectionURI.getPrefix())).thenReturn(model);
+        when(groupManagementService.mapUser()).thenReturn(TestUtils.mapUser);
+
+        var dto = conceptCollectionService.get(
+                conceptCollectionURI.getPrefix(),
+                conceptCollectionURI.getResourceId());
+
+        assertFalse(dto.getLabel().isEmpty());
+        assertFalse(dto.getDescription().isEmpty());
+
+        // only authenticated user should see this information
+        assertNull(dto.getCreator().getName());
+        assertNull(dto.getModifier().getName());
+    }
+
+    @Test
+    void testGetConceptCollectionNotFound() {
+        var conceptCollectionURI = TerminologyURI.createConceptCollectionURI(
+                "test",
+                "collection-1");
+        var model = TestUtils.getModelFromFile(
+                "/terminology-with-concept-collections.ttl",
+                conceptCollectionURI.getGraphURI());
+        when(repository.fetchByPrefix(conceptCollectionURI.getPrefix()))
+                .thenReturn(model);
+
+        assertThrows(
+                ResourceNotFoundException.class,
+                () -> conceptCollectionService.get(
+                        "test",
+                        "foo"));
+    }
+
+    @Test
+    void testCreateConceptCollection() throws URISyntaxException {
+        var conceptCollectionURI = TerminologyURI.createConceptCollectionURI(
+                "test",
+                "collection-1");
+        var model = new ModelWrapper(
+                ModelFactory.createDefaultModel(),
+                conceptCollectionURI.getGraphURI());
+        when(repository.fetchByPrefix(conceptCollectionURI.getPrefix())).thenReturn(model);
+        when(repository.resourceExistsInGraph(
+                conceptCollectionURI.getGraphURI(),
+                conceptCollectionURI.getResourceURI()))
+                .thenReturn(false);
+
+        var dto = new ConceptCollectionDTO();
+        dto.setIdentifier(conceptCollectionURI.getResourceId());
+
+        dto.addMember("concept-1");
+        dto.addMember("concept-2");
+
+        conceptCollectionService.create(conceptCollectionURI.getPrefix(), dto);
+
+        verify(repository).put(
+                eq(conceptCollectionURI.getGraphURI()),
+                modelCaptor.capture());
+
+        var updatedModel = modelCaptor.getValue();
+
+        assertTrue(updatedModel.getResource(
+                conceptCollectionURI.getResourceURI())
+                .listProperties().hasNext());
+    }
+
+    @Test
+    void testCreateConceptCollectionExists() {
+        var conceptCollectionURI = TerminologyURI.createConceptCollectionURI(
+                "test",
+                "collection-1");
+        var model = new ModelWrapper(
+                ModelFactory.createDefaultModel(),
+                conceptCollectionURI.getGraphURI());
+        when(repository.fetchByPrefix(
+                conceptCollectionURI.getPrefix()))
+                .thenReturn(model);
+        when(repository.resourceExistsInGraph(
+                conceptCollectionURI.getGraphURI(),
+                conceptCollectionURI.getResourceURI()))
+                .thenReturn(true);
+
+        var dto = new ConceptCollectionDTO();
+        dto.setIdentifier(conceptCollectionURI.getResourceId());
+
+        assertThrows(
+                ResourceExistsException.class,
+                () -> conceptCollectionService.create("test", dto));
+
+        verify(repository,
+                times(0)).put(eq("test"),
+                any(Model.class));
+        verifyNoMoreInteractions(indexService);
+    }
+
+    @Test
+    void testCreateConceptCollectionGraphNotExists() {
+        var prefix = "test456";
+        var conceptCollectionURI = TerminologyURI.createConceptCollectionURI(
+                prefix,
+                "collection-1");
+        when(repository.fetchByPrefix(prefix)).thenThrow(ResourceNotFoundException.class);
+        when(repository.resourceExistsInGraph(
+                conceptCollectionURI.getGraphURI(),
+                conceptCollectionURI.getResourceURI())).thenReturn(false);
+
+        var dto = new ConceptCollectionDTO();
+        dto.setIdentifier(conceptCollectionURI.getResourceId());
+
+        assertThrows(
+                ResourceNotFoundException.class,
+                () -> conceptCollectionService.create(prefix, dto));
+
+        verify(repository,
+                times(0)).put(eq(prefix),
+                any(Model.class));
+        verifyNoMoreInteractions(indexService);
+    }
+
+    @Test
+    void testCreateConceptCollectionNotAuthorized() {
+        when(authorizationManager.hasRightsToTerminology(
+                eq("test"),
+                any(Model.class)))
+                .thenReturn(false);
+
+        var dto = new ConceptCollectionDTO();
+        dto.setIdentifier("collection-1");
+
+        assertThrows(
+                AuthorizationException.class,
+                () -> conceptCollectionService.create("test", dto));
+
+        verify(repository, times(0)).put(
+                eq("test"),
+                any(Model.class));
+    }
+
+    @Test
+    void testUpdateConceptCollection() {
+        var conceptCollectionURI = TerminologyURI.createConceptCollectionURI(
+                "test",
+                "collection-1");
+        var model = new ModelWrapper(
+                ModelFactory.createDefaultModel(),
+                conceptCollectionURI.getGraphURI());
+
+        model.createResourceWithId(conceptCollectionURI.getResourceId())
+                .addProperty(
+                        SKOS.member,
+                        model.createList(
+                                Stream.of("concept-1", "concept-2")
+                                        .map(ResourceFactory::createStringLiteral)
+                                        .iterator()));
+
+        when(repository.fetchByPrefix(conceptCollectionURI.getPrefix()))
+                .thenReturn(model);
+        when(repository.resourceExistsInGraph(
+                conceptCollectionURI.getGraphURI(),
+                conceptCollectionURI.getResourceURI()))
+                .thenReturn(true);
+
+        var dto = new ConceptCollectionDTO();
+        dto.setIdentifier(conceptCollectionURI.getResourceId());
+        dto.addMember("concept-3");
+        dto.addMember("concept-4");
+
+        conceptCollectionService.update(
+                conceptCollectionURI.getPrefix(),
+                conceptCollectionURI.getResourceId(),
+                dto);
+
+        verify(repository).put(eq(conceptCollectionURI.getGraphURI()), modelCaptor.capture());
+
+        var updatedResource = modelCaptor.getValue().getResource(conceptCollectionURI.getResourceURI());
+    }
+}

--- a/src/test/resources/terminology-with-concept-collections.ttl
+++ b/src/test/resources/terminology-with-concept-collections.ttl
@@ -1,0 +1,115 @@
+@prefix dcap:       <http://purl.org/ws-mmi-dc/terms/> .
+@prefix dcterms:    <http://purl.org/dc/terms/> .
+@prefix foaf:       <http://xmlns.com/foaf/0.1/> .
+@prefix owl:        <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:       <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh:         <http://www.w3.org/ns/shacl#> .
+@prefix skos:       <http://www.w3.org/2004/02/skos/core#> .
+@prefix skos-xl:    <http://www.w3.org/2008/05/skos-xl#> .
+@prefix suomi-meta: <https://iri.suomi.fi/model/suomi-meta/> .
+@prefix term:       <https://iri.suomi.fi/model/term/> .
+@prefix test:       <https://iri.suomi.fi/terminology/test/> .
+@prefix xsd:        <http://www.w3.org/2001/XMLSchema#> .
+
+# Terminology metadata
+
+test:   rdf:type                      skos:ConceptScheme;
+        dcterms:contributor           <urn:uuid:8d610719-105a-48fd-a4ce-ebef26bc5776>;
+        dcterms:isPartOf              <http://urn.fi/URN:NBN:fi:au:ptvl:v1105>;
+        dcterms:language              "en" , "fi";
+        dcap:preferredXMLNamespace    "https://iri.suomi.fi/terminology/test/";
+        dcap:preferredXMLNamespacePrefix
+                "test";
+        skos:prefLabel                "Sanaston nimi modified"@fi , "Test mod"@en;
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID";
+        term:terminologyType          "TERMINOLOGICAL_VOCABULARY" .
+
+# Concept collection containing concept-1 and concept-2
+
+test:collection-1   rdf:type    skos:Collection;
+                    skos:member test:concept-1, test:concept-2;
+        skos:prefLabel                "Testikokoelma 1"@fi , "Test collection 1"@en;
+        rdfs:comment                  "Test collection description 1"@en , "Testikokoelman kuvaus 1"@fi;
+        dcterms:created               "2024-05-15T05:00:00.000Z"^^xsd:dateTime;
+        dcterms:modified              "2024-05-16T04:00:00.000Z"^^xsd:dateTime;
+        suomi-meta:creator            "23006bf4-4c09-4438-8224-785fdf108812";
+        suomi-meta:modifier           "23006bf4-4c09-4438-8224-785fdf108812" .
+
+# Concept 1 with terms
+
+test:concept-1  rdfs:seeAlso          [ dcterms:description  "description"@fi;
+                                        dcterms:title        "link 1"@fi;
+                                        foaf:homepage        "https://dvv.fi"
+                                      ];
+        dcterms:created               "2024-05-06T05:00:00.000Z"^^xsd:dateTime;
+        dcterms:modified              "2024-05-07T04:00:00.000Z"^^xsd:dateTime;
+        skos:altLabel                 test:term-f04ce627-c799-4e9a-9b0c-71b65f69130b , test:term-ce6c2547-261f-46e1-9cba-662f886df7f6;
+        skos:broader                  test:concept-2;
+        skos:changeNote               "change";
+        skos:definition               "def"@fi;
+        skos:editorialNote            ( "editorial" );
+        skos:example                  ( "example"@fi );
+        skos:hiddenLabel              test:term-45f21a97-4bae-42ee-b7c5-c1d871ee9c2a;
+        skos:historyNote              "history";
+        skos:inScheme                 test:;
+        skos:note                     ( "note"@fi );
+        skos:prefLabel                test:term-614007ae-5d84-45d8-b473-6359c3cbc5ca;
+        suomi-meta:creator            "23006bf4-4c09-4438-8224-785fdf108812";
+        suomi-meta:modifier           "23006bf4-4c09-4438-8224-785fdf108812";
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT";
+        term:conceptClass             "concept class";
+        term:notRecommendedSynonym    test:term-47d79614-d8f5-4c42-8967-a860c3451f5b;
+        term:source                   ( "source" );
+        term:subjectArea              "subject area"@fi .
+
+test:term-614007ae-5d84-45d8-b473-6359c3cbc5ca
+         rdf:type                      skos-xl:Label;
+         skos:changeNote               "term change";
+         skos:historyNote              "term history";
+         skos-xl:literalForm           "Suositettava termi"@fi;
+         suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT";
+         term:homographNumber          2;
+         term:scope                    "scope";
+         term:termConjugation          "SINGULAR";
+         term:termEquivalency          "BROADER";
+         term:termFamily               "NEUTRAL";
+         term:termInfo                 "info";
+         term:termStyle                "term style";
+         term:wordClass                "ADJECTIVE" .
+
+test:term-f04ce627-c799-4e9a-9b0c-71b65f69130b
+        rdf:type                      skos-xl:Label;
+        skos-xl:literalForm           "synonyymi 1"@fi;
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT" .
+
+test:term-ce6c2547-261f-46e1-9cba-662f886df7f6
+        rdf:type                      skos-xl:Label;
+        skos-xl:literalForm           "synonyymi 2"@fi;
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT" .
+
+test:term-47d79614-d8f5-4c42-8967-a860c3451f5b
+        rdf:type                      skos-xl:Label;
+        skos-xl:literalForm           "ei suositettava"@fi;
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT" .
+
+test:term-45f21a97-4bae-42ee-b7c5-c1d871ee9c2a
+        rdf:type                      skos-xl:Label;
+        skos-xl:literalForm           "hakutermi"@fi;
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT" .
+
+# Concept 2 with term
+
+test:concept-2
+        dcterms:created               "2024-05-02T11:00:00.000Z"^^xsd:dateTime;
+        dcterms:modified              "2024-05-03T12:00:00.000Z"^^xsd:dateTime;
+        suomi-meta:creator            "23006bf4-4c09-4438-8224-785fdf108812";
+        suomi-meta:modifier           "23006bf4-4c09-4438-8224-785fdf108812";
+        skos:inScheme                 test:;
+        skos:prefLabel                test:term-4429d6a0-1aba-4964-a2c0-972a13409b2f;
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT" .
+
+test:term-4429d6a0-1aba-4964-a2c0-972a13409b2f
+        rdf:type                      skos-xl:Label;
+        skos-xl:literalForm           "Suositettava termi"@fi;
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT" .


### PR DESCRIPTION
* basic end points for get/add/update/delete/exists
* each collection may contain a number of "members", which point to concepts
* When adding or updating, members should be just strings, e.g.: `[ "concept-1", "concept-2" ]`
* When retreiving a collection, concepts will contain some extra details from concept, but not a full concept
* **Indexing is not yet implemented!**

### Example queries using curl

```sh
# Create new collection
"$BASE_URL/terminology-api/v2/collection/urhotest1" \
  -X POST \
  -H 'Content-Type: application/json' \
  -H "Authorization: Bearer $APIKEY" \
  --data-binary @- << EOF
{
    "identifier": "collection-1",
    "label": {
        "fi": "Testikokoelma 1",
        "en": "Test collection 1"
    },
    "description": 7
        "fi": "Testikokoelman kuvaus 1",
        "en": "Test collection description 1"
    },
    "members": [ "concept-1", "concept-2" ]
}
EOF
```

```sh
# Fetch collection
curl -sS "$BASE_URL/terminology-api/v2/collection/urhotest1/collection-1" \
  -H 'Content-Type: application/json'
```

```sh
# Modify collection
curl -sS "$BASE_URL/terminology-api/v2/collection/urhotest1/collection-1" \
  -X PUT \
  -H 'Content-Type: application/json' \
  -H "Authorization: Bearer $APIKEY" \
  --data-binary @- << EOF
{
    "identifier": "collection-1",
    "label": {
        "en": "Test collection 1 A"
    },
    "description": {
        "en": "Test collection description 1 A"
    },
    "members": [ "concept-1", "concept-2" ]
}
EOF
```