### PR TITLE
YTI-4057 URI redirections

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/ExportController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/ExportController.java
@@ -1,0 +1,35 @@
+package fi.vm.yti.terminology.api.v2.endpoint;
+
+import fi.vm.yti.terminology.api.v2.service.TerminologyService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("v2/export")
+@Tag(name = "Export")
+public class ExportController {
+
+    private final TerminologyService terminologyService;
+
+    public ExportController(TerminologyService terminologyService) {
+        this.terminologyService = terminologyService;
+    }
+
+    @Operation(summary = "Get terminology serialized")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Get and serialize terminology successfully"),
+            @ApiResponse(responseCode = "404", description = "Terminology not found")
+    })
+    @GetMapping(value = {"{prefix}"},
+            produces = {"application/ld+json;charset=utf-8", "text/turtle;charset=utf-8", "application/rdf+xml;charset=utf-8"})
+    public ResponseEntity<String> export(@PathVariable @Parameter(description = "Terminology prefix") String prefix,
+                                         @RequestHeader(value = HttpHeaders.ACCEPT) String accept) {
+        return terminologyService.export(prefix, accept);
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/ResolveController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/ResolveController.java
@@ -1,0 +1,45 @@
+package fi.vm.yti.terminology.api.v2.endpoint;
+
+import fi.vm.yti.terminology.api.v2.service.UriResolveService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("v2/resolve")
+@Tag(name = "Resolve")
+public class ResolveController {
+
+    private final UriResolveService uriResolveService;
+
+    public ResolveController(UriResolveService uriResolveService) {
+        this.uriResolveService = uriResolveService;
+    }
+
+    @Operation(summary = "Resolve content by its IRI")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "303", description = "Resolves given uri and redirects the request per accept header"),
+            @ApiResponse(responseCode = "404", description = "Resource not found")
+    })
+    @GetMapping
+    public ResponseEntity<String> resolve(@RequestParam @Parameter(description = "Resource IRI") String iri,
+                                          @RequestHeader(value = HttpHeaders.ACCEPT) String accept) {
+        return uriResolveService.resolve(iri, accept);
+    }
+
+    @GetMapping("/v1")
+    public ResponseEntity<Void> resolveV1URL(@RequestParam String termedId) {
+        HttpHeaders headers = new HttpHeaders();
+
+        var url = uriResolveService.resolveLegacyURL(termedId);
+        headers.add(HttpHeaders.LOCATION, url);
+
+        return new ResponseEntity<>(headers, HttpStatus.MOVED_PERMANENTLY);
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/service/UriResolveService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/service/UriResolveService.java
@@ -1,0 +1,113 @@
+package fi.vm.yti.terminology.api.v2.service;
+
+import fi.vm.yti.common.Constants;
+import fi.vm.yti.common.exception.ResourceNotFoundException;
+import fi.vm.yti.terminology.api.v2.migration.v1.Termed;
+import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
+import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
+import org.apache.jena.arq.querybuilder.SelectBuilder;
+import org.apache.jena.arq.querybuilder.WhereBuilder;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.SKOS;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MimeTypeUtils;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.ArrayList;
+
+@Service
+public class UriResolveService {
+
+    private final TerminologyRepository repository;
+
+    @Value("${env:}")
+    private String awsEnv;
+
+    public UriResolveService(TerminologyRepository repository) {
+        this.repository = repository;
+    }
+
+    public ResponseEntity<String> resolve(String iri, String accept) {
+
+        if (checkIRI(iri)) {
+            return ResponseEntity.badRequest().build();
+        }
+        var currentUrl = ServletUriComponentsBuilder.fromCurrentRequestUri().build().toUri();
+        var redirectURL = UriComponentsBuilder.newInstance()
+                .scheme(currentUrl.getScheme())
+                .host(currentUrl.getHost());
+
+        if (currentUrl.getHost().equals("localhost")) {
+            redirectURL.port(3000);
+        }
+
+        var terminologyURI = TerminologyURI.fromUri(iri);
+
+        if (accept != null && accept.contains(MimeTypeUtils.TEXT_HTML_VALUE)) {
+            redirectURL.pathSegment("terminology", terminologyURI.getPrefix());
+            if (terminologyURI.getResourceId() != null) {
+                var resourceType = getResourceType(terminologyURI.getResourceURI());
+                redirectURL.pathSegment(resourceType, terminologyURI.getResourceId());
+            }
+        } else {
+            redirectURL.pathSegment("terminology-api", "v2", "export", terminologyURI.getPrefix());
+        }
+        return ResponseEntity
+                .status(HttpStatus.SEE_OTHER)
+                .header(HttpHeaders.LOCATION, redirectURL.toUriString())
+                .build();
+    }
+
+    public String resolveLegacyURL(String termedId) {
+
+        var select = new SelectBuilder();
+        select.addVar("?subject")
+                .addWhere(new WhereBuilder()
+                        .addWhere("?subject", Termed.id, termedId)
+                );
+
+        var result = new ArrayList<String>();
+        repository.querySelect(select.build(), row -> result.add(row.get("subject").toString()));
+
+        if (result.isEmpty()) {
+            throw new ResourceNotFoundException(termedId);
+        }
+
+        if (!awsEnv.isBlank()) {
+            return result.get(0) + "?env=" + awsEnv;
+        }
+        return result.get(0);
+    }
+
+    private boolean checkIRI(String iri) {
+        return iri == null || !iri.startsWith(Constants.TERMINOLOGY_NAMESPACE);
+    }
+
+    private String getResourceType(String resourceURI) {
+        var select = new SelectBuilder()
+                .addVar("?type")
+                .addWhere(new WhereBuilder()
+                        .addWhere(NodeFactory.createURI(resourceURI), RDF.type, "?type")
+                );
+        var result = new ArrayList<String>();
+        repository.querySelect(select.build(), row -> result.add(row.get("type").toString()));
+
+        String resourceType;
+        if (result.isEmpty()) {
+            throw new ResourceNotFoundException(resourceURI);
+        } else if (result.get(0).equals(SKOS.Concept.getURI())) {
+            resourceType = "concept";
+        } else if (result.get(0).equals(SKOS.Collection.getURI())) {
+            resourceType = "collection";
+        } else {
+            throw new ResourceNotFoundException(resourceURI);
+        }
+        return resourceType;
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/util/TerminologyURI.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/util/TerminologyURI.java
@@ -1,26 +1,18 @@
 package fi.vm.yti.terminology.api.v2.util;
 
 import fi.vm.yti.common.Constants;
-import fi.vm.yti.common.exception.MappingError;
-import fi.vm.yti.common.properties.DCAP;
 import fi.vm.yti.common.util.GraphURI;
-import fi.vm.yti.common.util.MapperUtils;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.vocabulary.RDF;
-import org.apache.jena.vocabulary.SKOS;
+
+import java.util.regex.Pattern;
 
 public class TerminologyURI extends GraphURI {
 
+    private static final Pattern iriPattern = Pattern.compile("https?://iri.suomi.fi/terminology/" +
+                                                              "(?<prefix>[\\w-]+)/" +
+                                                              "(?<resource>[\\w-]+)?");
+
     public static TerminologyURI createTerminologyURI(String prefix) {
         return new TerminologyURI(prefix);
-    }
-
-    public static TerminologyURI createTerminologyURI(Model model) {
-        var subj = model.listSubjectsWithProperty(RDF.type, SKOS.ConceptScheme);
-        if (!subj.hasNext()) {
-            throw new MappingError("Not a valid model");
-        }
-        return new TerminologyURI(MapperUtils.propertyToString(subj.next(), DCAP.preferredXMLNamespacePrefix));
     }
 
     public static TerminologyURI createConceptURI(String prefix, String conceptId) {
@@ -29,6 +21,20 @@ public class TerminologyURI extends GraphURI {
 
     public static TerminologyURI createConceptCollectionURI(String prefix, String conceptCollectionId) {
         return new TerminologyURI(prefix, conceptCollectionId);
+    }
+
+    public static TerminologyURI fromUri(String uri) {
+        var matcher = iriPattern.matcher(uri);
+        if (matcher.matches()) {
+            var prefix = matcher.group("prefix");
+            var resourceId = matcher.group("resource");
+
+            if (resourceId != null) {
+                return new TerminologyURI(prefix, resourceId);
+            }
+            return new TerminologyURI(prefix);
+        }
+        return new TerminologyURI(uri);
     }
 
     private TerminologyURI(String prefix) {

--- a/src/test/java/fi/vm/yti/terminology/api/v2/service/UriResolveServiceTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/service/UriResolveServiceTest.java
@@ -1,0 +1,84 @@
+package fi.vm.yti.terminology.api.v2.service;
+
+import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
+import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.vocabulary.SKOS;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@Import({
+        UriResolveService.class
+})
+class UriResolveServiceTest {
+
+    @MockBean
+    private TerminologyRepository repository;
+
+    @Autowired
+    private UriResolveService service;
+
+    @BeforeEach
+    void init() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    }
+
+    @Test
+    void redirectTerminologyToSite() {
+        var uri = TerminologyURI.createTerminologyURI("test").getGraphURI();
+        var response = service.resolve(uri, "text/html");
+
+        assertTrue(response.getStatusCode().is3xxRedirection());
+        assertNotNull(response.getHeaders().getLocation());
+        assertTrue(response.getHeaders().getLocation().toString().endsWith("/terminology/test"));
+    }
+
+    @Test
+    void redirectResourceToSite() {
+        var uri = TerminologyURI.createConceptURI("test", "concept-1").getResourceURI();
+
+        var qs = mock(QuerySolution.class);
+        when(qs.get("type")).thenReturn(ResourceFactory.createStringLiteral(SKOS.Concept.getURI()));
+
+        doAnswer(ans -> {
+            Consumer<QuerySolution> cons = ans.getArgument(1, Consumer.class);
+            cons.accept(qs);
+            return null;
+        }).when(repository).querySelect(any(Query.class), any(Consumer.class));
+
+        var response = service.resolve(uri, "text/html");
+
+        assertTrue(response.getStatusCode().is3xxRedirection());
+        assertNotNull(response.getHeaders().getLocation());
+        assertTrue(response.getHeaders().getLocation().toString().endsWith("/terminology/test/concept/concept-1"));
+    }
+
+    @Test
+    void redirectTerminologyToExport() {
+        var uri = TerminologyURI.createTerminologyURI("test").getGraphURI();
+        var response = service.resolve(uri, "text/turtle");
+
+        assertTrue(response.getStatusCode().is3xxRedirection());
+        assertNotNull(response.getHeaders().getLocation());
+        assertTrue(response.getHeaders().getLocation().toString().endsWith("/terminology-api/v2/export/test"));
+    }
+}


### PR DESCRIPTION
- Resolve permanent IRIs, e.g. https://iri.suomi.fi/terminology/test/
- Redirect UUID based old addresses (UUID values migrated from Termed) to new site, e.g. /terminology/<uuid>/concept/<uuid> -> /terminology/prefix/concept/conceptIdentifier
- Added simple export functionality (turtle, rdf, jsonld)