### PR TITLE
YTI-3951 terminology & concept search

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/v2/StartUpListener.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/StartUpListener.java
@@ -19,7 +19,8 @@ public class StartUpListener {
 
     @Autowired
     StartUpListener(MigrationInitializer migrationInitializer,
-                    IndexService indexService, GroupManagementService groupManagementService) {
+                    IndexService indexService,
+                    GroupManagementService groupManagementService) {
         this.indexService = indexService;
         this.groupManagementService = groupManagementService;
         // TODO: should start migration automatically. Imports javax.* should be changed to jakarta.* in yti-spring-migration

--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptSearchResultDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptSearchResultDTO.java
@@ -1,0 +1,6 @@
+package fi.vm.yti.terminology.api.v2.dto;
+
+import fi.vm.yti.terminology.api.v2.opensearch.IndexConcept;
+
+public class ConceptSearchResultDTO extends IndexConcept {
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/TerminologySearchResultDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/TerminologySearchResultDTO.java
@@ -1,0 +1,26 @@
+package fi.vm.yti.terminology.api.v2.dto;
+
+import fi.vm.yti.terminology.api.v2.opensearch.IndexTerminology;
+
+import java.util.List;
+
+public class TerminologySearchResultDTO extends IndexTerminology {
+    public TerminologySearchResultDTO() {
+        this.setMatchingConcepts(new java.util.ArrayList<>());
+    }
+
+    // matching concepts from deep search
+    private List<ConceptSearchResultDTO> matchingConcepts;
+
+    public List<ConceptSearchResultDTO> getMatchingConcepts() {
+        return matchingConcepts;
+    }
+
+    public void setMatchingConcepts(List<ConceptSearchResultDTO> matchingConcepts) {
+        this.matchingConcepts = matchingConcepts;
+    }
+
+    public void addMatchingConcept(ConceptSearchResultDTO concept) {
+        this.matchingConcepts.add(concept);
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapper.java
@@ -161,6 +161,7 @@ public class ConceptMapper {
         indexConcept.setId(resource.getURI());
         indexConcept.setUri(resource.getURI());
         indexConcept.setStatus(MapperUtils.getStatus(resource));
+        indexConcept.setNamespace(resource.getNameSpace());
         indexConcept.setLabel(prefLabels);
         indexConcept.setAltLabel(getIndexedTerm(model, resource, SKOS.altLabel));
         indexConcept.setNotRecommendedSynonym(getIndexedTerm(model, resource, Term.notRecommendedSynonym));

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptQueryFactory.java
@@ -1,0 +1,124 @@
+package fi.vm.yti.terminology.api.v2.opensearch;
+
+import fi.vm.yti.common.opensearch.QueryFactoryUtils;
+import fi.vm.yti.terminology.api.v2.service.IndexService;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.query_dsl.*;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.search.Highlight;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static fi.vm.yti.common.opensearch.OpenSearchUtil.logPayload;
+
+public class ConceptQueryFactory {
+    public ConceptQueryFactory() {
+    }
+
+    public static SearchRequest createConceptQuery(
+            ConceptSearchRequest request,
+            boolean isSuperUser,
+            // concept search needs a list of terminologies, since the
+            // organizations themselves are not in the concept index
+            Set<String> incompleteFromTerminologies) {
+
+        var conceptQuery = getConceptBaseQuery(request, isSuperUser, incompleteFromTerminologies);
+
+        Highlight.Builder highlight = new Highlight.Builder();
+        highlight.fields("definition.*", f -> f);
+        var sr = new SearchRequest.Builder()
+                .index(IndexService.CONCEPT_INDEX)
+                .size(QueryFactoryUtils.pageSize(request.getPageSize()))
+                .from(QueryFactoryUtils.pageFrom(request.getPageFrom()))
+                .sort(QueryFactoryUtils.getLangSortOptions(request.getSortLang()))
+                .highlight(highlight.build())
+                .query(conceptQuery)
+                .build();
+
+        logPayload(sr, IndexService.CONCEPT_INDEX);
+
+        return sr;
+    }
+
+    private static Query getConceptBaseQuery(
+            ConceptSearchRequest request,
+            boolean isSuperUser,
+            Set<String> incompleteFromTerminologies) {
+
+        var allQueries = new ArrayList<Query>();
+
+        var queryString = request.getQuery();
+        if (queryString != null && !queryString.isBlank()) {
+            var definitionQuery = QueryStringQuery.of(q -> q
+                    .query("*" + queryString.trim() + "*")
+                    .fields("label.*").boost(5.0f)
+                    .fields("altLabel.*", "searchTerm.*", "hiddenTerm.*", "definition.*").boost(3.0f)
+                    .fields("notRecommendedSynonym.*").boost(1.5f)
+                    .fuzziness("2")
+            ).toQuery();
+
+            allQueries.add(QueryBuilders.bool()
+                    .should(definitionQuery)
+                    .minimumShouldMatch("1")
+                    .build()
+                    .toQuery());
+        }
+
+        if (request.getStatus() != null) {
+            allQueries.add(TermsQuery.of(q -> q
+                            .field("status")
+                            .terms(t -> t.value(request
+                                    .getStatus()
+                                    .stream()
+                                    .map(Enum::name)
+                                    .map(FieldValue::of)
+                                    .toList())))
+                    .toQuery());
+        }
+
+        if (request.getNamespace() != null) {
+            allQueries.add(TermQuery.of(q -> q
+                            .field("namespace")
+                            .value(FieldValue.of(request.getNamespace())))
+                    .toQuery());
+        }
+
+        if (!isSuperUser) {
+            // if the user is not superuser, filter out INCOMPLETE
+            var draftQuery = QueryBuilders.bool()
+                    .mustNot(TermsQuery.of(q -> q
+                                    .field("status")
+                                    .terms(t -> t.value(List.of("INCOMPLETE")
+                                            .stream()
+                                            .map(FieldValue::of)
+                                            .toList())))
+                            .toQuery())
+                    .build()
+                    .toQuery();
+            // ...unless we were given a list of terminologies as exceptions
+            if (incompleteFromTerminologies != null &&
+                    !incompleteFromTerminologies.isEmpty()) {
+                draftQuery = QueryBuilders.bool()
+                        .should(draftQuery)
+                        .should(TermsQuery.of(q -> q
+                                        .field("namespace")
+                                        .terms(t -> t.value(new ArrayList<>(
+                                                incompleteFromTerminologies != null ?
+                                                        incompleteFromTerminologies :
+                                                        List.of())
+                                                .stream()
+                                                .map(FieldValue::of)
+                                                .toList())))
+                                .toQuery())
+                        .build()
+                        .toQuery();
+            }
+
+            allQueries.add(draftQuery);
+        }
+
+        return QueryBuilders.bool().must(allQueries).build().toQuery();
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptSearchRequest.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptSearchRequest.java
@@ -1,0 +1,18 @@
+package fi.vm.yti.terminology.api.v2.opensearch;
+
+import fi.vm.yti.common.opensearch.BaseSearchRequest;
+
+import java.util.Set;
+import java.util.UUID;
+
+public class ConceptSearchRequest extends BaseSearchRequest {
+    private String namespace;
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/IndexConcept.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/IndexConcept.java
@@ -6,10 +6,19 @@ import java.util.List;
 import java.util.Map;
 
 public class IndexConcept extends IndexBase {
+    private String namespace;
     private Map<String, String> definition;
     private Map<String, List<String>> altLabel;
     private Map<String, List<String>> searchTerm;
     private Map<String, List<String>> notRecommendedSynonym;
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
+    }
 
     public Map<String, String> getDefinition() {
         return definition;

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologyQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologyQueryFactory.java
@@ -1,0 +1,252 @@
+package fi.vm.yti.terminology.api.v2.opensearch;
+
+import fi.vm.yti.common.opensearch.OpenSearchClientWrapper;
+import fi.vm.yti.common.opensearch.SearchResponseDTO;
+import fi.vm.yti.common.opensearch.QueryFactoryUtils;
+import fi.vm.yti.terminology.api.v2.dto.ConceptSearchResultDTO;
+import fi.vm.yti.terminology.api.v2.service.IndexService;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.jena.query.QueryFactory;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.query_dsl.*;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.search.Highlight;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static fi.vm.yti.common.opensearch.OpenSearchUtil.logPayload;
+
+public class TerminologyQueryFactory {
+
+    private static final Logger logger = LoggerFactory.getLogger(OpenSearchClientWrapper.class);
+
+    private TerminologyQueryFactory() {
+    }
+
+    public static SearchRequest createTerminologyQuery(
+            TerminologySearchRequest request,
+            boolean isSuperUser,
+            Set<UUID> privilegedOrganizations) {
+        return TerminologyQueryFactory.createTerminologyQuery(
+                request,
+                isSuperUser,
+                null,
+                privilegedOrganizations);
+    }
+
+    public static SearchRequest createTerminologyQuery(
+            TerminologySearchRequest request,
+            boolean isSuperUser,
+            SearchResponseDTO<ConceptSearchResultDTO> deepSearchHits,
+            Set<UUID> privilegedOrganizations) {
+
+        Set<String> additionalTerminologyUris = deepSearchHits == null ?
+                Set.of() :
+                deepSearchHits
+                        .getResponseObjects()
+                        .stream()
+                        .map(ConceptSearchResultDTO::getUri)
+                        // we got a list of concepts, and their terminology is part of the uri
+                        .map(uri -> uri.substring(0, uri
+                                .replaceAll("/$", "")
+                                .lastIndexOf("/")) + "/")
+                        .collect(Collectors.toSet());
+
+        logger.debug("Deep concept search resulted in " + additionalTerminologyUris.size() + " terminology matches");
+
+        var terminologyQuery = getTerminologyBaseQuery(request, isSuperUser, additionalTerminologyUris, privilegedOrganizations);
+
+        Highlight.Builder highlight = new Highlight.Builder();
+        highlight.fields("label.*", f -> f);
+        var sr = new SearchRequest.Builder()
+                .index(IndexService.TERMINOLOGY_INDEX)
+                .size(QueryFactoryUtils.pageSize(request.getPageSize()))
+                .from(QueryFactoryUtils.pageFrom(request.getPageFrom()))
+                .sort(QueryFactoryUtils.getLangSortOptions(request.getSortLang()))
+                .highlight(highlight.build())
+                .query(terminologyQuery)
+                .build();
+
+        logPayload(sr, IndexService.TERMINOLOGY_INDEX);
+
+        return sr;
+    }
+
+    private static Query getTerminologyBaseQuery(
+            TerminologySearchRequest request,
+            boolean isSuperUser,
+            Set<String> additionalTerminologyUris,
+            Set<UUID> privilegedOrganizations) {
+
+        // separate sections within should for the user query and
+        // terminologies from deep search results
+        var shouldQueries = new ArrayList<Query>();
+        var mustQueries = new ArrayList<Query>();
+
+        var excludeIncomplete = new ArrayList<Query>();
+
+        //
+        // Filter out DRAFT unless superuser or has access to the terminology
+        //
+        if (privilegedOrganizations != null && !privilegedOrganizations.isEmpty()) {
+            var incompleteFromQuery = QueryFactoryUtils.termsQuery(
+                    "organizations",
+                    privilegedOrganizations
+                            .stream()
+                            .map(UUID::toString)
+                            .toList());
+            excludeIncomplete.add(incompleteFromQuery);
+        }
+
+        if (!isSuperUser) {
+            excludeIncomplete.add(BoolQuery.of(bq -> bq
+                            .mustNot(TermQuery.of(tq -> tq
+                                            .field("status")
+                                            .value(FieldValue.of("INCOMPLETE")))
+                                    .toQuery()))
+                    .toQuery());
+        }
+
+        if (excludeIncomplete.size() == 1) {
+            mustQueries.add(excludeIncomplete.get(0));
+        } else if (excludeIncomplete.size() > 1) {
+            mustQueries.add(BoolQuery
+                    .of(bq -> bq
+                            .should(excludeIncomplete)
+                            .minimumShouldMatch("1"))
+                    .toQuery());
+        }
+
+        //
+        // Filter by query string
+        //
+        var queryString = request.getQuery();
+        if (queryString != null && !queryString.isBlank()) {
+            mustQueries.add(QueryBuilders.bool()
+                    .should(QueryFactoryUtils.labelQuery(queryString))
+                    .minimumShouldMatch("1")
+                    .build()
+                    .toQuery());
+        }
+
+        //
+        // Filter by status
+        //
+        if (request.getStatus() != null) {
+            mustQueries.add(TermsQuery.of(q -> q
+                            .field("status")
+                            .terms(t -> t.value(request
+                                    .getStatus()
+                                    .stream()
+                                    .map(Enum::name)
+                                    .map(FieldValue::of)
+                                    .toList())))
+                    .toQuery());
+        }
+
+        //
+        // Filter by organizations
+        //
+        if (request.getOrganizations() != null && !request.getOrganizations().isEmpty()) {
+            mustQueries.add(TermsQuery.of(q -> q
+                            .field("organizations")
+                            .terms(t -> t.value(request
+                                    .getOrganizations()
+                                    .stream()
+                                    .map(UUID::toString)
+                                    .map(FieldValue::of)
+                                    .toList())))
+                    .toQuery());
+        }
+
+        //
+        // Filter by groups
+        //
+        if (request.getGroups() != null && !request.getGroups().isEmpty()) {
+            mustQueries.add(TermsQuery.of(q -> q
+                            .field("groups")
+                            .terms(t -> t.value(request.getGroups()
+                                    .stream()
+                                    .map(FieldValue::of)
+                                    .toList())))
+                    .toQuery());
+        }
+
+        //
+        // Filter by languages
+        //
+        if (request.getLanguages() != null && !request.getLanguages().isEmpty()) {
+            mustQueries.add(TermsQuery.of(q -> q
+                            .field("languages")
+                            .terms(t -> t.value(request.getLanguages()
+                                    .stream()
+                                    .map(FieldValue::of)
+                                    .toList())))
+                    .toQuery());
+        }
+
+        //
+        // Results from deep concept search
+        //
+        if (additionalTerminologyUris != null && !additionalTerminologyUris.isEmpty()) {
+            shouldQueries.add(QueryBuilders.bool()
+                    .should(TermsQuery.of(q -> q
+                                    .field("uri")
+                                    .terms(t -> t.value(additionalTerminologyUris
+                                            .stream()
+                                            .map(FieldValue::of)
+                                            .toList())))
+                            .toQuery())
+                    .minimumShouldMatch("1")
+                    .build()
+                    .toQuery());
+        }
+
+        //
+        // Construct final query
+        //
+        Query mustQuery;
+        if (mustQueries.size() == 1) {
+            mustQuery = mustQueries.get(0);
+        } else if (mustQueries.size() > 1) {
+            mustQuery = QueryBuilders.bool().must(mustQueries).build().toQuery();
+        } else {
+            mustQuery = QueryBuilders.matchAll().build().toQuery();
+        }
+
+        Query shouldQuery = null;
+        if (!shouldQueries.isEmpty()) {
+            shouldQueries.add(mustQuery);
+            shouldQuery = QueryBuilders
+                    .bool()
+                    .should(shouldQueries)
+                    .minimumShouldMatch("1")
+                    .build()
+                    .toQuery();
+        }
+
+        return shouldQuery != null ? shouldQuery : mustQuery;
+    }
+
+    public static SearchRequest createMatchingTerminologiesQuery(
+            final Collection<UUID> privilegedOrganizations) {
+        var q1 = TermsQuery.of(q -> q
+                        .field("organizations")
+                        .terms(t -> t.value(privilegedOrganizations
+                                .stream()
+                                .map(UUID::toString)
+                                .map(FieldValue::of)
+                                .toList())))
+                .toQuery();
+        var sr = new SearchRequest.Builder()
+                .index(IndexService.TERMINOLOGY_INDEX)
+                .size(10000)
+                .query(q1)
+                .build();
+        return sr;
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologySearchRequest.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologySearchRequest.java
@@ -1,0 +1,48 @@
+package fi.vm.yti.terminology.api.v2.opensearch;
+
+import fi.vm.yti.common.opensearch.BaseSearchRequest;
+
+import java.util.Set;
+import java.util.UUID;
+
+public class TerminologySearchRequest extends BaseSearchRequest {
+    private boolean searchConcepts;
+
+    private Set<String> groups;
+
+    private Set<UUID> organizations;
+
+    private Set<String> languages;
+
+    public boolean isSearchConcepts() {
+        return searchConcepts;
+    }
+
+    public void setSearchConcepts(boolean searchConcepts) {
+        this.searchConcepts = searchConcepts;
+    }
+
+    public Set<String> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(Set<String> groups) {
+        this.groups = groups;
+    }
+
+    public Set<UUID> getOrganizations() {
+        return organizations;
+    }
+
+    public void setOrganizations(Set<UUID> organizations) {
+        this.organizations = organizations;
+    }
+
+    public Set<String> getLanguages() {
+        return languages;
+    }
+
+    public void setLanguages(Set<String> languages) {
+        this.languages = languages;
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/service/IndexService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/service/IndexService.java
@@ -19,7 +19,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Map;
+
+import static fi.vm.yti.common.opensearch.OpenSearchUtil.*;
 
 @Service
 public class IndexService extends OpenSearchInitializer {
@@ -46,7 +49,8 @@ public class IndexService extends OpenSearchInitializer {
 
         var indexConfig = Map.of(
                 TERMINOLOGY_INDEX, getTerminologyMappings(),
-                CONCEPT_INDEX, new TypeMapping.Builder().build()
+                // CONCEPT_INDEX, new TypeMapping.Builder().build()
+                CONCEPT_INDEX, getConceptMappings()
         );
         super.initIndexes(fn, indexConfig);
     }
@@ -113,6 +117,26 @@ public class IndexService extends OpenSearchInitializer {
         return new TypeMapping.Builder()
                 .dynamicTemplates(OpenSearchUtil.getMetaDataDynamicTemplates())
                 .properties(OpenSearchUtil.getMetaDataProperties())
+                .build();
+    }
+
+    private TypeMapping getConceptMappings() {
+        return new TypeMapping.Builder()
+                .dynamicTemplates(List.of(
+                        getDynamicTemplate("label", "label.*"),
+                        getDynamicTemplate("definition", "definition.*"),
+                        getDynamicTemplate("altLabel", "altLabel.*"),
+                        getDynamicTemplate("searchTerm", "searchTerm.*"),
+                        getDynamicTemplate("notRecommendedSynonym", "notRecommendedSynonym.*")))
+                .properties(Map.ofEntries(
+                        Map.entry("id", getKeywordProperty()),
+                        Map.entry("uri", getKeywordProperty()),
+                        Map.entry("status", getKeywordProperty()),
+                        Map.entry("namespace", getKeywordProperty()),
+                        Map.entry("prefix", getKeywordProperty()),
+                        Map.entry("created", getDateProperty()),
+                        Map.entry("modified", getDateProperty())
+                ))
                 .build();
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/service/SearchIndexService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/service/SearchIndexService.java
@@ -1,0 +1,126 @@
+package fi.vm.yti.terminology.api.v2.service;
+
+import fi.vm.yti.common.opensearch.OpenSearchClientWrapper;
+import fi.vm.yti.common.opensearch.SearchResponseDTO;
+import fi.vm.yti.common.service.GroupManagementService;
+import fi.vm.yti.security.YtiUser;
+import fi.vm.yti.terminology.api.v2.dto.ConceptSearchResultDTO;
+import fi.vm.yti.terminology.api.v2.dto.TerminologySearchResultDTO;
+import fi.vm.yti.terminology.api.v2.opensearch.ConceptQueryFactory;
+import fi.vm.yti.terminology.api.v2.opensearch.ConceptSearchRequest;
+import fi.vm.yti.terminology.api.v2.opensearch.TerminologyQueryFactory;
+import fi.vm.yti.terminology.api.v2.opensearch.TerminologySearchRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+import static fi.vm.yti.common.opensearch.OpenSearchUtil.logPayload;
+
+@Service
+public class SearchIndexService {
+
+    private static final Logger logger = LoggerFactory.getLogger(OpenSearchClientWrapper.class);
+
+    private final OpenSearchClientWrapper client;
+
+    private final GroupManagementService groupManagementService;
+
+    private final TerminologyService terminologyService;
+
+    private final ConceptService conceptService;
+
+    private final ConceptCollectionService conceptCollectionService;
+
+    public SearchIndexService(OpenSearchClientWrapper client,
+                              GroupManagementService groupManagementService,
+                              TerminologyService terminologyService,
+                              ConceptService conceptService,
+                              ConceptCollectionService conceptCollectionService) {
+        this.client = client;
+        this.groupManagementService = groupManagementService;
+        this.terminologyService = terminologyService;
+        this.conceptService = conceptService;
+        this.conceptCollectionService = conceptCollectionService;
+    }
+
+    public SearchResponseDTO<TerminologySearchResultDTO> searchTerminologies(
+            TerminologySearchRequest request,
+            YtiUser user) {
+        // list of organizations that the user belongs to
+        Set<java.util.UUID> privilegedOrganizations = user.isSuperuser() ?
+                Collections.emptySet() :
+                this.groupManagementService.getOrganizationsForUser(user);
+
+        SearchResponseDTO<ConceptSearchResultDTO> matchingConcepts = null;
+        if (request.isSearchConcepts() && !request.getQuery().isEmpty()) {
+            // list of terminologies that the user has access to
+            Set<String> incompleteFromTerminologies = user.isSuperuser() ?
+                    Collections.emptySet() :
+                    terminologiesMatchingOrganizations(privilegedOrganizations);
+
+            var conceptRequest = new ConceptSearchRequest();
+            conceptRequest.setQuery(request.getQuery());
+            var query = ConceptQueryFactory.createConceptQuery(
+                    conceptRequest,
+                    user.isSuperuser(),
+                    incompleteFromTerminologies);
+            matchingConcepts = client.search(query, ConceptSearchResultDTO.class);
+        }
+
+        var query = TerminologyQueryFactory.createTerminologyQuery(
+                request,
+                user.isSuperuser(),
+                matchingConcepts,
+                privilegedOrganizations);
+        var terminologies = client.search(query, TerminologySearchResultDTO.class);
+
+        if (matchingConcepts != null) {
+            for (var searchResult : terminologies.getResponseObjects()) {
+                // link each matching concept to the terminology, if the id matches
+                matchingConcepts.getResponseObjects().stream()
+                        .filter(o -> o.getNamespace().matches(searchResult.getUri()))
+                        .forEach(searchResult::addMatchingConcept);
+            }
+        }
+
+        return terminologies;
+    }
+
+    public SearchResponseDTO<ConceptSearchResultDTO> searchConcepts(
+            ConceptSearchRequest request,
+            YtiUser user) {
+        Set<java.util.UUID> privilegedOrganizations = user.isSuperuser() ?
+                Collections.emptySet() :
+                this.groupManagementService.getOrganizationsForUser(user);
+        Set<String> incompleteFromTerminologies = user.isSuperuser() ?
+                Collections.emptySet() :
+                terminologiesMatchingOrganizations(privilegedOrganizations);
+
+        var query = ConceptQueryFactory.createConceptQuery(request, user.isSuperuser(), incompleteFromTerminologies);
+        var concepts = client.search(query, ConceptSearchResultDTO.class);
+
+        return concepts;
+    }
+
+    private Set<String> terminologiesMatchingOrganizations(Set<java.util.UUID> privilegedOrganizations) {
+        try {
+            if (privilegedOrganizations.isEmpty()) {
+                return Collections.emptySet();
+            }
+            var query = TerminologyQueryFactory.createMatchingTerminologiesQuery(
+                    privilegedOrganizations);
+            logPayload(query, IndexService.TERMINOLOGY_INDEX);
+            var terminologies = client.search(query, TerminologySearchResultDTO.class);
+            return new HashSet<>(terminologies
+                    .getResponseObjects()
+                    .stream()
+                    .map(TerminologySearchResultDTO::getUri)
+                    .toList());
+        } catch (Exception e) {
+            logger.error("Failed to resolve terminologies based on contributors", e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/fi/vm/yti/terminology/api/v2/TestUtils.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/TestUtils.java
@@ -15,6 +15,7 @@ import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFLanguages;
 
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.function.Consumer;
@@ -150,5 +151,10 @@ public class TestUtils {
         term.setTermStyle("style");
         term.setTermEquivalency(TermEquivalency.BROADER);
         return term;
+    }
+
+    public static String getJsonString(String file) throws Exception {
+        return new String(TestUtils.class
+                .getResourceAsStream(file).readAllBytes(), StandardCharsets.UTF_8);
     }
 }

--- a/src/test/java/fi/vm/yti/terminology/api/v2/endpoint/FrontendControllerTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/endpoint/FrontendControllerTest.java
@@ -1,0 +1,80 @@
+package fi.vm.yti.terminology.api.v2.endpoint;
+
+import fi.vm.yti.common.repository.CommonRepository;
+import fi.vm.yti.common.service.GroupManagementService;
+import fi.vm.yti.security.AuthenticatedUserProvider;
+import fi.vm.yti.security.YtiUser;
+import fi.vm.yti.terminology.api.v2.TestUtils;
+import fi.vm.yti.terminology.api.v2.exception.TerminologyExceptionHandlerAdvice;
+import fi.vm.yti.terminology.api.v2.opensearch.ConceptSearchRequest;
+import fi.vm.yti.terminology.api.v2.opensearch.TerminologySearchRequest;
+import fi.vm.yti.terminology.api.v2.service.SearchIndexService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestPropertySource(properties = {
+        "spring.cloud.config.import-check.enabled=false"
+})
+@WebMvcTest(controllers = FrontendController.class)
+@ActiveProfiles("test")
+public class FrontendControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private GroupManagementService groupManagementService;
+
+    @MockBean
+    private CommonRepository commonRepository;
+
+    @Autowired
+    private FrontendController frontendController;
+
+    @MockBean
+    private SearchIndexService searchIndexService;
+
+    @MockBean
+    private AuthenticatedUserProvider userProvider;
+
+    @BeforeEach
+    void setup() {
+        this.mvc = MockMvcBuilders
+                .standaloneSetup(this.frontendController)
+                .setControllerAdvice(new TerminologyExceptionHandlerAdvice())
+                .build();
+
+        when(userProvider.getUser()).thenReturn(TestUtils.mockUser);
+    }
+
+    @Test
+    void shouldSearchTerminologies() throws Exception {
+        this.mvc.perform(get("/v2/frontend/search-terminologies")
+                        .contentType("application/json"))
+                .andExpect(status().isOk());
+        verify(searchIndexService)
+                .searchTerminologies(any(TerminologySearchRequest.class), any(YtiUser.class));
+    }
+
+    @Test
+    void shouldSearchConcepts() throws Exception {
+        this.mvc.perform(get("/v2/frontend/search-concepts")
+                        .contentType("application/json"))
+                .andExpect(status().isOk());
+        verify(searchIndexService)
+                .searchConcepts(any(ConceptSearchRequest.class), any(YtiUser.class));
+    }
+}

--- a/src/test/java/fi/vm/yti/terminology/api/v2/endpoint/TerminologyControllerTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/endpoint/TerminologyControllerTest.java
@@ -29,6 +29,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -42,6 +43,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@TestPropertySource(properties = {
+        "spring.cloud.config.import-check.enabled=false"
+})
 @WebMvcTest(controllers = TerminologyController.class)
 @ActiveProfiles("test")
 class TerminologyControllerTest {
@@ -70,7 +74,9 @@ class TerminologyControllerTest {
     private static final UUID ORGANIZATION_ID = UUID.randomUUID();
 
     private static final String VALID_GRAPH_URI = TerminologyURI.createTerminologyURI("test").getGraphURI();
+
     private static final String EXISTING_GRAPH = TerminologyURI.createTerminologyURI("existing-graph").getGraphURI();
+
     @BeforeEach
     public void setup() {
         this.mvc = MockMvcBuilders

--- a/src/test/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptQueryFactoryTest.java
@@ -1,0 +1,74 @@
+package fi.vm.yti.terminology.api.v2.opensearch;
+
+import fi.vm.yti.common.enums.Status;
+import fi.vm.yti.terminology.api.v2.TestUtils;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.util.Set;
+
+import static fi.vm.yti.common.opensearch.OpenSearchUtil.getPayload;
+import static org.springframework.test.util.AssertionErrors.assertEquals;
+
+public class ConceptQueryFactoryTest {
+    @Test
+    void shouldCreateConceptQuery() throws Exception {
+        var request = new ConceptSearchRequest();
+        request.setQuery("test");
+        request.setPageSize(100);
+        request.setStatus(Set.of(
+                Status.VALID,
+                Status.DRAFT,
+                Status.INCOMPLETE));
+        var conceptQuery = ConceptQueryFactory.createConceptQuery(
+                request,
+                false,
+                null);
+        var expected = TestUtils.getJsonString("/opensearch/concept-request.json");
+        JSONAssert.assertEquals(expected, getPayload(conceptQuery), JSONCompareMode.LENIENT);
+
+        assertEquals("Page from value not matching", 0, conceptQuery.from());
+        assertEquals("Page size value not matching", 100, conceptQuery.size());
+    }
+
+    @Test
+    void shouldCreateConceptQueryWithExceptions() throws Exception {
+        var request = new ConceptSearchRequest();
+        request.setQuery("test");
+        request.setPageSize(100);
+        request.setStatus(Set.of(
+                Status.VALID,
+                Status.DRAFT,
+                Status.INCOMPLETE));
+        var conceptQuery = ConceptQueryFactory.createConceptQuery(
+                request,
+                false,
+                Set.of("https://iri.test/terminology/terminology1/concept"));
+        var expected = TestUtils.getJsonString("/opensearch/concept-exceptions-request.json");
+        JSONAssert.assertEquals(expected, getPayload(conceptQuery), JSONCompareMode.LENIENT);
+
+        assertEquals("Page from value not matching", 0, conceptQuery.from());
+        assertEquals("Page size value not matching", 100, conceptQuery.size());
+    }
+
+    @Test
+    void shouldCreateConceptQueryAsSuperuser() throws Exception {
+        var request = new ConceptSearchRequest();
+        request.setQuery("test");
+        request.setPageSize(100);
+        request.setStatus(Set.of(
+                Status.VALID,
+                Status.DRAFT,
+                Status.INCOMPLETE));
+        var conceptQuery = ConceptQueryFactory.createConceptQuery(
+                request,
+                true,
+                null);
+        var expected = TestUtils.getJsonString("/opensearch/concept-superuser-request.json");
+        JSONAssert.assertEquals(expected, getPayload(conceptQuery), JSONCompareMode.LENIENT);
+
+        assertEquals("Page from value not matching", 0, conceptQuery.from());
+        assertEquals("Page size value not matching", 100, conceptQuery.size());
+    }
+}

--- a/src/test/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologyQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologyQueryFactoryTest.java
@@ -1,0 +1,87 @@
+package fi.vm.yti.terminology.api.v2.opensearch;
+
+import fi.vm.yti.common.opensearch.SearchResponseDTO;
+import fi.vm.yti.terminology.api.v2.dto.ConceptSearchResultDTO;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import fi.vm.yti.terminology.api.v2.TestUtils;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static fi.vm.yti.common.opensearch.OpenSearchUtil.getPayload;
+import static org.springframework.test.util.AssertionErrors.assertEquals;
+
+public class TerminologyQueryFactoryTest {
+
+    @Test
+    void shouldCreateTerminologyQuery() throws Exception {
+        var request = new TerminologySearchRequest();
+        request.setQuery("test");
+        request.setGroups(Set.of("P11", "P1"));
+        request.setPageSize(100);
+        var terminologyQuery = TerminologyQueryFactory.createTerminologyQuery(request, false, null);
+        var expected = TestUtils.getJsonString("/opensearch/terminology-request.json");
+        JSONAssert.assertEquals(expected, getPayload(terminologyQuery), JSONCompareMode.LENIENT);
+
+        assertEquals("Page from value not matching", 0, terminologyQuery.from());
+        assertEquals("Page size value not matching", 100, terminologyQuery.size());
+    }
+
+    @Test
+    void shouldCreateTerminologyQueryWithDeepSearch() throws Exception {
+        var request = new TerminologySearchRequest();
+        request.setQuery("test");
+        request.setGroups(Set.of("P11", "P1"));
+        request.setPageSize(100);
+
+        var deepSearchHits = new SearchResponseDTO<ConceptSearchResultDTO>();
+        var conceptSearchResult1 = new ConceptSearchResultDTO();
+        conceptSearchResult1.setUri("https://iri.test/terminology/terminology1/concept1");
+        var conceptSearchResult2 = new ConceptSearchResultDTO();
+        conceptSearchResult2.setUri("https://iri.test/terminology/terminology1/concept2");
+        deepSearchHits.setResponseObjects(List.of(conceptSearchResult1, conceptSearchResult2));
+
+        var testUuid = UUID.fromString("d1f9f5fc-3aca-11ef-8006-7ef97ea86967");
+
+        var terminologyQuery = TerminologyQueryFactory.createTerminologyQuery(
+                request,
+                false,
+                deepSearchHits,
+                Set.of(testUuid));
+        var expected = TestUtils.getJsonString("/opensearch/terminology-deep-request.json");
+        JSONAssert.assertEquals(expected, getPayload(terminologyQuery), JSONCompareMode.LENIENT);
+
+        assertEquals("Page from value not matching", 0, terminologyQuery.from());
+        assertEquals("Page size value not matching", 100, terminologyQuery.size());
+    }
+
+    @Test
+    void shouldCreateTerminologyQueryWithDeepSearchAsSuperuser() throws Exception {
+        var request = new TerminologySearchRequest();
+        request.setQuery("test");
+        request.setGroups(Set.of("P11", "P1"));
+        request.setPageSize(100);
+
+        var deepSearchHits = new SearchResponseDTO<ConceptSearchResultDTO>();
+        var conceptSearchResult1 = new ConceptSearchResultDTO();
+        conceptSearchResult1.setUri("https://iri.test/terminology/terminology1/concept1");
+        var conceptSearchResult2 = new ConceptSearchResultDTO();
+        conceptSearchResult2.setUri("https://iri.test/terminology/terminology1/concept2");
+        deepSearchHits.setResponseObjects(List.of(conceptSearchResult1, conceptSearchResult2));
+
+        var testUuid = UUID.fromString("d1f9f5fc-3aca-11ef-8006-7ef97ea86967");
+
+        var terminologyQuery = TerminologyQueryFactory.createTerminologyQuery(
+                request,
+                true,
+                deepSearchHits,
+                null);
+        var expected = TestUtils.getJsonString("/opensearch/terminology-deep-superuser-request.json");
+        JSONAssert.assertEquals(expected, getPayload(terminologyQuery), JSONCompareMode.LENIENT);
+
+        assertEquals("Page from value not matching", 0, terminologyQuery.from());
+        assertEquals("Page size value not matching", 100, terminologyQuery.size());
+    }
+}

--- a/src/test/resources/opensearch/concept-exceptions-request.json
+++ b/src/test/resources/opensearch/concept-exceptions-request.json
@@ -1,0 +1,80 @@
+{
+  "from": 0,
+  "size": 100,
+  "highlight": {
+    "fields": {
+      "definition.*": {}
+    }
+  },
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "bool": {
+            "minimum_should_match": "1",
+            "should": [
+              {
+                "query_string": {
+                  "boost": 1.5,
+                  "fields": [
+                    "label.*",
+                    "altLabel.*",
+                    "searchTerm.*",
+                    "hiddenTerm.*",
+                    "definition.*",
+                    "notRecommendedSynonym.*"
+                  ],
+                  "fuzziness": "2",
+                  "query": "*test*"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "terms": {
+            "status": [
+              "INCOMPLETE",
+              "VALID",
+              "DRAFT"
+            ]
+          }
+        },
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must_not": [
+                    {
+                      "terms": {
+                        "status": [
+                          "INCOMPLETE"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "terms": {
+                  "namespace": [
+                    "https://iri.test/terminology/terminology1/concept"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "sort": [
+    {
+      "label.fi.keyword": {
+        "order": "asc",
+        "unmapped_type": "keyword"
+      }
+    }
+  ]
+}

--- a/src/test/resources/opensearch/concept-request.json
+++ b/src/test/resources/opensearch/concept-request.json
@@ -1,0 +1,67 @@
+{
+  "from": 0,
+  "highlight": {
+    "fields": {
+      "definition.*": {}
+    }
+  },
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "bool": {
+            "minimum_should_match": "1",
+            "should": [
+              {
+                "query_string": {
+                  "boost": 1.5,
+                  "fields": [
+                    "label.*",
+                    "altLabel.*",
+                    "searchTerm.*",
+                    "hiddenTerm.*",
+                    "definition.*",
+                    "notRecommendedSynonym.*"
+                  ],
+                  "fuzziness": "2",
+                  "query": "*test*"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "terms": {
+            "status": [
+              "DRAFT",
+              "INCOMPLETE",
+              "VALID"
+            ]
+          }
+        },
+        {
+          "bool": {
+            "must_not": [
+              {
+                "terms": {
+                  "status": [
+                    "INCOMPLETE"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "size": 100,
+  "sort": [
+    {
+      "label.fi.keyword": {
+        "order": "asc",
+        "unmapped_type": "keyword"
+      }
+    }
+  ]
+}

--- a/src/test/resources/opensearch/concept-superuser-request.json
+++ b/src/test/resources/opensearch/concept-superuser-request.json
@@ -1,0 +1,54 @@
+{
+  "from": 0,
+  "size": 100,
+  "highlight": {
+    "fields": {
+      "definition.*": {}
+    }
+  },
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "bool": {
+            "minimum_should_match": "1",
+            "should": [
+              {
+                "query_string": {
+                  "boost": 1.5,
+                  "fields": [
+                    "label.*",
+                    "altLabel.*",
+                    "searchTerm.*",
+                    "hiddenTerm.*",
+                    "definition.*",
+                    "notRecommendedSynonym.*"
+                  ],
+                  "fuzziness": "2",
+                  "query": "*test*"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "terms": {
+            "status": [
+              "INCOMPLETE",
+              "VALID",
+              "DRAFT"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "sort": [
+    {
+      "label.fi.keyword": {
+        "order": "asc",
+        "unmapped_type": "keyword"
+      }
+    }
+  ]
+}

--- a/src/test/resources/opensearch/terminology-deep-request.json
+++ b/src/test/resources/opensearch/terminology-deep-request.json
@@ -1,0 +1,95 @@
+{
+  "from": 0,
+  "size": 100,
+  "highlight": {
+    "fields": {
+      "label.*": {}
+    }
+  },
+  "query": {
+    "bool": {
+      "minimum_should_match": "1",
+      "should": [
+        {
+          "bool": {
+            "minimum_should_match": "1",
+            "should": [
+              {
+                "terms": {
+                  "uri": [
+                    "https://iri.test/terminology/terminology1/"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "bool": {
+            "must": [
+              {
+                "bool": {
+                  "minimum_should_match": "1",
+                  "should": [
+                    {
+                      "terms": {
+                        "organizations": [
+                          "d1f9f5fc-3aca-11ef-8006-7ef97ea86967"
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "must_not": [
+                          {
+                            "term": {
+                              "status": {
+                                "value": "INCOMPLETE"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "minimum_should_match": "1",
+                  "should": [
+                    {
+                      "query_string": {
+                        "fields": [
+                          "label.*"
+                        ],
+                        "fuzziness": "2",
+                        "query": "*test*"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "terms": {
+                  "groups": [
+                    "P11",
+                    "P1"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "sort": [
+    {
+      "label.fi.keyword": {
+        "order": "asc",
+        "unmapped_type": "keyword"
+      }
+    }
+  ]
+}

--- a/src/test/resources/opensearch/terminology-deep-superuser-request.json
+++ b/src/test/resources/opensearch/terminology-deep-superuser-request.json
@@ -1,0 +1,68 @@
+{
+  "from": 0,
+  "size": 100,
+  "highlight": {
+    "fields": {
+      "label.*": {}
+    }
+  },
+  "query": {
+    "bool": {
+      "minimum_should_match": "1",
+      "should": [
+        {
+          "bool": {
+            "minimum_should_match": "1",
+            "should": [
+              {
+                "terms": {
+                  "uri": [
+                    "https://iri.test/terminology/terminology1/"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "bool": {
+            "must": [
+              {
+                "bool": {
+                  "minimum_should_match": "1",
+                  "should": [
+                    {
+                      "query_string": {
+                        "fields": [
+                          "label.*"
+                        ],
+                        "fuzziness": "2",
+                        "query": "*test*"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "terms": {
+                  "groups": [
+                    "P1",
+                    "P11"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "sort": [
+    {
+      "label.fi.keyword": {
+        "order": "asc",
+        "unmapped_type": "keyword"
+      }
+    }
+  ]
+}

--- a/src/test/resources/opensearch/terminology-request.json
+++ b/src/test/resources/opensearch/terminology-request.json
@@ -1,0 +1,60 @@
+{
+  "from": 0,
+  "size": 100,
+  "highlight": {
+    "fields": {
+      "label.*": {}
+    }
+  },
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "bool": {
+            "must_not": [
+              {
+                "term": {
+                  "status": {
+                    "value": "INCOMPLETE"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "bool": {
+            "minimum_should_match": "1",
+            "should": [
+              {
+                "query_string": {
+                  "fields": [
+                    "label.*"
+                  ],
+                  "fuzziness": "2",
+                  "query": "*test*"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "terms": {
+            "groups": [
+              "P11",
+              "P1"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "sort": [
+    {
+      "label.fi.keyword": {
+        "order": "asc",
+        "unmapped_type": "keyword"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
New endpoints in FrontendController:

- search-concepts
- search-terminologies

The terminology search supports "deep search" by doing another search within concepts using the same search parameters.

Querying counts is currently not implemented.

Example terminology query:
```sh
curl -sS "$BASE_URL/terminology-api/v2/frontend/search-terminologies?query=test&searchConcepts=true&sortLang=en" \
  -H 'Content-Type: application/json' \
  -H "Authorization: Bearer $APIKEY" \
  | jq
```

Example concept query:

```sh
curl -sS "$BASE_URL/terminology-api/v2/frontend/search-concepts?namespace=https://iri.suomi.fi/terminology/test/&status=VALID,INCOMPLETE&sortLang=en&pageSize=1000" \
  -H 'Content-Type: application/json' \
  -H "Authorization: Bearer $APIKEY" \
  | jq
```
