### PR TITLE
YTI-4244 Improve performance

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/v2/enums/TermFamily.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/enums/TermFamily.java
@@ -1,7 +1,7 @@
 package fi.vm.yti.terminology.api.v2.enums;
 
 public enum TermFamily {
-    NEUTRAL,
+    NEUTER,
     FEMININE,
     MASCULINE
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/mapper/NTRFMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/mapper/NTRFMapper.java
@@ -322,7 +322,7 @@ public class NTRFMapper {
             dto.setTermConjugation(TermConjugation.PLURAL);
         } else if ("n pl".equalsIgnoreCase(gt.getValue())) {
             dto.setTermConjugation(TermConjugation.PLURAL);
-            dto.setTermFamily(TermFamily.NEUTRAL);
+            dto.setTermFamily(TermFamily.NEUTER);
         } else if ("f pl".equalsIgnoreCase(gt.getValue())) {
             dto.setTermConjugation(TermConjugation.PLURAL);
             dto.setTermFamily(TermFamily.FEMININE);
@@ -333,7 +333,7 @@ public class NTRFMapper {
         } else if ("m".equalsIgnoreCase(gt.getGend())) {
             dto.setTermFamily(TermFamily.MASCULINE);
         } else if ("n".equalsIgnoreCase(gt.getGend())) {
-            dto.setTermFamily(TermFamily.NEUTRAL);
+            dto.setTermFamily(TermFamily.NEUTER);
         }
         // wordClass
         if (gt.getPos() != null && !gt.getPos().isEmpty()) {

--- a/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedDataMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedDataMapper.java
@@ -37,7 +37,8 @@ public class TermedDataMapper {
     private static final Map<String, Enum<?>> enumValueMap = Map.ofEntries(
             Map.entry("maskuliini", TermFamily.MASCULINE),
             Map.entry("feminiini", TermFamily.FEMININE),
-            Map.entry("neutri", TermFamily.NEUTRAL),
+            Map.entry("neutri", TermFamily.NEUTER),
+            Map.entry("neutral", TermFamily.NEUTER),
             Map.entry("monikko", TermConjugation.PLURAL),
             Map.entry("yksikkö", TermConjugation.SINGULAR),
             Map.entry(">", TermEquivalency.BROADER),

--- a/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedMigrationService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedMigrationService.java
@@ -181,14 +181,14 @@ public class TermedMigrationService {
         var modified = oldData.getString("lastModifiedDate");
         var modifier = oldData.getString("lastModifiedBy");
 
-        resource.removeAll(DCTerms.creator)
+        resource.removeAll(SuomiMeta.creator)
                 .removeAll(DCTerms.created)
                 .removeAll(DCTerms.modified)
                 .removeAll(SuomiMeta.modifier);
 
         resource.addProperty(DCTerms.created, ResourceFactory.createTypedLiteral(created));
         resource.addProperty(DCTerms.modified, ResourceFactory.createTypedLiteral(modified));
-        resource.addProperty(DCTerms.creator, creator);
+        resource.addProperty(SuomiMeta.creator, creator);
         resource.addProperty(SuomiMeta.modifier, modifier);
         resource.addProperty(Termed.id, node.get("id").asText());
     }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedMigrationService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedMigrationService.java
@@ -1,21 +1,22 @@
 package fi.vm.yti.terminology.api.v2.migration.v1;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import fi.vm.yti.common.Constants;
 import fi.vm.yti.common.properties.SuomiMeta;
+import fi.vm.yti.common.service.FrontendService;
+import fi.vm.yti.common.util.ModelWrapper;
 import fi.vm.yti.security.AuthenticatedUserProvider;
 import fi.vm.yti.security.AuthorizationException;
+import fi.vm.yti.terminology.api.v2.mapper.ConceptCollectionMapper;
+import fi.vm.yti.terminology.api.v2.mapper.ConceptMapper;
+import fi.vm.yti.terminology.api.v2.mapper.TerminologyMapper;
 import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
-import fi.vm.yti.terminology.api.v2.service.ConceptCollectionService;
-import fi.vm.yti.terminology.api.v2.service.ConceptService;
 import fi.vm.yti.terminology.api.v2.service.TerminologyService;
 import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
-import org.apache.jena.arq.querybuilder.UpdateBuilder;
-import org.apache.jena.arq.querybuilder.WhereBuilder;
-import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.DCTerms;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.SKOS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,21 +31,14 @@ import org.springframework.web.util.UriBuilder;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.resources.ConnectionProvider;
 
-import java.net.URISyntaxException;
-
 @Service
 public class TermedMigrationService {
 
     private static final Logger LOG = LoggerFactory.getLogger(TermedMigrationService.class);
 
-    @Value("${terminology.host:https://sanastot.test.yti.cloud.dvv.fi}")
-    String terminologyHost;
-
     private final TerminologyService terminologyService;
 
-    private final ConceptService conceptService;
-
-    private final ConceptCollectionService collectionService;
+    private final FrontendService frontendService;
 
     private final TerminologyRepository terminologyRepository;
 
@@ -52,25 +46,23 @@ public class TermedMigrationService {
     private final AuthenticatedUserProvider userProvider;
 
     public TermedMigrationService(TerminologyService terminologyService,
-                                  ConceptService conceptService,
                                   TerminologyRepository terminologyRepository,
                                   AuthenticatedUserProvider userProvider,
-                                  ConceptCollectionService collectionService,
+                                  FrontendService frontendService,
                                   @Value("${api.url:http://localhost:9102/api}") String termedHost,
                                   @Value("${api.user:}") String termedUser,
                                   @Value("${api.pw:}") String termedPassword) {
         this.terminologyService = terminologyService;
-        this.conceptService = conceptService;
         this.terminologyRepository = terminologyRepository;
         this.userProvider = userProvider;
-        this.collectionService = collectionService;
+        this.frontendService = frontendService;
 
         HttpHeaders defaultHttpHeaders = new HttpHeaders();
         defaultHttpHeaders.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
         defaultHttpHeaders.setBasicAuth(termedUser, termedPassword);
 
         final ExchangeStrategies strategies = ExchangeStrategies.builder()
-                .codecs(codecs -> codecs.defaultCodecs().maxInMemorySize(16 * 1024 * 1024))
+                .codecs(codecs -> codecs.defaultCodecs().maxInMemorySize(200 * 1024 * 1024))
                 .build();
         this.webClient = WebClient.builder()
                 .exchangeStrategies(strategies)
@@ -83,7 +75,7 @@ public class TermedMigrationService {
     }
 
     @Async
-    public void migrateAll() throws URISyntaxException {
+    public void migrateAll() {
         var graphs = webClient.get()
                 .uri(UriBuilder::build)
                 .retrieve()
@@ -98,7 +90,7 @@ public class TermedMigrationService {
                     continue;
                 }
                 var id = graph.get("id").asText();
-                LOG.info("Migrate graph {}/{}, {}", id, count, graphs.size());
+                LOG.info("Migrate graph {}, ({}/{})", id, count, graphs.size());
                 migrate(id);
                 count++;
             }
@@ -106,7 +98,7 @@ public class TermedMigrationService {
     }
 
     @Async
-    public void migrate(final String terminologyId) throws URISyntaxException {
+    public void migrate(final String terminologyId) {
         if (!userProvider.getUser().isSuperuser()) {
             throw new AuthorizationException("Not allowed");
         }
@@ -128,27 +120,36 @@ public class TermedMigrationService {
             // not yet added
         }
 
-        terminologyService.create(terminologyDTO);
+        var categories = frontendService.getServiceCategories("fi");
+        var graphURI = TerminologyURI.createTerminologyURI(terminologyDTO.getPrefix()).getGraphURI();
 
-        updateTimestamps(terminologyNode, terminologyDTO.getPrefix(), null);
-        addTermedId(terminologyDTO.getPrefix(), null, terminologyId);
+        var model = TerminologyMapper.dtoToModel(terminologyDTO, graphURI, categories, userProvider.getUser());
+        fixMetadata(terminologyNode, model.getModelResource());
 
-        handleConceptTermedData(terminologyId, terminologyDTO.getPrefix(), defaultLanguage);
-        handleCollectionTermedData(terminologyId, terminologyDTO.getPrefix());
+        handleConceptTermedData(model, terminologyId, defaultLanguage);
+
+        if (!model.listSubjectsWithProperty(RDF.type, SKOS.Concept).hasNext()) {
+            LOG.info("Skip empty terminology {}", terminologyId);
+            return;
+        }
+        handleCollectionTermedData(model, terminologyId);
+
+        terminologyRepository.put(graphURI, model);
+
         LOG.info("Terminology {} migrated", terminologyId);
     }
 
-    private void handleConceptTermedData(String terminologyId, String prefix, String defaultLanguage) {
+    private void handleConceptTermedData(ModelWrapper model, String terminologyId, String defaultLanguage) {
         var result = getTermedDataByType(terminologyId, "Concept");
-
+        var user = userProvider.getUser();
         if (result != null && !result.isEmpty()) {
             result.iterator().forEachRemaining(concept -> {
                 try {
                     var dto = TermedDataMapper.mapConcept(concept, defaultLanguage);
+                    ConceptMapper.dtoToModel(model, dto, user);
 
-                    conceptService.create(prefix, dto);
-                    updateTimestamps(concept, prefix, dto.getIdentifier());
-                    addTermedId(prefix, dto.getIdentifier(), concept.get("id").asText());
+                    var resource = model.getResourceById(dto.getIdentifier());
+                    fixMetadata(concept, resource);
                 } catch (Exception e) {
                     LOG.error("MIGRATION ERROR concept " + concept.get("uri").asText(), e);
                 }
@@ -156,17 +157,16 @@ public class TermedMigrationService {
         }
     }
 
-    private void handleCollectionTermedData(String terminologyId, String prefix) {
+    private void handleCollectionTermedData(ModelWrapper model, String terminologyId) {
         var result = getTermedDataByType(terminologyId, "Collection");
+        var user = userProvider.getUser();
 
         if (result != null && !result.isEmpty()) {
             result.iterator().forEachRemaining(collection -> {
                 try {
                     var dto = TermedDataMapper.mapCollection(collection);
-
-                    collectionService.create(prefix, dto);
-                    updateTimestamps(collection, prefix, dto.getIdentifier());
-                    addTermedId(prefix, dto.getIdentifier(), collection.get("id").asText());
+                    ConceptCollectionMapper.dtoToModel(model, dto, user);
+                    fixMetadata(collection, model.getResourceById(dto.getIdentifier()));
                 } catch (Exception e) {
                     LOG.error("MIGRATION ERROR collection " + collection.get("uri").asText(), e);
                 }
@@ -174,66 +174,23 @@ public class TermedMigrationService {
         }
     }
 
-    private void updateTimestamps(JsonNode node, String prefix, String identifier) {
-        TerminologyURI terminologyURI;
-        Resource subject;
-        if (identifier != null) {
-            terminologyURI = TerminologyURI.createConceptURI(prefix, identifier);
-            subject = ResourceFactory.createResource(terminologyURI.getResourceURI());
-        } else {
-            terminologyURI = TerminologyURI.createTerminologyURI(prefix);
-            subject = ResourceFactory.createResource(terminologyURI.getModelResourceURI());
-        }
-        var graph = NodeFactory.createURI(terminologyURI.getGraphURI());
-        
-        var builder = new UpdateBuilder();
-        builder.addPrefixes(Constants.PREFIXES);
-
+    private static void fixMetadata(JsonNode node, Resource resource) {
         var oldData = new TermedDataParser(node);
-
         var created = oldData.getString("createdDate");
         var creator = oldData.getString("createdBy");
         var modified = oldData.getString("lastModifiedDate");
         var modifier = oldData.getString("lastModifiedBy");
 
-        builder.addDelete(graph, subject, SuomiMeta.creator, "?creator")
-                .addDelete(graph, subject, SuomiMeta.modifier, "?modifier")
-                .addDelete(graph, subject, DCTerms.created, "?created")
-                .addDelete(graph, subject, DCTerms.modified, "?modified")
-                .addInsert(graph, subject, DCTerms.created, created)
-                .addInsert(graph, subject, DCTerms.modified, modified)
-                .addInsert(graph, subject, SuomiMeta.creator, creator)
-                .addInsert(graph, subject, SuomiMeta.modifier, modifier);
+        resource.removeAll(DCTerms.creator)
+                .removeAll(DCTerms.created)
+                .removeAll(DCTerms.modified)
+                .removeAll(SuomiMeta.modifier);
 
-        var whereBuilder = new WhereBuilder()
-                .addWhere(subject, SuomiMeta.creator, "?creator")
-                .addWhere(subject, SuomiMeta.modifier, "?modifier")
-                .addWhere(subject, DCTerms.created, "?created")
-                .addWhere(subject, DCTerms.modified, "?modified");
-
-        builder.addGraph(graph, whereBuilder);
-        
-        terminologyRepository.queryUpdate(builder.buildRequest());
-    }
-
-    private void addTermedId(String prefix, String identifier, String termedId) {
-        TerminologyURI terminologyURI;
-        Resource subject;
-        if (identifier != null) {
-            terminologyURI = TerminologyURI.createConceptURI(prefix, identifier);
-            subject = ResourceFactory.createResource(terminologyURI.getResourceURI());
-        } else {
-            terminologyURI = TerminologyURI.createTerminologyURI(prefix);
-            subject = ResourceFactory.createResource(terminologyURI.getModelResourceURI());
-        }
-
-        var builder = new UpdateBuilder();
-        builder.addPrefixes(Constants.PREFIXES);
-        var graph = NodeFactory.createURI(terminologyURI.getGraphURI());
-
-        builder.addInsert(graph, subject, Termed.id, termedId);
-
-        terminologyRepository.queryUpdate(builder.buildRequest());
+        resource.addProperty(DCTerms.created, ResourceFactory.createTypedLiteral(created));
+        resource.addProperty(DCTerms.modified, ResourceFactory.createTypedLiteral(modified));
+        resource.addProperty(DCTerms.creator, creator);
+        resource.addProperty(SuomiMeta.modifier, modifier);
+        resource.addProperty(Termed.id, node.get("id").asText());
     }
 
     private JsonNode getTermedDataByType(String terminologyId, String type) {
@@ -241,7 +198,10 @@ public class TermedMigrationService {
                 .pathSegment(terminologyId, "node-trees")
                 .queryParam("select", "*")
                 .queryParam("where", "type.id:" + type)
-                .queryParam("max", 10000)
-                .build()).retrieve().bodyToMono(JsonNode.class).block();
+                .queryParam("max", "-1")
+                .build())
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/repository/TerminologyRepository.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/repository/TerminologyRepository.java
@@ -12,6 +12,8 @@ import org.apache.jena.rdfconnection.RDFConnection;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 
+import java.util.concurrent.TimeUnit;
+
 @Repository
 public class TerminologyRepository extends BaseRepository {
 
@@ -23,7 +25,10 @@ public class TerminologyRepository extends BaseRepository {
                 RDFConnection.connect(endpoint + "/terminology/sparql"),
                 RDFConnection.connect(endpoint + "/terminology/update")
         );
-        this.modelCache = CacheBuilder.newBuilder().maximumSize(50).build();
+        this.modelCache = CacheBuilder.newBuilder()
+                .expireAfterWrite(30, TimeUnit.MINUTES)
+                .maximumSize(50)
+                .build();
     }
 
     @Override

--- a/src/main/java/fi/vm/yti/terminology/api/v2/repository/TerminologyRepository.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/repository/TerminologyRepository.java
@@ -1,10 +1,13 @@
 package fi.vm.yti.terminology.api.v2.repository;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import fi.vm.yti.common.Constants;
 import fi.vm.yti.common.repository.BaseRepository;
 import fi.vm.yti.common.util.ModelWrapper;
 import fi.vm.yti.terminology.api.v2.property.Term;
 import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
+import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdfconnection.RDFConnection;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
@@ -12,21 +15,37 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class TerminologyRepository extends BaseRepository {
 
+    private final Cache<String, ModelWrapper> modelCache;
+
     public TerminologyRepository(@Value(("${fuseki.url}")) String endpoint){
         super(RDFConnection.connect(endpoint + "/terminology/get"),
                 RDFConnection.connect(endpoint + "/terminology/data"),
                 RDFConnection.connect(endpoint + "/terminology/sparql"),
                 RDFConnection.connect(endpoint + "/terminology/update")
         );
+        this.modelCache = CacheBuilder.newBuilder().maximumSize(50).build();
     }
 
     @Override
     public ModelWrapper fetch(String graphURI) {
-        var model = new ModelWrapper(super.fetch(graphURI), graphURI);
+        var model = modelCache.getIfPresent(graphURI);
+
+        if (model != null) {
+            return model;
+        }
+        model = new ModelWrapper(super.fetch(graphURI), graphURI);
         model.setNsPrefixes(Constants.PREFIXES);
         model.setNsPrefix("term", Term.getNamespace());
         model.setNsPrefix(model.getPrefix(), model.getModelResource().getNameSpace());
+
+        modelCache.put(graphURI, model);
         return model;
+    }
+
+    @Override
+    public void put(String graph, Model model) {
+        super.put(graph, model);
+        modelCache.invalidate(graph);
     }
 
     public ModelWrapper fetchByPrefix(String prefix) {

--- a/src/test/java/fi/vm/yti/terminology/api/v2/TestUtils.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/TestUtils.java
@@ -169,7 +169,7 @@ public class TestUtils {
         term.setStatus(Status.VALID);
         term.setScope("scope");
         term.setTermInfo("info");
-        term.setTermFamily(TermFamily.NEUTRAL);
+        term.setTermFamily(TermFamily.NEUTER);
         term.setTermConjugation(TermConjugation.SINGULAR);
         term.setWordClass(WordClass.VERB);
         term.setTermStyle("style");

--- a/src/test/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapperTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapperTest.java
@@ -276,7 +276,7 @@ class ConceptMapperTest {
         assertEquals(2, term.getHomographNumber());
         assertEquals(Status.DRAFT, term.getStatus());
         assertEquals(TermConjugation.SINGULAR, term.getTermConjugation());
-        assertEquals(TermFamily.NEUTRAL, term.getTermFamily());
+        assertEquals(TermFamily.NEUTER, term.getTermFamily());
         assertEquals(WordClass.ADJECTIVE, term.getWordClass());
         assertEquals(TermEquivalency.BROADER, term.getTermEquivalency());
     }

--- a/src/test/java/fi/vm/yti/terminology/api/v2/service/TerminologyServiceTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/service/TerminologyServiceTest.java
@@ -11,6 +11,7 @@ import fi.vm.yti.terminology.api.v2.dto.TerminologyDTO;
 import fi.vm.yti.terminology.api.v2.opensearch.IndexTerminology;
 import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
 import fi.vm.yti.terminology.api.v2.security.TerminologyAuthorizationManager;
+import org.apache.jena.query.Query;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.vocabulary.DCTerms;
 import org.junit.jupiter.api.BeforeEach;
@@ -77,6 +78,7 @@ class TerminologyServiceTest {
 
         var model = TestUtils.getModelFromFile("/terminology-metadata.ttl", GRAPH_URI);
         when(terminologyRepository.fetchByPrefix(PREFIX)).thenReturn(model);
+        when(terminologyRepository.queryConstruct(any(Query.class))).thenReturn(model);
     }
 
     @Test

--- a/src/test/resources/terminology-with-concepts.ttl
+++ b/src/test/resources/terminology-with-concepts.ttl
@@ -67,7 +67,7 @@ test:concept-1  rdfs:seeAlso          ( [
                                              term:scope                    "scope";
                                              term:termConjugation          "SINGULAR";
                                              term:termEquivalency          "BROADER";
-                                             term:termFamily               "NEUTRAL";
+                                             term:termFamily               "NEUTER";
                                              term:termInfo                 "info";
                                              term:termStyle                "term style";
                                              term:wordClass                "ADJECTIVE"


### PR DESCRIPTION
- Migration performance improvement: Map all resources to Jena model and save them at once instead of saving single resources. 
- Use simple CONSTRUCT query for fetching terminology metadata. If the whole model is fetched, i'll cause significant lag when fetching larger terminologies.
- Add model cache, because current implementation requires, that the whole model has to be fetched when fetching single resource (concept or collection)

Other fix: Renamed enum constant NEUTRAL -> NEUTER per feedback