### PR TITLE
Migration data fix and change to terminology search logic

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedDataMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedDataMapper.java
@@ -60,14 +60,18 @@ public class TermedDataMapper {
             "VI", 6
     );
 
-    private static final Map<String, Set<String>> missingLanguageMap = Map.of(
-            "yti", Set.of("sv", "en"),
-            "vtj", Set.of("sv", "en"),
-            "aviovero", Set.of("en"),
-            "jate", Set.of("sv", "en"),
-            "rytj-mkr", Set.of("en"),
-            "a2fc99c20", Set.of("sv"),
-            "nbvoc", Set.of("sv-SE", "nb-NO")
+    private static final Map<String, Set<String>> missingLanguageMap = Map.ofEntries(
+            Map.entry("yti", Set.of("sv", "en")),
+            Map.entry("vtj", Set.of("sv", "en")),
+            Map.entry("aviovero", Set.of("en")),
+            Map.entry("jate", Set.of("sv", "en")),
+            Map.entry("rytj-mkr", Set.of("en")),
+            Map.entry("a2fc99c20", Set.of("sv")),
+            Map.entry("nbvoc", Set.of("sv-SE", "nb-NO")),
+            Map.entry("for", Set.of("ru")), // test environment
+            Map.entry("a989329f0", Set.of("en")), // test environment
+            Map.entry("forestry", Set.of("ru")), // test environment
+            Map.entry("rtestsa", Set.of("sv", "en")) // test environment
     );
 
     private TermedDataMapper() {

--- a/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedMigrationService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedMigrationService.java
@@ -87,13 +87,19 @@ public class TermedMigrationService {
             for (var graph : graphs) {
                 // skip graphs without code, e.g. organization and category graphs
                 if (graph.get("code") == null) {
+                    count++;
                     continue;
                 }
                 var id = graph.get("id").asText();
                 LOG.info("Migrate graph {}, ({}/{})", id, count, graphs.size());
-                migrate(id);
+                try {
+                    migrate(id);
+                } catch (Exception e) {
+                    LOG.error("MIGRATION ERROR terminology: " + id, e);
+                }
                 count++;
             }
+            LOG.info("All terminologies migrated");
         }
     }
 

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologyQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologyQueryFactory.java
@@ -1,5 +1,6 @@
 package fi.vm.yti.terminology.api.v2.opensearch;
 
+import fi.vm.yti.common.enums.Status;
 import fi.vm.yti.common.opensearch.SearchResponseDTO;
 import fi.vm.yti.common.opensearch.QueryFactoryUtils;
 import fi.vm.yti.terminology.api.v2.dto.ConceptSearchResultDTO;
@@ -130,19 +131,24 @@ public class TerminologyQueryFactory {
         }
 
         //
-        // Filter by status
+        // Filter by status. By default, show only VALID, DRAFT, SUGGESTED and INCOMPLETE
         //
-        if (request.getStatus() != null) {
-            mustQueries.add(TermsQuery.of(q -> q
-                            .field("status")
-                            .terms(t -> t.value(request
-                                    .getStatus()
-                                    .stream()
-                                    .map(Enum::name)
-                                    .map(FieldValue::of)
-                                    .toList())))
-                    .toQuery());
-        }
+        var statusList = request.getStatus() != null && !request.getStatus().isEmpty()
+                ? request.getStatus()
+                : List.of(
+                        Status.DRAFT,
+                        Status.INCOMPLETE,
+                        Status.SUGGESTED,
+                        Status.VALID
+                );
+        mustQueries.add(TermsQuery.of(q -> q
+                        .field("status")
+                        .terms(t -> t.value(statusList
+                                .stream()
+                                .map(Enum::name)
+                                .map(FieldValue::of)
+                                .toList())))
+                .toQuery());
 
         //
         // Filter by organizations

--- a/src/test/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologyQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologyQueryFactoryTest.java
@@ -1,5 +1,6 @@
 package fi.vm.yti.terminology.api.v2.opensearch;
 
+import fi.vm.yti.common.enums.Status;
 import fi.vm.yti.common.opensearch.SearchResponseDTO;
 import fi.vm.yti.terminology.api.v2.dto.ConceptSearchResultDTO;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ public class TerminologyQueryFactoryTest {
         request.setQuery("test");
         request.setGroups(Set.of("P11", "P1"));
         request.setPageSize(100);
+        request.setStatus(Set.of(Status.VALID));
         var terminologyQuery = TerminologyQueryFactory.createTerminologyQuery(request, false, null);
         var expected = TestUtils.getJsonString("/opensearch/terminology-request.json");
         JSONAssert.assertEquals(expected, getPayload(terminologyQuery), JSONCompareMode.LENIENT);

--- a/src/test/resources/opensearch/terminology-deep-request.json
+++ b/src/test/resources/opensearch/terminology-deep-request.json
@@ -72,6 +72,16 @@
               },
               {
                 "terms": {
+                  "status": [
+                    "DRAFT",
+                    "INCOMPLETE",
+                    "SUGGESTED",
+                    "VALID"
+                  ]
+                }
+              },
+              {
+                "terms": {
                   "groups": [
                     "P11",
                     "P1"

--- a/src/test/resources/opensearch/terminology-deep-superuser-request.json
+++ b/src/test/resources/opensearch/terminology-deep-superuser-request.json
@@ -45,6 +45,16 @@
               },
               {
                 "terms": {
+                  "status": [
+                    "DRAFT",
+                    "INCOMPLETE",
+                    "SUGGESTED",
+                    "VALID"
+                  ]
+                }
+              },
+              {
+                "terms": {
                   "groups": [
                     "P1",
                     "P11"

--- a/src/test/resources/opensearch/terminology-request.json
+++ b/src/test/resources/opensearch/terminology-request.json
@@ -40,6 +40,13 @@
         },
         {
           "terms": {
+            "status": [
+              "VALID"
+            ]
+          }
+        },
+        {
+          "terms": {
             "groups": [
               "P11",
               "P1"


### PR DESCRIPTION
Fix data during migration process 
- homograph number, e.g. `II` -> 2
- missing languages
- add better logging, if the whole terminology migration fails

Change search logic to include particular statuses by default. This functionality is copied from the old application.