### PR TITLE
YTI-4054 send notifications

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/v2/integration/IntegrationController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/integration/IntegrationController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -21,12 +22,12 @@ public class IntegrationController {
 
     @GetMapping("/containers")
     public IntegrationResponse getContainers() {
-        return service.getContainers(Set.of());
+        return service.getContainers(new ContainerRequest());
     }
 
     @PostMapping("/containers")
     public IntegrationResponse getContainers(@RequestBody ContainerRequest request) {
-        return service.getContainers(request.getUri());
+        return service.getContainers(request);
     }
 
 
@@ -55,7 +56,7 @@ public class IntegrationController {
     }
 
     public static class ContainerRequest {
-        private Set<String> uri;
+        private Set<String> uri = new HashSet<>();
 
         public Set<String> getUri() {
             return uri;
@@ -68,6 +69,7 @@ public class IntegrationController {
 
     public static class ResourceRequest {
         private List<String> container = new ArrayList<>();
+        private String before;
         private String after;
         private Integer pageSize;
         private String searchTerm;
@@ -79,6 +81,14 @@ public class IntegrationController {
 
         public void setContainer(List<String> container) {
             this.container = container;
+        }
+
+        public String getBefore() {
+            return before;
+        }
+
+        public void setBefore(String before) {
+            this.before = before;
         }
 
         public String getAfter() {

--- a/src/main/java/fi/vm/yti/terminology/api/v2/integration/IntegrationController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/integration/IntegrationController.java
@@ -4,10 +4,12 @@ import fi.vm.yti.common.enums.Status;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 @RestController
-@RequestMapping("api/v1/integration")
+@RequestMapping(value = { "api/v1/integration", "v2/integration" })
 @Tag(name = "Integration")
 public class IntegrationController {
 
@@ -30,14 +32,16 @@ public class IntegrationController {
 
     @GetMapping("/resources")
     public IntegrationResponse getResources(
-            @RequestParam String containerUri,
+            @RequestParam(required = false) String containerUri,
             @RequestParam(required = false) String searchTerm,
             @RequestParam(required = false) String after,
             @RequestParam(required = false) Status status,
             @RequestParam(required = false) Integer pageSize
     ) {
         var request = new ResourceRequest();
-        request.setContainer(containerUri);
+        if (containerUri != null) {
+            request.setContainer(List.of(containerUri));
+        }
         request.setSearchTerm(searchTerm);
         request.setAfter(after);
         request.setPageSize(pageSize);
@@ -63,17 +67,17 @@ public class IntegrationController {
     }
 
     public static class ResourceRequest {
-        private String container;
+        private List<String> container = new ArrayList<>();
         private String after;
         private Integer pageSize;
         private String searchTerm;
         private Status status;
 
-        public String getContainer() {
+        public List<String> getContainer() {
             return container;
         }
 
-        public void setContainer(String container) {
+        public void setContainer(List<String> container) {
             this.container = container;
         }
 

--- a/src/main/java/fi/vm/yti/terminology/api/v2/integration/IntegrationController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/integration/IntegrationController.java
@@ -1,0 +1,112 @@
+package fi.vm.yti.terminology.api.v2.integration;
+
+import fi.vm.yti.common.enums.Status;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Set;
+
+@RestController
+@RequestMapping("api/v1/integration")
+@Tag(name = "Integration")
+public class IntegrationController {
+
+    private final IntegrationService service;
+
+    public IntegrationController(IntegrationService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/containers")
+    public IntegrationResponse getContainers() {
+        return service.getContainers(Set.of());
+    }
+
+    @PostMapping("/containers")
+    public IntegrationResponse getContainers(@RequestBody ContainerRequest request) {
+        return service.getContainers(request.getUri());
+    }
+
+
+    @GetMapping("/resources")
+    public IntegrationResponse getResources(
+            @RequestParam String containerUri,
+            @RequestParam(required = false) String searchTerm,
+            @RequestParam(required = false) String after,
+            @RequestParam(required = false) Status status,
+            @RequestParam(required = false) Integer pageSize
+    ) {
+        var request = new ResourceRequest();
+        request.setContainer(containerUri);
+        request.setSearchTerm(searchTerm);
+        request.setAfter(after);
+        request.setPageSize(pageSize);
+        request.setStatus(status);
+        return service.getContainerResources(request);
+    }
+
+    @PostMapping("/resources")
+    public IntegrationResponse getResources(@RequestBody ResourceRequest request) {
+        return service.getContainerResources(request);
+    }
+
+    public static class ContainerRequest {
+        private Set<String> uri;
+
+        public Set<String> getUri() {
+            return uri;
+        }
+
+        public void setUri(Set<String> uri) {
+            this.uri = uri;
+        }
+    }
+
+    public static class ResourceRequest {
+        private String container;
+        private String after;
+        private Integer pageSize;
+        private String searchTerm;
+        private Status status;
+
+        public String getContainer() {
+            return container;
+        }
+
+        public void setContainer(String container) {
+            this.container = container;
+        }
+
+        public String getAfter() {
+            return after;
+        }
+
+        public void setAfter(String after) {
+            this.after = after;
+        }
+
+        public Integer getPageSize() {
+            return pageSize;
+        }
+
+        public void setPageSize(Integer pageSize) {
+            this.pageSize = pageSize;
+        }
+
+        public String getSearchTerm() {
+            return searchTerm;
+        }
+
+        public void setSearchTerm(String searchTerm) {
+            this.searchTerm = searchTerm;
+        }
+
+        public Status getStatus() {
+            return status;
+        }
+
+        public void setStatus(Status status) {
+            this.status = status;
+        }
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/integration/IntegrationResponse.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/integration/IntegrationResponse.java
@@ -1,0 +1,26 @@
+package fi.vm.yti.terminology.api.v2.integration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class IntegrationResponse {
+    private Meta meta;
+
+    private List<IntegrationResult> results = new ArrayList<>();
+
+    public Meta getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Meta meta) {
+        this.meta = meta;
+    }
+
+    public List<IntegrationResult> getResults() {
+        return results;
+    }
+
+    public void setResults(List<IntegrationResult> results) {
+        this.results = results;
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/integration/IntegrationResult.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/integration/IntegrationResult.java
@@ -2,9 +2,7 @@ package fi.vm.yti.terminology.api.v2.integration;
 
 import fi.vm.yti.common.enums.Status;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class IntegrationResult {
@@ -15,7 +13,6 @@ public class IntegrationResult {
     private String created;
     private String modified;
     private String type;
-    private List<String> languages = new ArrayList<>();
 
     public String getUri() {
         return uri;
@@ -63,14 +60,6 @@ public class IntegrationResult {
 
     public void setType(String type) {
         this.type = type;
-    }
-
-    public List<String> getLanguages() {
-        return languages;
-    }
-
-    public void setLanguages(List<String> languages) {
-        this.languages = languages;
     }
 
     public Map<String, String> getDescription() {

--- a/src/main/java/fi/vm/yti/terminology/api/v2/integration/IntegrationResult.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/integration/IntegrationResult.java
@@ -1,0 +1,83 @@
+package fi.vm.yti.terminology.api.v2.integration;
+
+import fi.vm.yti.common.enums.Status;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class IntegrationResult {
+    private String uri;
+    private Map<String, String> prefLabel = new HashMap<>();
+    private Map<String, String> description = new HashMap<>();
+    private Status status;
+    private String created;
+    private String modified;
+    private String type;
+    private List<String> languages = new ArrayList<>();
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public Map<String, String> getPrefLabel() {
+        return prefLabel;
+    }
+
+    public void setPrefLabel(Map<String, String> prefLabel) {
+        this.prefLabel = prefLabel;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public String getCreated() {
+        return created;
+    }
+
+    public void setCreated(String created) {
+        this.created = created;
+    }
+
+    public String getModified() {
+        return modified;
+    }
+
+    public void setModified(String modified) {
+        this.modified = modified;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public List<String> getLanguages() {
+        return languages;
+    }
+
+    public void setLanguages(List<String> languages) {
+        this.languages = languages;
+    }
+
+    public Map<String, String> getDescription() {
+        return description;
+    }
+
+    public void setDescription(Map<String, String> description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/integration/IntegrationService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/integration/IntegrationService.java
@@ -118,7 +118,9 @@ public class IntegrationService {
     private static Collection<String> fixURIs(Collection<String> uris) {
         return uris.stream()
             .map(u -> {
-                u = u.replace("http://uri.suomi.fi", "https://iri.suomi.fi");
+                u = u
+                        .replace("http://uri.suomi.fi", "https://iri.suomi.fi")
+                        .replaceAll("terminological-vocabulary-\\d$", "");
                 if (!u.endsWith("/")) {
                     u = u + "/";
                 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/integration/IntegrationService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/integration/IntegrationService.java
@@ -117,7 +117,13 @@ public class IntegrationService {
 
     private static Collection<String> fixURIs(Collection<String> uris) {
         return uris.stream()
-                .map(u -> u.replace("http://uri.suomi.fi", "https://iri.suomi.fi"))
-                .toList();
+            .map(u -> {
+                u = u.replace("http://uri.suomi.fi", "https://iri.suomi.fi");
+                if (!u.endsWith("/")) {
+                    u = u + "/";
+                }
+                return u;
+            })
+            .toList();
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/integration/IntegrationService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/integration/IntegrationService.java
@@ -1,0 +1,125 @@
+package fi.vm.yti.terminology.api.v2.integration;
+
+import fi.vm.yti.common.opensearch.*;
+import fi.vm.yti.terminology.api.v2.opensearch.IndexConcept;
+import fi.vm.yti.terminology.api.v2.opensearch.IndexTerminology;
+import fi.vm.yti.terminology.api.v2.service.IndexService;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
+import org.opensearch.client.opensearch._types.query_dsl.RangeQuery;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class IntegrationService {
+
+    private final OpenSearchClientWrapper client;
+
+    public IntegrationService(OpenSearchClientWrapper client) {
+        this.client = client;
+    }
+
+    public IntegrationResponse getContainers(Set<String> uris) {
+        uris = uris.stream()
+                .map(IntegrationService::fixURI)
+                .collect(Collectors.toSet());
+
+        var request = new SearchRequest.Builder();
+
+        request.size(1000);
+        request.index(IndexService.TERMINOLOGY_INDEX);
+
+        if (!uris.isEmpty()) {
+            request.query(QueryFactoryUtils.termsQuery("uri", uris));
+        }
+
+        var result = client.search(request.build(), IndexTerminology.class);
+
+        var containers = result.getResponseObjects().stream()
+                .map(o -> getContainerResult(o, "terminology"))
+                .toList();
+
+        var response = new IntegrationResponse();
+        var meta = getMeta(result);
+
+        response.setResults(containers);
+        response.setMeta(meta);
+
+        return response;
+    }
+
+    public IntegrationResponse getContainerResources(IntegrationController.ResourceRequest req) {
+        var request = new SearchRequest.Builder();
+
+        request.size(req.getPageSize() != null ? req.getPageSize() : 20);
+        request.index(IndexService.CONCEPT_INDEX);
+
+        var queries = new ArrayList<Query>();
+        queries.add(
+                QueryFactoryUtils.termsQuery("namespace", Set.of(fixURI(req.getContainer())))
+        );
+
+        if (req.getAfter() != null) {
+            queries.add(new RangeQuery.Builder()
+                    .field("modified")
+                    .gte(JsonData.of(req.getAfter()))
+                    .build()
+                    .toQuery());
+        }
+        if (req.getSearchTerm() != null && !req.getSearchTerm().isBlank()) {
+            queries.add(QueryFactoryUtils.labelQuery(req.getSearchTerm()));
+        }
+        if (req.getStatus() != null) {
+            queries.add(QueryFactoryUtils.termQuery("status", req.getStatus().name()));
+        }
+
+        request.query(QueryBuilders
+                .bool()
+                .must(queries)
+                .build()
+                .toQuery());
+
+        var result = client.search(request.build(), IndexConcept.class);
+        var resources = result.getResponseObjects().stream()
+                .map(o -> getContainerResult(o, "concept"))
+                .toList();
+
+        var response = new IntegrationResponse();
+        response.setMeta(getMeta(result));
+        response.setResults(resources);
+        return response;
+    }
+
+    private static IntegrationResult getContainerResult(IndexBase index, String type) {
+        var container = new IntegrationResult();
+        container.setUri(index.getUri());
+        container.setType(type);
+        container.setPrefLabel(index.getLabel());
+
+        if (index instanceof IndexConcept concept) {
+            container.setDescription(concept.getDefinition());
+        } else {
+            container.setDescription(index.getDescription());
+        }
+        container.setCreated(index.getCreated());
+        container.setModified(index.getModified());
+        container.setStatus(index.getStatus());
+        return container;
+    }
+
+    private static Meta getMeta(SearchResponseDTO<? extends IndexBase> result) {
+        var meta = new Meta();
+        meta.setTotalResults(result.getTotalHitCount());
+        meta.setResultCount(result.getResponseObjects().size());
+        return meta;
+    }
+
+    private static String fixURI(String u) {
+        return u.replace("http://uri.suomi.fi", "https://iri.suomi.fi");
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/integration/Meta.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/integration/Meta.java
@@ -1,0 +1,23 @@
+package fi.vm.yti.terminology.api.v2.integration;
+
+public class Meta {
+
+    private long resultCount;
+    private long totalResults;
+
+    public long getResultCount() {
+        return resultCount;
+    }
+
+    public void setResultCount(long resultCount) {
+        this.resultCount = resultCount;
+    }
+
+    public long getTotalResults() {
+        return totalResults;
+    }
+
+    public void setTotalResults(long totalResults) {
+        this.totalResults = totalResults;
+    }
+}

--- a/src/test/java/fi/vm/yti/terminology/api/v2/service/IntegrationServiceTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/service/IntegrationServiceTest.java
@@ -1,0 +1,84 @@
+package fi.vm.yti.terminology.api.v2.service;
+
+import fi.vm.yti.common.enums.Status;
+import fi.vm.yti.common.opensearch.OpenSearchClientWrapper;
+import fi.vm.yti.common.opensearch.OpenSearchUtil;
+import fi.vm.yti.common.opensearch.SearchResponseDTO;
+import fi.vm.yti.terminology.api.v2.TestUtils;
+import fi.vm.yti.terminology.api.v2.integration.IntegrationController;
+import fi.vm.yti.terminology.api.v2.integration.IntegrationService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@Import({
+        IntegrationService.class,
+})
+class IntegrationServiceTest {
+
+    @MockBean
+    private OpenSearchClientWrapper client;
+
+    @Autowired
+    IntegrationService service;
+
+    @Test
+    void testGetResources() throws Exception {
+        var response = new SearchResponseDTO<>();
+        response.setResponseObjects(List.of());
+
+        when(client.search(any(SearchRequest.class), any()))
+                .thenReturn(response);
+
+        var request = new IntegrationController.ResourceRequest();
+        request.setAfter("2024-07-24T00:00:00");
+        request.setBefore("2024-07-25T00:00:00");
+        request.setStatus(Status.DRAFT);
+        request.setPageSize(50);
+        request.setContainer(List.of("https://iri.suomi.fi/terminology/test/"));
+        request.setSearchTerm("Search");
+
+        var expected = TestUtils.getJsonString("/integration/resource-search-request.json");
+
+        var captor = ArgumentCaptor.forClass(SearchRequest.class);
+        service.getContainerResources(request);
+
+        verify(client).search(captor.capture(), any());
+        JSONAssert.assertEquals(expected, OpenSearchUtil.getPayload(captor.getValue()), JSONCompareMode.LENIENT);
+    }
+
+    @Test
+    void testGetContainers() throws Exception {
+        var response = new SearchResponseDTO<>();
+        response.setResponseObjects(List.of());
+
+        when(client.search(any(SearchRequest.class), any()))
+                .thenReturn(response);
+
+        var request = new IntegrationController.ContainerRequest();
+        request.setUri(Set.of("https://iri.suomi.fi/terminology/test/"));
+
+        var expected = TestUtils.getJsonString("/integration/container-search-request.json");
+
+        var captor = ArgumentCaptor.forClass(SearchRequest.class);
+
+        service.getContainers(request);
+
+        verify(client).search(captor.capture(), any());
+        JSONAssert.assertEquals(expected, OpenSearchUtil.getPayload(captor.getValue()), JSONCompareMode.LENIENT);
+    }
+}

--- a/src/test/resources/integration/container-search-request.json
+++ b/src/test/resources/integration/container-search-request.json
@@ -1,0 +1,10 @@
+{
+  "query": {
+    "terms": {
+      "uri": [
+        "https://iri.suomi.fi/terminology/test/"
+      ]
+    }
+  },
+  "size": 1000
+}

--- a/src/test/resources/integration/resource-search-request.json
+++ b/src/test/resources/integration/resource-search-request.json
@@ -1,0 +1,40 @@
+{
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "terms": {
+            "namespace": [
+              "https://iri.suomi.fi/terminology/test/"
+            ]
+          }
+        },
+        {
+          "range": {
+            "modified": {
+              "gte": "2024-07-24T00:00:00",
+              "lte": "2024-07-25T00:00:00"
+            }
+          }
+        },
+        {
+          "query_string": {
+            "fields": [
+              "label.*"
+            ],
+            "fuzziness": "2",
+            "query": "*Search*"
+          }
+        },
+        {
+          "term": {
+            "status": {
+              "value": "DRAFT"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "size": 50
+}


### PR DESCRIPTION
Create simplified integration API (see [old implementation](https://github.com/VRK-YTI/yti-terminology-api/tree/develop/src/main/java/fi/vm/yti/terminology/api/integration)) for sending notifications (messaging-api) and adding concept references (codelist-content-intake-service). Support both GET and POST methods and both old (/api/v1/integrations) and new (v2/integrations) application path.

```
curl -X POST \
  -H 'content-type: application/json' \
  --data '{"uri": ["https://iri.suomi.fi/terminology/demo/"]}' \
  http://localhost:9103/terminology-api/v2/integration/containers
```

```
curl -X POST \
  -H 'content-type: application/json' \
  --data '{
    "container": ["https://iri.suomi.fi/terminology/demo/"],
    "after": "2024-07-24T00:00:00",
    "before": "2024-07-25T00:00:00",
    "searchTerm": "Test",
    "status": "DRAFT"
  }' \
  http://localhost:9103/terminology-api/v2/integration/resources 
```
