### PR TITLE
YTI-4053 Backend fixes for UI

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptCollectionInfoDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptCollectionInfoDTO.java
@@ -7,43 +7,12 @@ import java.util.Map;
 import java.util.Set;
 
 public class ConceptCollectionInfoDTO extends ResourceCommonInfoDTO {
-    class Concept {
-        private String identifier;
-
-        private String uri;
-
-        private Map<String, String> label = Map.of();
-
-        public String getIdentifier() {
-            return identifier;
-        }
-
-        public void setIdentifier(String identifier) {
-            this.identifier = identifier;
-        }
-
-        public String getUri() {
-            return uri;
-        }
-
-        public void setUri(String uri) {
-            this.uri = uri;
-        }
-
-        public Map<String, String> getLabel() {
-            return label;
-        }
-
-        public void setLabel(Map<String, String> label) {
-            this.label = label;
-        }
-    }
 
     private String identifier;
 
     private Map<String, String> description = Map.of();
 
-    private Set<Concept> members = new LinkedHashSet<>();
+    private Set<ConceptReferenceInfoDTO> members = new LinkedHashSet<>();
 
     public String getIdentifier() {
         return identifier;
@@ -61,19 +30,20 @@ public class ConceptCollectionInfoDTO extends ResourceCommonInfoDTO {
         this.description = description;
     }
 
-    public Set<Concept> getMembers() {
+    public Set<ConceptReferenceInfoDTO> getMembers() {
         return members;
     }
 
-    public void setMembers(Set<Concept> members) {
+    public void setMembers(Set<ConceptReferenceInfoDTO> members) {
         this.members = members;
     }
 
-    public void addMember(String identifier, String uri, Map<String, String> label) {
-        Concept concept = new Concept();
-        concept.identifier = identifier;
-        concept.uri = uri;
-        concept.label = label;
+    public void addMember(String identifier, String uri, Map<String, String> label, String prefix) {
+        ConceptReferenceInfoDTO concept = new ConceptReferenceInfoDTO();
+        concept.setIdentifier(identifier);
+        concept.setReferenceURI(uri);
+        concept.setLabel(label);
+        concept.setPrefix(prefix);
         members.add(concept);
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptInfoDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptInfoDTO.java
@@ -33,6 +33,7 @@ public class ConceptInfoDTO extends ResourceCommonInfoDTO {
     private List<TermDTO> synonyms = new ArrayList<>();
     private List<TermDTO> notRecommendedTerms = new ArrayList<>();
     private List<TermDTO> searchTerms = new ArrayList<>();
+    private List<ConceptReferenceInfoDTO> memberOf = new ArrayList<>();
 
     public String getIdentifier() {
         return identifier;
@@ -240,5 +241,13 @@ public class ConceptInfoDTO extends ResourceCommonInfoDTO {
 
     public void setSearchTerms(List<TermDTO> searchTerms) {
         this.searchTerms = searchTerms;
+    }
+
+    public List<ConceptReferenceInfoDTO> getMemberOf() {
+        return memberOf;
+    }
+
+    public void setMemberOf(List<ConceptReferenceInfoDTO> memberOf) {
+        this.memberOf = memberOf;
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptReferenceInfoDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptReferenceInfoDTO.java
@@ -3,15 +3,18 @@ package fi.vm.yti.terminology.api.v2.dto;
 import java.util.Map;
 
 public class ConceptReferenceInfoDTO {
-    private String conceptURI;
+    private String referenceURI;
     private Map<String, String> label;
+    private Map<String, String> terminologyLabel = Map.of();
+    private String prefix;
+    private String identifier;
 
-    public String getConceptURI() {
-        return conceptURI;
+    public String getReferenceURI() {
+        return referenceURI;
     }
 
-    public void setConceptURI(String conceptURI) {
-        this.conceptURI = conceptURI;
+    public void setReferenceURI(String referenceURI) {
+        this.referenceURI = referenceURI;
     }
 
     public Map<String, String> getLabel() {
@@ -20,5 +23,29 @@ public class ConceptReferenceInfoDTO {
 
     public void setLabel(Map<String, String> label) {
         this.label = label;
+    }
+
+    public Map<String, String> getTerminologyLabel() {
+        return terminologyLabel;
+    }
+
+    public void setTerminologyLabel(Map<String, String> terminologyLabel) {
+        this.terminologyLabel = terminologyLabel;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptSearchResultDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/ConceptSearchResultDTO.java
@@ -3,4 +3,13 @@ package fi.vm.yti.terminology.api.v2.dto;
 import fi.vm.yti.terminology.api.v2.opensearch.IndexConcept;
 
 public class ConceptSearchResultDTO extends IndexConcept {
+    private SimpleTerminologyDTO terminology;
+
+    public SimpleTerminologyDTO getTerminology() {
+        return terminology;
+    }
+
+    public void setTerminology(SimpleTerminologyDTO terminology) {
+        this.terminology = terminology;
+    }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/CountDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/CountDTO.java
@@ -1,0 +1,66 @@
+package fi.vm.yti.terminology.api.v2.dto;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class CountDTO {
+
+    private Map<String, Long> statuses;
+    private Map<String, Long> languages;
+
+    private Map<String, Long> groups;
+
+    private Map<String, Long> types;
+
+    public CountDTO() {
+        this.statuses = Collections.emptyMap();
+        this.languages = Collections.emptyMap();
+        this.types = Collections.emptyMap();
+        this.groups = Collections.emptyMap();
+    }
+
+    public CountDTO(
+            final Map<String, Long> statuses,
+            final Map<String, Long> languages,
+            final Map<String, Long> types,
+            final Map<String, Long> groups) {
+        this.statuses = statuses;
+        this.languages = languages;
+        this.types = types;
+        this.groups = groups;
+    }
+
+
+
+    public Map<String, Long> getStatuses() {
+        return statuses;
+    }
+
+    public void setStatuses(Map<String, Long> statuses) {
+        this.statuses = statuses;
+    }
+
+    public Map<String, Long> getLanguages() {
+        return languages;
+    }
+
+    public void setLanguages(Map<String, Long> languages) {
+        this.languages = languages;
+    }
+
+    public Map<String, Long> getTypes() {
+        return types;
+    }
+
+    public void setTypes(Map<String, Long> types){
+        this.types = types;
+    }
+
+    public Map<String, Long> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(Map<String, Long> groups) {
+        this.groups = groups;
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/CountSearchResponse.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/CountSearchResponse.java
@@ -1,0 +1,29 @@
+package fi.vm.yti.terminology.api.v2.dto;
+
+public class CountSearchResponse {
+
+    private long totalHitCount;
+    private CountDTO counts;
+
+    public CountSearchResponse() {
+        this.totalHitCount = 0;
+        this.counts = new CountDTO();
+    }
+
+    public long getTotalHitCount() {
+        return totalHitCount;
+    }
+
+    public void setTotalHitCount(long totalHitCount) {
+        this.totalHitCount = totalHitCount;
+    }
+
+    public CountDTO getCounts() {
+        return counts;
+    }
+
+    public void setCounts(CountDTO counts) {
+        this.counts = counts;
+    }
+}
+

--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/SimpleTerminologyDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/SimpleTerminologyDTO.java
@@ -1,0 +1,24 @@
+package fi.vm.yti.terminology.api.v2.dto;
+
+import java.util.Map;
+
+public class SimpleTerminologyDTO {
+    private String prefix;
+    private Map<String, String> label = Map.of();
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public Map<String, String> getLabel() {
+        return label;
+    }
+
+    public void setLabel(Map<String, String> label) {
+        this.label = label;
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/StatusCountResponse.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/StatusCountResponse.java
@@ -1,0 +1,38 @@
+package fi.vm.yti.terminology.api.v2.dto;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class StatusCountResponse {
+    private Map<String, Long> concepts;
+
+    private Map<String, Long> terms;
+
+    public StatusCountResponse() {
+        this.concepts = Collections.emptyMap();
+        this.terms = Collections.emptyMap();
+    }
+
+    public StatusCountResponse(
+            final Map<String, Long> concepts,
+            final Map<String, Long> terms) {
+        this.concepts = concepts;
+        this.terms = terms;
+    }
+
+    public Map<String, Long> getConcepts() {
+        return concepts;
+    }
+
+    public void setConcepts(Map<String, Long> concepts) {
+        this.concepts = concepts;
+    }
+
+    public Map<String, Long> getTerms() {
+        return terms;
+    }
+
+    public void setTerms(Map<String, Long> terms) {
+        this.terms = terms;
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/ConceptCollectionController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/ConceptCollectionController.java
@@ -15,6 +15,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URISyntaxException;
+import java.util.List;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -27,6 +28,15 @@ public class ConceptCollectionController {
 
     public ConceptCollectionController(ConceptCollectionService conceptCollectionService) {
         this.conceptCollectionService = conceptCollectionService;
+    }
+
+    @Operation(summary = "Get add concept collection in terminology")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Concept collections fetched successfully"),
+    })
+    @GetMapping(path = "/{prefix}")
+    public List<ConceptCollectionInfoDTO> list(@PathVariable @Parameter(description = "Terminology prefix") String prefix) {
+        return conceptCollectionService.list(prefix);
     }
 
     @Operation(summary = "Get concept collection information")

--- a/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/ConceptCollectionController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/ConceptCollectionController.java
@@ -30,7 +30,7 @@ public class ConceptCollectionController {
         this.conceptCollectionService = conceptCollectionService;
     }
 
-    @Operation(summary = "Get add concept collection in terminology")
+    @Operation(summary = "Get concept collections in terminology")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Concept collections fetched successfully"),
     })

--- a/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/FakeUserController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/FakeUserController.java
@@ -6,12 +6,17 @@ import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
+@Hidden
+@RequestMapping("v2/fakeable-users")
+@Tag(name = "Admin")
 public class FakeUserController {
 
     private final GroupManagementService groupManagementService;

--- a/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/FrontendController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/FrontendController.java
@@ -7,6 +7,8 @@ import fi.vm.yti.common.opensearch.SearchResponseDTO;
 import fi.vm.yti.common.service.FrontendService;
 import fi.vm.yti.security.AuthenticatedUserProvider;
 import fi.vm.yti.terminology.api.v2.dto.ConceptSearchResultDTO;
+import fi.vm.yti.terminology.api.v2.dto.CountSearchResponse;
+import fi.vm.yti.terminology.api.v2.dto.StatusCountResponse;
 import fi.vm.yti.terminology.api.v2.dto.TerminologySearchResultDTO;
 import fi.vm.yti.terminology.api.v2.opensearch.ConceptSearchRequest;
 import fi.vm.yti.terminology.api.v2.opensearch.TerminologySearchRequest;
@@ -81,5 +83,29 @@ public class FrontendController {
             @Parameter(description = "Concept search parameters") ConceptSearchRequest request
     ) {
         return searchIndexService.searchConcepts(request, userProvider.getUser());
+    }
+
+    @Operation(summary = "Get frontpage counts")
+    @ApiResponse(responseCode = "200", description = "")
+    @GetMapping(value = "/counts", produces = APPLICATION_JSON_VALUE)
+    public CountSearchResponse getCounts() {
+        // TODO: placeholder
+        return new CountSearchResponse();
+    }
+
+    @Operation(summary = "Get concept counts")
+    @ApiResponse(responseCode = "200", description = "")
+    @GetMapping(value = "/concept-counts", produces = APPLICATION_JSON_VALUE)
+    public CountSearchResponse getConceptCounts(@RequestParam String prefix) {
+        // TODO: placeholder
+        return new CountSearchResponse();
+    }
+
+    @Operation(summary = "Get status counts")
+    @ApiResponse(responseCode = "200", description = "")
+    @GetMapping(value = "/status-counts", produces = APPLICATION_JSON_VALUE)
+    public StatusCountResponse getStatusCounts(@RequestParam String prefix) {
+        // TODO: placeholder
+        return new StatusCountResponse();
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/ImportController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/ImportController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterStyle;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -31,5 +32,17 @@ public class ImportController {
                                      @RequestPart(value = "file") MultipartFile file) {
         ntrfImportService.importNTRF(prefix, file);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "Initiate simple Excel import job", description = "Start the procedure to import concepts from Excel file")
+    @ApiResponse(
+            responseCode = "200",
+            description = "If import process started successfully then job token is returned as JSON")
+    @PostMapping(path = "simpleExcel/{prefix}", consumes = MULTIPART_FORM_DATA_VALUE)
+    ResponseEntity<Void> importSimpleExcel(@Parameter(description = "The ID of the terminology to import concepts to")
+                                                             @PathVariable("prefix") String prefix,
+                                                             @RequestPart(value = "file") MultipartFile file) {
+        // TODO: implement simple excel import
+        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/UserController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/UserController.java
@@ -1,0 +1,29 @@
+package fi.vm.yti.terminology.api.v2.endpoint;
+
+import fi.vm.yti.security.AuthenticatedUserProvider;
+import fi.vm.yti.security.YtiUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("v2/user")
+@Tag(name = "Users")
+public class UserController {
+
+    private final AuthenticatedUserProvider userProvider;
+
+    UserController(AuthenticatedUserProvider userProvider) {
+        this.userProvider = userProvider;
+    }
+
+    @GetMapping
+    @Operation(description = "Get authenticated user")
+    @ApiResponse(responseCode = "200", description = "User object")
+    public YtiUser getUser() {
+        return userProvider.getUser();
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/exception/ResourceInUseException.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/exception/ResourceInUseException.java
@@ -1,0 +1,50 @@
+package fi.vm.yti.terminology.api.v2.exception;
+
+import java.util.List;
+import java.util.Map;
+
+public class ResourceInUseException extends RuntimeException {
+
+    private final List<ReferenceDetail> refList;
+
+    public ResourceInUseException(List<ReferenceDetail> refList) {
+        super("resource-in-use");
+        this.refList = refList;
+    }
+
+    public List<ReferenceDetail> getRefList() {
+        return refList;
+    }
+
+    public static class ReferenceDetail {
+        private Map<String, String> label;
+        private String uri;
+        private String property;
+
+        public Map<String, String> getLabel() {
+            return label;
+        }
+
+        public void setLabel(Map<String, String> label) {
+            this.label = label;
+        }
+
+        public String getUri() {
+            return uri;
+        }
+
+        public void setUri(String uri) {
+            this.uri = uri;
+        }
+
+        public String getProperty() {
+            return property;
+        }
+
+        public void setProperty(String property) {
+            this.property = property;
+        }
+    }
+}
+
+

--- a/src/main/java/fi/vm/yti/terminology/api/v2/exception/TerminologyExceptionHandlerAdvice.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/exception/TerminologyExceptionHandlerAdvice.java
@@ -1,13 +1,29 @@
 package fi.vm.yti.terminology.api.v2.exception;
 
+import fi.vm.yti.common.exception.ApiGenericError;
 import fi.vm.yti.common.exception.ExceptionHandlerAdvice;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.stream.Collectors;
 
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @ControllerAdvice
 public class TerminologyExceptionHandlerAdvice extends ExceptionHandlerAdvice {
 
     // Add terminology specific exception handlers
+
+    @ExceptionHandler(ResourceInUseException.class)
+    protected ResponseEntity<Object> handleAuthorizationException(ResourceInUseException ex) {
+        var apiError = new ApiGenericError(HttpStatus.BAD_REQUEST);
+        apiError.setMessage(ex.getMessage());
+        apiError.setDetails(ex.getRefList().stream()
+                .map(ref -> String.format("%s (%s)", ref.getUri(), ref.getProperty()))
+                .collect(Collectors.joining(", ")));
+        return new ResponseEntity<>(apiError, apiError.getStatus());
+    }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptCollectionMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptCollectionMapper.java
@@ -126,7 +126,9 @@ public class ConceptCollectionMapper {
 
     private static void addMembers(ModelWrapper model, Resource resource, Set<String> values) {
         var resources = values.stream()
-                .map(model::getResourceById)
+                .map(value -> value.contains("://")
+                        ? model.getResource(value)
+                        : model.getResourceById(value))
                 .toList();
 
         MapperUtils.addListProperty(resource, SKOS.member, resources);

--- a/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptCollectionMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptCollectionMapper.java
@@ -109,7 +109,7 @@ public class ConceptCollectionMapper {
                             labelMap.put(labelProperty.getLanguage(), labelProperty.getString());
                         }
                     });
-                    dto.addMember(concept.getLocalName(), concept.getURI(), labelMap);
+                    dto.addMember(concept.getLocalName(), concept.getURI(), labelMap, model.getPrefix());
                 });
 
         MapperUtils.mapCreationInfo(dto, resource, mapUser);

--- a/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapper.java
@@ -14,6 +14,7 @@ import fi.vm.yti.terminology.api.v2.enums.TermFamily;
 import fi.vm.yti.terminology.api.v2.enums.WordClass;
 import fi.vm.yti.terminology.api.v2.opensearch.IndexConcept;
 import fi.vm.yti.terminology.api.v2.property.Term;
+import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.sparql.vocabulary.FOAF;
 import org.apache.jena.vocabulary.*;
@@ -157,6 +158,7 @@ public class ConceptMapper {
         var indexConcept = new IndexConcept();
         indexConcept.setId(resource.getURI());
         indexConcept.setUri(resource.getURI());
+        indexConcept.setIdentifier(resource.getLocalName());
         indexConcept.setStatus(MapperUtils.getStatus(resource));
         indexConcept.setNamespace(resource.getNameSpace());
         indexConcept.setLabel(prefLabels);
@@ -194,8 +196,10 @@ public class ConceptMapper {
         var result = new LinkedHashSet<ConceptReferenceInfoDTO>();
         MapperUtils.getResourceList(resource, property).forEach(ref -> {
             var refDTO = new ConceptReferenceInfoDTO();
-            refDTO.setConceptURI(ref.getURI());
-
+            var terminologyURI = TerminologyURI.fromUri(ref.getURI());
+            refDTO.setReferenceURI(terminologyURI.getResourceURI());
+            refDTO.setIdentifier(terminologyURI.getResourceId());
+            refDTO.setPrefix(terminologyURI.getPrefix());
             var label = new HashMap<String, String>();
             MapperUtils.getResourceList(model.getResource(ref.getURI()), SKOS.prefLabel).forEach(r -> {
                 var value = r.getProperty(SKOSXL.literalForm);

--- a/src/main/java/fi/vm/yti/terminology/api/v2/mapper/NTRFMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/mapper/NTRFMapper.java
@@ -78,10 +78,7 @@ public class NTRFMapper {
         dto.setIdentifier(collection.getNumb());
 
         var members = new LinkedHashSet<String>();
-        collection.getLINK().forEach(member -> {
-            var conceptId = member.getHref().substring(1);
-            members.add(TerminologyURI.createConceptURI(model.getPrefix(), conceptId).getResourceURI());
-        });
+        collection.getLINK().forEach(member -> members.add(member.getHref().substring(1)));
         dto.setMembers(members);
 
         var collectionResource = model.getResourceById(collection.getNumb());

--- a/src/main/java/fi/vm/yti/terminology/api/v2/mapper/TerminologyMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/mapper/TerminologyMapper.java
@@ -68,7 +68,7 @@ public class TerminologyMapper {
         dto.setLabel(MapperUtils.localizedPropertyToMap(resource, SKOS.prefLabel));
         dto.setDescription(MapperUtils.localizedPropertyToMap(resource, RDFS.comment));
         dto.setContact(MapperUtils.propertyToString(resource, SuomiMeta.contact));
-        dto.setModelType(GraphType.valueOf(MapperUtils.propertyToString(resource, Term.terminologyType)));
+        dto.setGraphType(getTerminologyType(resource));
         dto.setLanguages(MapperUtils.arrayPropertyToSet(resource, DCTerms.language));
         dto.setStatus(MapperUtils.getStatus(resource));
 
@@ -105,7 +105,7 @@ public class TerminologyMapper {
         index.setStatus(MapperUtils.getStatus(terminologyResource));
         index.setModified(terminologyResource.getProperty(DCTerms.modified).getString());
         index.setCreated(terminologyResource.getProperty(DCTerms.created).getString());
-
+        index.setType(getTerminologyType(terminologyResource));
         var organizations = MapperUtils.arrayPropertyToSet(terminologyResource, DCTerms.contributor)
                 .stream()
                 .map(o -> o.replace(Constants.URN_UUID, ""))
@@ -160,5 +160,14 @@ public class TerminologyMapper {
                 DCTerms.contributor,
                 ResourceFactory.createResource(Constants.URN_UUID + org)
         ));
+    }
+
+    private static GraphType getTerminologyType(Resource resource) {
+        try {
+            return GraphType.valueOf(MapperUtils.propertyToString(resource, Term.terminologyType));
+        } catch (IllegalArgumentException e) {
+            // invalid type
+        }
+        return null;
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedDataMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedDataMapper.java
@@ -52,7 +52,9 @@ public class TermedDataMapper {
         terminologyDTO.setOrganizations(organizations);
 
         var groups = MapperUtils.arrayPropertyToSet(metaResource, DCTerms.isPartOf);
-
+        LOG.info("Found groups {}", groups);
+        LOG.info("All groups {}", allCategories.size());
+        LOG.info("sample {}, {}", allCategories.get(0).getId(), allCategories.get(0).getIdentifier());
         var newGroups = new HashSet<String>();
         groups.forEach(group ->
                 allCategories.stream()

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptQueryFactory.java
@@ -14,7 +14,8 @@ import java.util.Set;
 import static fi.vm.yti.common.opensearch.OpenSearchUtil.logPayload;
 
 public class ConceptQueryFactory {
-    public ConceptQueryFactory() {
+    private ConceptQueryFactory() {
+        // static methods
     }
 
     public static SearchRequest createConceptQuery(
@@ -83,6 +84,16 @@ public class ConceptQueryFactory {
                             .field("namespace")
                             .value(FieldValue.of(request.getNamespace())))
                     .toQuery());
+        }
+
+        if (request.getExcludeNamespace() != null) {
+            allQueries.add(QueryBuilders.bool()
+                    .mustNot(
+                        TermQuery.of(q -> q
+                                .field("namespace")
+                                .value(FieldValue.of(request.getExcludeNamespace())))
+                        .toQuery())
+                    .build().toQuery());
         }
 
         if (!isSuperUser) {

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptSearchRequest.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptSearchRequest.java
@@ -2,11 +2,10 @@ package fi.vm.yti.terminology.api.v2.opensearch;
 
 import fi.vm.yti.common.opensearch.BaseSearchRequest;
 
-import java.util.Set;
-import java.util.UUID;
-
 public class ConceptSearchRequest extends BaseSearchRequest {
     private String namespace;
+    private String excludeNamespace;
+    private boolean extendTerminologies;
 
     public String getNamespace() {
         return namespace;
@@ -14,5 +13,21 @@ public class ConceptSearchRequest extends BaseSearchRequest {
 
     public void setNamespace(String namespace) {
         this.namespace = namespace;
+    }
+
+    public String getExcludeNamespace() {
+        return excludeNamespace;
+    }
+
+    public void setExcludeNamespace(String excludeNamespace) {
+        this.excludeNamespace = excludeNamespace;
+    }
+
+    public boolean isExtendTerminologies() {
+        return extendTerminologies;
+    }
+
+    public void setExtendTerminologies(boolean extendTerminologies) {
+        this.extendTerminologies = extendTerminologies;
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/IndexConcept.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/IndexConcept.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 public class IndexConcept extends IndexBase {
     private String namespace;
+    private String identifier;
     private Map<String, String> definition;
     private Map<String, List<String>> altLabel;
     private Map<String, List<String>> searchTerm;
@@ -18,6 +19,14 @@ public class IndexConcept extends IndexBase {
 
     public void setNamespace(String namespace) {
         this.namespace = namespace;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
     }
 
     public Map<String, String> getDefinition() {

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologyQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologyQueryFactory.java
@@ -1,12 +1,9 @@
 package fi.vm.yti.terminology.api.v2.opensearch;
 
-import fi.vm.yti.common.opensearch.OpenSearchClientWrapper;
 import fi.vm.yti.common.opensearch.SearchResponseDTO;
 import fi.vm.yti.common.opensearch.QueryFactoryUtils;
 import fi.vm.yti.terminology.api.v2.dto.ConceptSearchResultDTO;
 import fi.vm.yti.terminology.api.v2.service.IndexService;
-import org.apache.commons.lang3.NotImplementedException;
-import org.apache.jena.query.QueryFactory;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.query_dsl.*;
 import org.opensearch.client.opensearch.core.SearchRequest;
@@ -16,13 +13,12 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static fi.vm.yti.common.opensearch.OpenSearchUtil.logPayload;
 
 public class TerminologyQueryFactory {
 
-    private static final Logger logger = LoggerFactory.getLogger(OpenSearchClientWrapper.class);
+    private static final Logger logger = LoggerFactory.getLogger(TerminologyQueryFactory.class);
 
     private TerminologyQueryFactory() {
     }
@@ -242,11 +238,25 @@ public class TerminologyQueryFactory {
                                 .map(FieldValue::of)
                                 .toList())))
                 .toQuery();
-        var sr = new SearchRequest.Builder()
+        return new SearchRequest.Builder()
                 .index(IndexService.TERMINOLOGY_INDEX)
                 .size(10000)
                 .query(q1)
                 .build();
-        return sr;
+    }
+
+    public static SearchRequest createFetchTerminologiesByNamespaceQuery(Set<String> namespaces) {
+        var query = TermsQuery.of(q -> q
+                .field("uri")
+                .terms(t -> t.value(namespaces
+                        .stream()
+                        .map(FieldValue::of)
+                        .toList())
+                )).toQuery();
+        return new SearchRequest.Builder()
+                .index(IndexService.TERMINOLOGY_INDEX)
+                .size(10000)
+                .query(query)
+                .build();
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/service/IndexService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/service/IndexService.java
@@ -130,6 +130,7 @@ public class IndexService extends OpenSearchInitializer {
                         getDynamicTemplate("notRecommendedSynonym", "notRecommendedSynonym.*")))
                 .properties(Map.ofEntries(
                         Map.entry("id", getKeywordProperty()),
+                        Map.entry("identifier", getKeywordProperty()),
                         Map.entry("uri", getKeywordProperty()),
                         Map.entry("status", getKeywordProperty()),
                         Map.entry("namespace", getKeywordProperty()),

--- a/src/main/java/fi/vm/yti/terminology/api/v2/util/TerminologyURI.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/util/TerminologyURI.java
@@ -24,6 +24,8 @@ public class TerminologyURI extends GraphURI {
     }
 
     public static TerminologyURI fromUri(String uri) {
+        // remove query parameters
+        uri = uri.split("\\?")[0];
         var matcher = iriPattern.matcher(uri);
         if (matcher.matches()) {
             var prefix = matcher.group("prefix");

--- a/src/test/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapperTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapperTest.java
@@ -245,11 +245,11 @@ class ConceptMapperTest {
         assertEquals("https://dvv.fi", link.getUri());
 
         var internalRef = dto.getBroader().iterator().next();
-        assertEquals(graphURI + "concept-2", internalRef.getConceptURI());
+        assertEquals(graphURI + "concept-2", internalRef.getReferenceURI());
         assertEquals("Suositettava termi", internalRef.getLabel().get("fi"));
 
         var externalRef = dto.getNarrowMatch().iterator().next();
-        assertEquals(TerminologyURI.createConceptURI("ext", "concept-1").getResourceURI(), externalRef.getConceptURI());
+        assertEquals(TerminologyURI.createConceptURI("ext", "concept-1").getResourceURI(), externalRef.getReferenceURI());
     }
 
     @Test

--- a/src/test/java/fi/vm/yti/terminology/api/v2/mapper/TerminologyMapperTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/mapper/TerminologyMapperTest.java
@@ -129,7 +129,7 @@ class TerminologyMapperTest {
 
         assertEquals("test", dto.getPrefix());
         assertEquals(graphURI, dto.getUri());
-        assertEquals(GraphType.TERMINOLOGICAL_VOCABULARY, dto.getModelType());
+        assertEquals(GraphType.TERMINOLOGICAL_VOCABULARY, dto.getGraphType());
         assertEquals(Status.DRAFT, dto.getStatus());
         assertEquals("Label fi", dto.getLabel().get("fi"));
         assertEquals("Label en", dto.getLabel().get("en"));

--- a/src/test/java/fi/vm/yti/terminology/api/v2/service/ConceptServiceTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/service/ConceptServiceTest.java
@@ -263,7 +263,7 @@ class ConceptServiceTest {
 
         when(repository.fetchByPrefix(conceptURI.getPrefix())).thenReturn(model);
         when(repository.resourceExistsInGraph(conceptURI.getGraphURI(), conceptURI.getResourceURI())).thenReturn(true);
-
+        when(repository.queryConstruct(any(Query.class))).thenReturn(ModelFactory.createDefaultModel());
         conceptService.delete("test", "concept-2");
 
         // resource concept-2 should not exists and it should not exists as an object either


### PR DESCRIPTION
Missing features and fixes noticed when setting up UI for new backend:
- Implemented list of collections in terminology
- Add user and fakeuser controllers
- Mapped info to concept if concept is part of any collection
- Stub implementations for count endpoints (/counts, /concept-counts, /status-counts) and excel import
- Better handling for removing concept: check that there are no references to the concept being removed 
- New search functionalities: 
  - exclude single terminology from concept search (parameter `excludeNamespace`)
  - map terminology info to concept search if requested (parameter `extendTerminologies`)