### PR TITLE
Search performance improvement

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapper.java
@@ -184,12 +184,11 @@ public class ConceptMapper {
         model.removeAll(resource, null, null);
     }
 
-    private static Map<String, List<String>> getIndexedTerm(Resource resource, Property property) {
+    private static List<String> getIndexedTerm(Resource resource, Property property) {
         return MapperUtils.getResourceList(resource, property).stream()
                 .filter(r -> r.hasProperty(SKOSXL.literalForm))
-                .collect(Collectors.groupingBy(
-                        r -> r.getProperty(SKOSXL.literalForm).getLanguage(),
-                        Collectors.mapping(r -> r.getProperty(SKOSXL.literalForm).getString(), Collectors.toList())));
+                .map(r -> r.getProperty(SKOSXL.literalForm).getString())
+                .toList();
     }
 
     private static Set<ConceptReferenceInfoDTO> mapConceptReferencesDTO(Model model, Resource resource, Property property) {

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptQueryFactory.java
@@ -59,8 +59,8 @@ public class ConceptQueryFactory {
             var definitionQuery = QueryStringQuery.of(q -> q
                     .query("*" + queryString.trim() + "*")
                     .fields("label.*^5.0")
-                    .fields("altLabel.*^3.0", "searchTerm.*^3.0", "definition.*^3.0")
-                    .fields("notRecommendedSynonym.*")
+                    .fields("altLabel^3.0", "searchTerm^3.0", "definition.*^3.0")
+                    .fields("notRecommendedSynonym")
             ).toQuery();
 
             allQueries.add(definitionQuery);

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptQueryFactory.java
@@ -60,14 +60,10 @@ public class ConceptQueryFactory {
                     .query("*" + queryString.trim() + "*")
                     .fields("label.*^5.0")
                     .fields("altLabel.*^3.0", "searchTerm.*^3.0", "definition.*^3.0")
-                    .fields("notRecommendedSynonym.*^1.5")
+                    .fields("notRecommendedSynonym.*")
             ).toQuery();
 
-            allQueries.add(QueryBuilders.bool()
-                    .should(definitionQuery)
-                    .minimumShouldMatch("1")
-                    .build()
-                    .toQuery());
+            allQueries.add(definitionQuery);
         }
 
         if (request.getStatus() != null) {

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/IndexConcept.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/IndexConcept.java
@@ -9,9 +9,9 @@ public class IndexConcept extends IndexBase {
     private String namespace;
     private String identifier;
     private Map<String, String> definition;
-    private Map<String, List<String>> altLabel;
-    private Map<String, List<String>> searchTerm;
-    private Map<String, List<String>> notRecommendedSynonym;
+    private List<String> altLabel;
+    private List<String> searchTerm;
+    private List<String> notRecommendedSynonym;
 
     public String getNamespace() {
         return namespace;
@@ -37,27 +37,27 @@ public class IndexConcept extends IndexBase {
         this.definition = definition;
     }
 
-    public Map<String, List<String>> getAltLabel() {
+    public List<String> getAltLabel() {
         return altLabel;
     }
 
-    public void setAltLabel(Map<String, List<String>> altLabel) {
+    public void setAltLabel(List<String> altLabel) {
         this.altLabel = altLabel;
     }
 
-    public Map<String, List<String>> getSearchTerm() {
+    public List<String> getSearchTerm() {
         return searchTerm;
     }
 
-    public void setSearchTerm(Map<String, List<String>> searchTerm) {
+    public void setSearchTerm(List<String> searchTerm) {
         this.searchTerm = searchTerm;
     }
 
-    public Map<String, List<String>> getNotRecommendedSynonym() {
+    public List<String> getNotRecommendedSynonym() {
         return notRecommendedSynonym;
     }
 
-    public void setNotRecommendedSynonym(Map<String, List<String>> notRecommendedSynonym) {
+    public void setNotRecommendedSynonym(List<String> notRecommendedSynonym) {
         this.notRecommendedSynonym = notRecommendedSynonym;
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologyQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologyQueryFactory.java
@@ -53,21 +53,24 @@ public class TerminologyQueryFactory {
                                 .lastIndexOf("/")) + "/")
                         .collect(Collectors.toSet());
 
-        logger.debug("Deep concept search resulted in " + additionalTerminologyUris.size() + " terminology matches");
+        logger.debug("Deep concept search resulted in {} terminology matches", additionalTerminologyUris.size());
 
         var terminologyQuery = getTerminologyBaseQuery(request, isSuperUser, additionalTerminologyUris, privilegedOrganizations);
 
         Highlight.Builder highlight = new Highlight.Builder();
         highlight.fields("label.*", f -> f);
-        var sr = new SearchRequest.Builder()
+        var builder = new SearchRequest.Builder()
                 .index(IndexService.TERMINOLOGY_INDEX)
                 .size(QueryFactoryUtils.pageSize(request.getPageSize()))
                 .from(QueryFactoryUtils.pageFrom(request.getPageFrom()))
-                .sort(QueryFactoryUtils.getLangSortOptions(request.getSortLang()))
                 .highlight(highlight.build())
-                .query(terminologyQuery)
-                .build();
+                .query(terminologyQuery);
 
+        if (request.getQuery() == null || request.getQuery().isBlank()) {
+            builder.sort(QueryFactoryUtils.getLangSortOptions(request.getSortLang()));
+        }
+
+        var sr = builder.build();
         logPayload(sr, IndexService.TERMINOLOGY_INDEX);
 
         return sr;

--- a/src/main/java/fi/vm/yti/terminology/api/v2/service/IndexService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/service/IndexService.java
@@ -123,18 +123,18 @@ public class IndexService extends OpenSearchInitializer {
     private TypeMapping getConceptMappings() {
         return new TypeMapping.Builder()
                 .dynamicTemplates(List.of(
-                        getDynamicTemplate("label", "label.*"),
-                        getDynamicTemplate("definition", "definition.*"),
-                        getDynamicTemplate("altLabel", "altLabel.*"),
-                        getDynamicTemplate("searchTerm", "searchTerm.*"),
-                        getDynamicTemplate("notRecommendedSynonym", "notRecommendedSynonym.*")))
+                        getDynamicTemplateWithSortKey("label", "label.*"),
+                        getDynamicTemplate("definition", "definition.*")))
                 .properties(Map.ofEntries(
                         Map.entry("id", getKeywordProperty()),
                         Map.entry("identifier", getKeywordProperty()),
                         Map.entry("uri", getKeywordProperty()),
                         Map.entry("status", getKeywordProperty()),
                         Map.entry("namespace", getKeywordProperty()),
-                        Map.entry("prefix", getKeywordProperty())
+                        Map.entry("prefix", getKeywordProperty()),
+                        Map.entry("altLabel", getTextProperty()),
+                        Map.entry("searchTerm", getTextProperty()),
+                        Map.entry("notRecommendedSynonym", getTextProperty())
                         //Map.entry("created", getDateProperty()),
                         //Map.entry("modified", getDateProperty())
                 ))

--- a/src/main/java/fi/vm/yti/terminology/api/v2/service/IndexService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/service/IndexService.java
@@ -132,11 +132,11 @@ public class IndexService extends OpenSearchInitializer {
                         Map.entry("status", getKeywordProperty()),
                         Map.entry("namespace", getKeywordProperty()),
                         Map.entry("prefix", getKeywordProperty()),
+                        Map.entry("created", getDateProperty()),
+                        Map.entry("modified", getDateProperty()),
                         Map.entry("altLabel", getTextProperty()),
                         Map.entry("searchTerm", getTextProperty()),
                         Map.entry("notRecommendedSynonym", getTextProperty())
-                        //Map.entry("created", getDateProperty()),
-                        //Map.entry("modified", getDateProperty())
                 ))
                 .build();
     }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/service/IndexService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/service/IndexService.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Map;
 
-import static fi.vm.yti.common.opensearch.OpenSearchUtil.logPayload;
+import static fi.vm.yti.common.opensearch.OpenSearchUtil.*;
 
 @Service
 public class IndexService extends OpenSearchInitializer {
@@ -150,23 +150,5 @@ public class IndexService extends OpenSearchInitializer {
         client.putToIndex(TERMINOLOGY_INDEX, index);
 
         initConceptIndex(model);
-    }
-
-    private Map<String, DynamicTemplate> getDynamicTemplate(String name, String pathMatch) {
-        return Map.of(name, new DynamicTemplate.Builder()
-                .pathMatch(pathMatch)
-                .mapping(getTextProperty()).build());
-    }
-
-    private Property getKeywordProperty() {
-        return new Property.Builder()
-                .keyword(new KeywordProperty.Builder().build())
-                .build();
-    }
-
-    private Property getTextProperty() {
-        return new Property.Builder()
-                .text(new TextProperty.Builder().build())
-                .build();
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/service/IndexService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/service/IndexService.java
@@ -15,7 +15,7 @@ import org.apache.jena.arq.querybuilder.SelectBuilder;
 import org.apache.jena.arq.querybuilder.WhereBuilder;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.SKOS;
-import org.opensearch.client.opensearch._types.mapping.TypeMapping;
+import org.opensearch.client.opensearch._types.mapping.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Map;
 
-import static fi.vm.yti.common.opensearch.OpenSearchUtil.*;
+import static fi.vm.yti.common.opensearch.OpenSearchUtil.logPayload;
 
 @Service
 public class IndexService extends OpenSearchInitializer {
@@ -134,9 +134,9 @@ public class IndexService extends OpenSearchInitializer {
                         Map.entry("uri", getKeywordProperty()),
                         Map.entry("status", getKeywordProperty()),
                         Map.entry("namespace", getKeywordProperty()),
-                        Map.entry("prefix", getKeywordProperty()),
-                        Map.entry("created", getDateProperty()),
-                        Map.entry("modified", getDateProperty())
+                        Map.entry("prefix", getKeywordProperty())
+                        //Map.entry("created", getDateProperty()),
+                        //Map.entry("modified", getDateProperty())
                 ))
                 .build();
     }
@@ -150,5 +150,23 @@ public class IndexService extends OpenSearchInitializer {
         client.putToIndex(TERMINOLOGY_INDEX, index);
 
         initConceptIndex(model);
+    }
+
+    private Map<String, DynamicTemplate> getDynamicTemplate(String name, String pathMatch) {
+        return Map.of(name, new DynamicTemplate.Builder()
+                .pathMatch(pathMatch)
+                .mapping(getTextProperty()).build());
+    }
+
+    private Property getKeywordProperty() {
+        return new Property.Builder()
+                .keyword(new KeywordProperty.Builder().build())
+                .build();
+    }
+
+    private Property getTextProperty() {
+        return new Property.Builder()
+                .text(new TextProperty.Builder().build())
+                .build();
     }
 }

--- a/src/test/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapperTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapperTest.java
@@ -293,9 +293,9 @@ class ConceptMapperTest {
         assertEquals(Status.DRAFT, dto.getStatus());
         assertEquals("Suositettava termi", dto.getLabel().get("fi"));
         assertEquals("def", dto.getDefinition().get("fi"));
-        assertEquals(List.of("synonyymi 1", "synonyymi 2"), dto.getAltLabel().get("fi"));
-        assertEquals(List.of("ei suositettava"), dto.getNotRecommendedSynonym().get("fi"));
-        assertEquals(List.of("hakutermi"), dto.getSearchTerm().get("fi"));
+        assertEquals(List.of("synonyymi 1", "synonyymi 2"), dto.getAltLabel());
+        assertEquals(List.of("ei suositettava"), dto.getNotRecommendedSynonym());
+        assertEquals(List.of("hakutermi"), dto.getSearchTerm());
         assertEquals("2024-05-06T05:00:00.000Z", dto.getCreated());
         assertEquals("2024-05-07T04:00:00.000Z", dto.getModified());
     }

--- a/src/test/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptQueryFactoryTest.java
@@ -11,7 +11,7 @@ import java.util.Set;
 import static fi.vm.yti.common.opensearch.OpenSearchUtil.getPayload;
 import static org.springframework.test.util.AssertionErrors.assertEquals;
 
-public class ConceptQueryFactoryTest {
+class ConceptQueryFactoryTest {
     @Test
     void shouldCreateConceptQuery() throws Exception {
         var request = new ConceptSearchRequest();
@@ -70,5 +70,19 @@ public class ConceptQueryFactoryTest {
 
         assertEquals("Page from value not matching", 0, conceptQuery.from());
         assertEquals("Page size value not matching", 100, conceptQuery.size());
+    }
+
+    @Test
+    void shouldCreateConceptQueryWithSorting() throws Exception {
+        var request = new ConceptSearchRequest();
+        request.setPageSize(100);
+        request.setNamespace("https://iri.suomi.fi/terminology/test/");
+        request.setStatus(Set.of(Status.VALID));
+        var conceptQuery = ConceptQueryFactory.createConceptQuery(
+                request,
+                true,
+                null);
+        var expected = TestUtils.getJsonString("/opensearch/concept-query-with-sort.json");
+        JSONAssert.assertEquals(expected, getPayload(conceptQuery), JSONCompareMode.LENIENT);
     }
 }

--- a/src/test/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologyQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologyQueryFactoryTest.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 import static fi.vm.yti.common.opensearch.OpenSearchUtil.getPayload;
 import static org.springframework.test.util.AssertionErrors.assertEquals;
 
-public class TerminologyQueryFactoryTest {
+class TerminologyQueryFactoryTest {
 
     @Test
     void shouldCreateTerminologyQuery() throws Exception {
@@ -25,6 +25,7 @@ public class TerminologyQueryFactoryTest {
         request.setStatus(Set.of(Status.VALID));
         var terminologyQuery = TerminologyQueryFactory.createTerminologyQuery(request, false, null);
         var expected = TestUtils.getJsonString("/opensearch/terminology-request.json");
+        System.out.println(getPayload(terminologyQuery));
         JSONAssert.assertEquals(expected, getPayload(terminologyQuery), JSONCompareMode.LENIENT);
 
         assertEquals("Page from value not matching", 0, terminologyQuery.from());

--- a/src/test/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologyQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologyQueryFactoryTest.java
@@ -25,7 +25,6 @@ class TerminologyQueryFactoryTest {
         request.setStatus(Set.of(Status.VALID));
         var terminologyQuery = TerminologyQueryFactory.createTerminologyQuery(request, false, null);
         var expected = TestUtils.getJsonString("/opensearch/terminology-request.json");
-        System.out.println(getPayload(terminologyQuery));
         JSONAssert.assertEquals(expected, getPayload(terminologyQuery), JSONCompareMode.LENIENT);
 
         assertEquals("Page from value not matching", 0, terminologyQuery.from());

--- a/src/test/resources/opensearch/concept-exceptions-request.json
+++ b/src/test/resources/opensearch/concept-exceptions-request.json
@@ -1,5 +1,6 @@
 {
   "from": 0,
+  "size": 100,
   "highlight": {
     "fields": {
       "definition.*": {}
@@ -23,9 +24,9 @@
         {
           "terms": {
             "status": [
-              "INCOMPLETE",
+              "DRAFT",
               "VALID",
-              "DRAFT"
+              "INCOMPLETE"
             ]
           }
         },
@@ -57,6 +58,5 @@
         }
       ]
     }
-  },
-  "size": 100
+  }
 }

--- a/src/test/resources/opensearch/concept-exceptions-request.json
+++ b/src/test/resources/opensearch/concept-exceptions-request.json
@@ -12,10 +12,10 @@
           "query_string": {
             "fields": [
               "label.*^5.0",
-              "altLabel.*^3.0",
-              "searchTerm.*^3.0",
+              "altLabel^3.0",
+              "searchTerm^3.0",
               "definition.*^3.0",
-              "notRecommendedSynonym.*"
+              "notRecommendedSynonym"
             ],
             "query": "*test*"
           }

--- a/src/test/resources/opensearch/concept-exceptions-request.json
+++ b/src/test/resources/opensearch/concept-exceptions-request.json
@@ -1,6 +1,5 @@
 {
   "from": 0,
-  "size": 100,
   "highlight": {
     "fields": {
       "definition.*": {}
@@ -10,25 +9,15 @@
     "bool": {
       "must": [
         {
-          "bool": {
-            "minimum_should_match": "1",
-            "should": [
-              {
-                "query_string": {
-                  "boost": 1.5,
-                  "fields": [
-                    "label.*",
-                    "altLabel.*",
-                    "searchTerm.*",
-                    "hiddenTerm.*",
-                    "definition.*",
-                    "notRecommendedSynonym.*"
-                  ],
-                  "fuzziness": "2",
-                  "query": "*test*"
-                }
-              }
-            ]
+          "query_string": {
+            "fields": [
+              "label.*^5.0",
+              "altLabel.*^3.0",
+              "searchTerm.*^3.0",
+              "definition.*^3.0",
+              "notRecommendedSynonym.*"
+            ],
+            "query": "*test*"
           }
         },
         {
@@ -69,12 +58,5 @@
       ]
     }
   },
-  "sort": [
-    {
-      "label.fi.keyword": {
-        "order": "asc",
-        "unmapped_type": "keyword"
-      }
-    }
-  ]
+  "size": 100
 }

--- a/src/test/resources/opensearch/concept-query-with-sort.json
+++ b/src/test/resources/opensearch/concept-query-with-sort.json
@@ -1,0 +1,37 @@
+{
+  "from": 0,
+  "highlight": {
+    "fields": {
+      "definition.*": {}
+    }
+  },
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "terms": {
+            "status": [
+              "VALID"
+            ]
+          }
+        },
+        {
+          "term": {
+            "namespace": {
+              "value": "https://iri.suomi.fi/terminology/test/"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "size": 100,
+  "sort": [
+    {
+      "label.fi.keyword": {
+        "order": "asc",
+        "unmapped_type": "keyword"
+      }
+    }
+  ]
+}

--- a/src/test/resources/opensearch/concept-query-with-sort.json
+++ b/src/test/resources/opensearch/concept-query-with-sort.json
@@ -28,7 +28,7 @@
   "size": 100,
   "sort": [
     {
-      "label.fi.keyword": {
+      "label.fi.sortKey": {
         "order": "asc",
         "unmapped_type": "keyword"
       }

--- a/src/test/resources/opensearch/concept-request.json
+++ b/src/test/resources/opensearch/concept-request.json
@@ -12,10 +12,10 @@
           "query_string": {
             "fields": [
               "label.*^5.0",
-              "altLabel.*^3.0",
-              "searchTerm.*^3.0",
+              "altLabel^3.0",
+              "searchTerm^3.0",
               "definition.*^3.0",
-              "notRecommendedSynonym.*"
+              "notRecommendedSynonym"
             ],
             "query": "*test*"
           }

--- a/src/test/resources/opensearch/concept-request.json
+++ b/src/test/resources/opensearch/concept-request.json
@@ -23,9 +23,9 @@
         {
           "terms": {
             "status": [
-              "VALID",
+              "DRAFT",
               "INCOMPLETE",
-              "DRAFT"
+              "VALID"
             ]
           }
         },

--- a/src/test/resources/opensearch/concept-request.json
+++ b/src/test/resources/opensearch/concept-request.json
@@ -9,33 +9,23 @@
     "bool": {
       "must": [
         {
-          "bool": {
-            "minimum_should_match": "1",
-            "should": [
-              {
-                "query_string": {
-                  "boost": 1.5,
-                  "fields": [
-                    "label.*",
-                    "altLabel.*",
-                    "searchTerm.*",
-                    "hiddenTerm.*",
-                    "definition.*",
-                    "notRecommendedSynonym.*"
-                  ],
-                  "fuzziness": "2",
-                  "query": "*test*"
-                }
-              }
-            ]
+          "query_string": {
+            "fields": [
+              "label.*^5.0",
+              "altLabel.*^3.0",
+              "searchTerm.*^3.0",
+              "definition.*^3.0",
+              "notRecommendedSynonym.*"
+            ],
+            "query": "*test*"
           }
         },
         {
           "terms": {
             "status": [
-              "DRAFT",
+              "VALID",
               "INCOMPLETE",
-              "VALID"
+              "DRAFT"
             ]
           }
         },
@@ -55,13 +45,5 @@
       ]
     }
   },
-  "size": 100,
-  "sort": [
-    {
-      "label.fi.keyword": {
-        "order": "asc",
-        "unmapped_type": "keyword"
-      }
-    }
-  ]
+  "size": 100
 }

--- a/src/test/resources/opensearch/concept-superuser-request.json
+++ b/src/test/resources/opensearch/concept-superuser-request.json
@@ -12,10 +12,10 @@
           "query_string": {
             "fields": [
               "label.*^5.0",
-              "altLabel.*^3.0",
-              "searchTerm.*^3.0",
+              "altLabel^3.0",
+              "searchTerm^3.0",
               "definition.*^3.0",
-              "notRecommendedSynonym.*"
+              "notRecommendedSynonym"
             ],
             "query": "*test*"
           }

--- a/src/test/resources/opensearch/concept-superuser-request.json
+++ b/src/test/resources/opensearch/concept-superuser-request.json
@@ -1,5 +1,6 @@
 {
   "from": 0,
+  "size": 100,
   "highlight": {
     "fields": {
       "definition.*": {}
@@ -23,14 +24,13 @@
         {
           "terms": {
             "status": [
-              "DRAFT",
+              "INCOMPLETE",
               "VALID",
-              "INCOMPLETE"
+              "DRAFT"
             ]
           }
         }
       ]
     }
-  },
-  "size": 100
+  }
 }

--- a/src/test/resources/opensearch/concept-superuser-request.json
+++ b/src/test/resources/opensearch/concept-superuser-request.json
@@ -1,6 +1,5 @@
 {
   "from": 0,
-  "size": 100,
   "highlight": {
     "fields": {
       "definition.*": {}
@@ -10,45 +9,28 @@
     "bool": {
       "must": [
         {
-          "bool": {
-            "minimum_should_match": "1",
-            "should": [
-              {
-                "query_string": {
-                  "boost": 1.5,
-                  "fields": [
-                    "label.*",
-                    "altLabel.*",
-                    "searchTerm.*",
-                    "hiddenTerm.*",
-                    "definition.*",
-                    "notRecommendedSynonym.*"
-                  ],
-                  "fuzziness": "2",
-                  "query": "*test*"
-                }
-              }
-            ]
+          "query_string": {
+            "fields": [
+              "label.*^5.0",
+              "altLabel.*^3.0",
+              "searchTerm.*^3.0",
+              "definition.*^3.0",
+              "notRecommendedSynonym.*"
+            ],
+            "query": "*test*"
           }
         },
         {
           "terms": {
             "status": [
-              "INCOMPLETE",
+              "DRAFT",
               "VALID",
-              "DRAFT"
+              "INCOMPLETE"
             ]
           }
         }
       ]
     }
   },
-  "sort": [
-    {
-      "label.fi.keyword": {
-        "order": "asc",
-        "unmapped_type": "keyword"
-      }
-    }
-  ]
+  "size": 100
 }

--- a/src/test/resources/opensearch/terminology-deep-request.json
+++ b/src/test/resources/opensearch/terminology-deep-request.json
@@ -1,5 +1,6 @@
 {
   "from": 0,
+  "size": 100,
   "highlight": {
     "fields": {
       "label.*": {}
@@ -92,6 +93,5 @@
         }
       ]
     }
-  },
-  "size": 100
+  }
 }

--- a/src/test/resources/opensearch/terminology-deep-request.json
+++ b/src/test/resources/opensearch/terminology-deep-request.json
@@ -1,6 +1,5 @@
 {
   "from": 0,
-  "size": 100,
   "highlight": {
     "fields": {
       "label.*": {}
@@ -94,12 +93,5 @@
       ]
     }
   },
-  "sort": [
-    {
-      "label.fi.keyword": {
-        "order": "asc",
-        "unmapped_type": "keyword"
-      }
-    }
-  ]
+  "size": 100
 }

--- a/src/test/resources/opensearch/terminology-deep-superuser-request.json
+++ b/src/test/resources/opensearch/terminology-deep-superuser-request.json
@@ -1,6 +1,5 @@
 {
   "from": 0,
-  "size": 100,
   "highlight": {
     "fields": {
       "label.*": {}
@@ -67,12 +66,5 @@
       ]
     }
   },
-  "sort": [
-    {
-      "label.fi.keyword": {
-        "order": "asc",
-        "unmapped_type": "keyword"
-      }
-    }
-  ]
+  "size": 100
 }

--- a/src/test/resources/opensearch/terminology-deep-superuser-request.json
+++ b/src/test/resources/opensearch/terminology-deep-superuser-request.json
@@ -1,5 +1,6 @@
 {
   "from": 0,
+  "size": 100,
   "highlight": {
     "fields": {
       "label.*": {}
@@ -65,6 +66,5 @@
         }
       ]
     }
-  },
-  "size": 100
+  }
 }

--- a/src/test/resources/opensearch/terminology-request.json
+++ b/src/test/resources/opensearch/terminology-request.json
@@ -1,5 +1,6 @@
 {
   "from": 0,
+  "size": 100,
   "highlight": {
     "fields": {
       "label.*": {}
@@ -54,6 +55,5 @@
         }
       ]
     }
-  },
-  "size": 100
+  }
 }

--- a/src/test/resources/opensearch/terminology-request.json
+++ b/src/test/resources/opensearch/terminology-request.json
@@ -1,6 +1,5 @@
 {
   "from": 0,
-  "size": 100,
   "highlight": {
     "fields": {
       "label.*": {}
@@ -56,12 +55,5 @@
       ]
     }
   },
-  "sort": [
-    {
-      "label.fi.keyword": {
-        "order": "asc",
-        "unmapped_type": "keyword"
-      }
-    }
-  ]
+  "size": 100
 }


### PR DESCRIPTION
Search performs quite bad with ~30k documents. Simplify mappings by mapping definition and other terms than preferred term without sort key (results are sorted only by preferred term). So instead of mapping e.g. searchTerm with dynamic template like this:
```
"dynamic_templates": [
        {
          "label": {
            "path_match": "searchTerm.*",
            "mapping": {
              "fields": {
                "sortKey": {
                  "normalizer": "lowercase",
                  "ignore_above": 256,
                  "type": "keyword"
                }
              },
              "type": "text"
            }
          }
        }
]
``` 

...use simple mapping as a text field

```
"searchTerm": {
  "type": "text"
},
```

Apply sorting to the results only if searching without query. When searching with query string, we expect results sorted by relevance, not in alphabetical order. 

Fixed field boosting. These must be added to the field name, otherwise it affects to the whole query, not particular field.