### PR TITLE
Handle ordered properties

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptCollectionMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptCollectionMapper.java
@@ -104,12 +104,9 @@ public class ConceptCollectionMapper {
         MapperUtils.getResourceList(resource, Term.orderedMember)
                 .forEach(concept -> {
                     var labelMap = new HashMap<String, String>();
-                    MapperUtils.getResourceList(concept, SKOS.prefLabel).forEach(term -> {
-                        if (term.hasProperty(SKOSXL.literalForm)) {
-                            var labelProperty = term.getProperty(SKOSXL.literalForm);
-                            labelMap.put(labelProperty.getLanguage(), labelProperty.getString());
-                        }
-                    });
+                    concept.listProperties(SKOS.prefLabel)
+                            .forEach(s -> labelMap.putAll(
+                                    MapperUtils.localizedPropertyToMap(s.getResource(), SKOSXL.literalForm)));
                     dto.addMember(concept.getLocalName(), concept.getURI(), labelMap, model.getPrefix());
                 });
 

--- a/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapper.java
@@ -334,7 +334,10 @@ public class ConceptMapper {
         var termResource = model.createResource(UUID.randomUUID().toString());
         termResource.addProperty(RDF.type, SKOSXL.Label);
         termResource.addProperty(SKOSXL.literalForm, ResourceFactory.createLangLiteral(term.getLabel(), term.getLanguage()));
-        MapperUtils.addLiteral(termResource, Term.homographNumber, term.getHomographNumber());
+
+        if (term.getHomographNumber() != null && term.getHomographNumber() > 0) {
+            MapperUtils.addLiteral(termResource, Term.homographNumber, term.getHomographNumber());
+        }
         MapperUtils.addStatus(termResource, term.getStatus());
         MapperUtils.addOptionalStringProperty(termResource, Term.termInfo, term.getTermInfo());
         MapperUtils.addOptionalStringProperty(termResource, Term.scope, term.getScope());

--- a/src/main/java/fi/vm/yti/terminology/api/v2/mapper/NTRFMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/mapper/NTRFMapper.java
@@ -29,10 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class NTRFMapper {
 
@@ -123,10 +120,17 @@ public class NTRFMapper {
                     langValue,
                     value -> getContentWithTags(def.getContent(), dto, model)
             ));
-            lang.getNOTE().forEach(note -> dto.getNotes().add(
+
+            // Notes and examples are reversed to preserve the order in xml file.
+            // In the UI notes and examples are represented in latest first
+            var notes = lang.getNOTE();
+            Collections.reverse(notes);
+            notes.forEach(note -> dto.getNotes().add(
                     new LocalizedValueDTO(langValue, getContentWithTags(note.getContent(), dto, model)))
             );
-            lang.getEXAMP().forEach(example -> dto.getExamples().add(
+            var examples = lang.getEXAMP();
+            Collections.reverse(examples);
+            examples.forEach(example -> dto.getExamples().add(
                     new LocalizedValueDTO(langValue, getContentWithTags(example.getContent(), dto, model)))
             );
 

--- a/src/main/java/fi/vm/yti/terminology/api/v2/migration/task/V3_RDFListConversion.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/migration/task/V3_RDFListConversion.java
@@ -1,11 +1,13 @@
 package fi.vm.yti.terminology.api.v2.migration.task;
 
 import fi.vm.yti.common.util.MapperUtils;
+import fi.vm.yti.common.util.ModelWrapper;
 import fi.vm.yti.migration.MigrationTask;
 import fi.vm.yti.terminology.api.v2.mapper.ConceptMapper;
 import fi.vm.yti.terminology.api.v2.property.Term;
 import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
 import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.SKOS;
 import org.slf4j.Logger;
@@ -36,72 +38,94 @@ public class V3_RDFListConversion implements MigrationTask {
         graphs.forEach(g -> {
             var model = repository.fetch(g);
 
+            var orphanBlankNodes = model.listStatements()
+                    .filterKeep(s -> s.getSubject().isAnon())
+                    .filterKeep(s -> !model.contains(null, null, s.getSubject()))
+                    .toList();
+
+            model.remove(orphanBlankNodes);
+
             model.listSubjectsWithProperty(RDF.type, SKOS.Concept).forEach(concept -> {
                 var properties = concept.listProperties().toList();
-                properties.forEach(stmt -> {
-                    var orderProperty = ConceptMapper.orderProperties.get(stmt.getPredicate().getLocalName());
-
-                    if (ConceptMapper.termProperties.contains(stmt.getPredicate())) {
-
-                        var orderedTerms = new ArrayList<Resource>();
-                        var terms = stmt.getList();
-
-                        // remove property from concept
-                        concept.removeAll(stmt.getPredicate());
-
-                        terms.asJavaList().forEach(term -> {
-                            var termResource = model.createResource(UUID.randomUUID().toString());
-                            term.asResource().listProperties().forEach(s -> termResource.addProperty(s.getPredicate(), s.getObject()));
-                            concept.addProperty(stmt.getPredicate(), termResource);
-                            orderedTerms.add(termResource);
-
-                            // remove old term resources from the model
-                            model.removeAll(term.asResource(), null, null);
-                            model.removeAll(null, null, term.asResource());
-                        });
-
-                        if (orderProperty != null) {
-                            MapperUtils.addListProperty(concept, orderProperty, orderedTerms);
-                        }
-
-                        // finally, remove the whole list object
-                        terms.removeList();
-                    } else {
-                        if (orderProperty == null) {
-                            return;
-                        }
-
-                        var list = stmt.getList();
-                        concept.removeAll(stmt.getPredicate());
-
-                        list.asJavaList().forEach(r -> concept.addProperty(stmt.getPredicate(), r));
-                        MapperUtils.addListProperty(concept, orderProperty, list.asJavaList());
-
-                        // remove original list
-                        list.removeList();
-                    }
-                });
+                properties.forEach(stmt -> handleConceptProperties(concept, stmt, model));
             });
 
-                model.listSubjectsWithProperty(RDF.type, SKOS.Collection).forEach(collection -> {
-                    try {
-                        var members = MapperUtils.getList(collection, SKOS.member);
+            model.listSubjectsWithProperty(RDF.type, SKOS.Collection)
+                    .forEach(V3_RDFListConversion::handleCollectionProperties);
 
-                        if (!members.isEmpty()) {
-                            collection.removeAll(SKOS.member);
-                            members.asJavaList().forEach(member -> collection.addProperty(SKOS.member, member));
-
-                            MapperUtils.addListProperty(collection, Term.orderedMember, members.asJavaList());
-
-                            members.removeList();
-                        }
-                    } catch (Exception e) {
-                        LOG.warn("error converting collection {}", collection.getURI());
-                        LOG.error(e.getMessage(), e);
-                    }
-                });
+            LOG.info("Migrated graph {}", g);
             repository.put(g, model);
         });
 
+    }
+
+    private static void handleCollectionProperties(Resource collection) {
+        try {
+            if (!collection.hasProperty(SKOS.member)) {
+                return;
+            }
+
+            var members = MapperUtils.getList(collection, SKOS.member);
+
+            if (!members.isEmpty()) {
+                collection.removeAll(SKOS.member);
+                members.asJavaList().forEach(member -> collection.addProperty(SKOS.member, member));
+
+                MapperUtils.addListProperty(collection, Term.orderedMember, members.asJavaList());
+
+                members.removeList();
+            }
+        } catch (Exception e) {
+            LOG.warn("error converting collection {}", collection.getURI());
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    private static void handleConceptProperties(Resource concept, Statement stmt, ModelWrapper model) {
+        var orderProperty = ConceptMapper.orderProperties.get(stmt.getPredicate().getLocalName());
+
+        try {
+            if (ConceptMapper.termProperties.contains(stmt.getPredicate())) {
+
+                var orderedTerms = new ArrayList<Resource>();
+                var terms = stmt.getList();
+
+                // remove property from concept
+                concept.removeAll(stmt.getPredicate());
+
+                terms.asJavaList().forEach(term -> {
+                    var termResource = model.createResource(UUID.randomUUID().toString());
+                    term.asResource().listProperties().forEach(s -> termResource.addProperty(s.getPredicate(), s.getObject()));
+                    concept.addProperty(stmt.getPredicate(), termResource);
+                    orderedTerms.add(termResource);
+
+                    // remove old term resources from the model
+                    model.removeAll(term.asResource(), null, null);
+                    model.removeAll(null, null, term.asResource());
+                });
+
+                if (orderProperty != null) {
+                    MapperUtils.addListProperty(concept, orderProperty, orderedTerms);
+                }
+
+                // finally, remove the whole list object
+                terms.removeList();
+            } else {
+                if (orderProperty == null) {
+                    return;
+                }
+
+                var list = stmt.getList();
+                concept.removeAll(stmt.getPredicate());
+
+                list.asJavaList().forEach(r -> concept.addProperty(stmt.getPredicate(), r));
+                MapperUtils.addListProperty(concept, orderProperty, list.asJavaList());
+
+                // remove original list
+                list.removeList();
+            }
+        } catch (Exception e) {
+            LOG.warn("error converting concept {}, property {}", concept.getURI(), stmt.getPredicate().getURI());
+        }
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/migration/task/V3_RDFListConversion.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/migration/task/V3_RDFListConversion.java
@@ -1,0 +1,107 @@
+package fi.vm.yti.terminology.api.v2.migration.task;
+
+import fi.vm.yti.common.util.MapperUtils;
+import fi.vm.yti.migration.MigrationTask;
+import fi.vm.yti.terminology.api.v2.mapper.ConceptMapper;
+import fi.vm.yti.terminology.api.v2.property.Term;
+import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.SKOS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.UUID;
+
+@SuppressWarnings("java:S101")
+@Component
+public class V3_RDFListConversion implements MigrationTask {
+
+    private static final Logger LOG = LoggerFactory.getLogger(V3_RDFListConversion.class);
+    private final TerminologyRepository repository;
+
+    public V3_RDFListConversion(TerminologyRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public void migrate() {
+
+        String allGraphsQuery = "select * where { GRAPH ?g {} }";
+        var graphs = new ArrayList<String>();
+        repository.querySelect(allGraphsQuery, row -> graphs.add(row.get("g").toString()));
+
+        graphs.forEach(g -> {
+            var model = repository.fetch(g);
+
+            model.listSubjectsWithProperty(RDF.type, SKOS.Concept).forEach(concept -> {
+                var properties = concept.listProperties().toList();
+                properties.forEach(stmt -> {
+                    var orderProperty = ConceptMapper.orderProperties.get(stmt.getPredicate().getLocalName());
+
+                    if (ConceptMapper.termProperties.contains(stmt.getPredicate())) {
+
+                        var orderedTerms = new ArrayList<Resource>();
+                        var terms = stmt.getList();
+
+                        // remove property from concept
+                        concept.removeAll(stmt.getPredicate());
+
+                        terms.asJavaList().forEach(term -> {
+                            var termResource = model.createResource(UUID.randomUUID().toString());
+                            term.asResource().listProperties().forEach(s -> termResource.addProperty(s.getPredicate(), s.getObject()));
+                            concept.addProperty(stmt.getPredicate(), termResource);
+                            orderedTerms.add(termResource);
+
+                            // remove old term resources from the model
+                            model.removeAll(term.asResource(), null, null);
+                            model.removeAll(null, null, term.asResource());
+                        });
+
+                        if (orderProperty != null) {
+                            MapperUtils.addListProperty(concept, orderProperty, orderedTerms);
+                        }
+
+                        // finally, remove the whole list object
+                        terms.removeList();
+                    } else {
+                        if (orderProperty == null) {
+                            return;
+                        }
+
+                        var list = stmt.getList();
+                        concept.removeAll(stmt.getPredicate());
+
+                        list.asJavaList().forEach(r -> concept.addProperty(stmt.getPredicate(), r));
+                        MapperUtils.addListProperty(concept, orderProperty, list.asJavaList());
+
+                        // remove original list
+                        list.removeList();
+                    }
+                });
+            });
+
+                model.listSubjectsWithProperty(RDF.type, SKOS.Collection).forEach(collection -> {
+                    try {
+                        var members = MapperUtils.getList(collection, SKOS.member);
+
+                        if (!members.isEmpty()) {
+                            collection.removeAll(SKOS.member);
+                            members.asJavaList().forEach(member -> collection.addProperty(SKOS.member, member));
+
+                            MapperUtils.addListProperty(collection, Term.orderedMember, members.asJavaList());
+
+                            members.removeList();
+                        }
+                    } catch (Exception e) {
+                        LOG.warn("error converting collection {}", collection.getURI());
+                        LOG.error(e.getMessage(), e);
+                    }
+                });
+            repository.put(g, model);
+        });
+
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/property/Term.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/property/Term.java
@@ -25,6 +25,20 @@ public class Term {
     public static final Property wordClass = ResourceFactory.createProperty(URI, "wordClass");
     public static final Property notRecommendedSynonym = ResourceFactory.createProperty(URI, "notRecommendedSynonym");
 
+    public static final Property orderedSynonym = ResourceFactory.createProperty(URI, "orderedSynonym");
+    public static final Property orderedNotRecommendedSynonym = ResourceFactory.createProperty(URI, "orderedNotRecommendedSynonym");
+    public static final Property orderedMember = ResourceFactory.createProperty(URI, "orderedMember");
+    public static final Property orderedBroader = ResourceFactory.createProperty(URI, "orderedBroader");
+    public static final Property orderedNarrower = ResourceFactory.createProperty(URI, "orderedNarrower");
+    public static final Property orderedRelated = ResourceFactory.createProperty(URI, "orderedRelated");
+    public static final Property orderedIsPartOf = ResourceFactory.createProperty(URI, "orderedIsPartOf");
+    public static final Property orderedHasPart = ResourceFactory.createProperty(URI, "orderedHasPart");
+    public static final Property orderedRelatedMatch = ResourceFactory.createProperty(URI, "orderedRelatedMatch");
+    public static final Property orderedBroadMatch = ResourceFactory.createProperty(URI, "orderedBroadMatch");
+    public static final Property orderedNarrowMatch = ResourceFactory.createProperty(URI, "orderedNarrowMatch");
+    public static final Property orderedExactMatch = ResourceFactory.createProperty(URI, "orderedExactMatch");
+    public static final Property orderedCloseMatch = ResourceFactory.createProperty(URI, "orderedCloseMatch");
+
     public static String getNamespace() {
         return URI;
     }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/property/Term.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/property/Term.java
@@ -38,6 +38,10 @@ public class Term {
     public static final Property orderedNarrowMatch = ResourceFactory.createProperty(URI, "orderedNarrowMatch");
     public static final Property orderedExactMatch = ResourceFactory.createProperty(URI, "orderedExactMatch");
     public static final Property orderedCloseMatch = ResourceFactory.createProperty(URI, "orderedCloseMatch");
+    public static final Property orderedNote =  ResourceFactory.createProperty(URI, "orderedNote");
+    public static final Property orderedExample =  ResourceFactory.createProperty(URI, "orderedExample");
+    public static final Property orderedEditorialNote =  ResourceFactory.createProperty(URI, "orderedEditorialNote");
+    public static final Property orderedSource =  ResourceFactory.createProperty(URI, "orderedSource");
 
     public static String getNamespace() {
         return URI;

--- a/src/main/java/fi/vm/yti/terminology/api/v2/repository/TerminologyRepository.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/repository/TerminologyRepository.java
@@ -39,6 +39,7 @@ public class TerminologyRepository extends BaseRepository {
             return model;
         }
         model = new ModelWrapper(super.fetch(graphURI), graphURI);
+        model.getGraph().getPrefixMapping().clearNsPrefixMap();
         model.setNsPrefixes(Constants.PREFIXES);
         model.setNsPrefix("term", Term.getNamespace());
         model.setNsPrefix(model.getPrefix(), model.getModelResource().getNameSpace());

--- a/src/test/java/fi/vm/yti/terminology/api/v2/TestUtils.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/TestUtils.java
@@ -141,6 +141,16 @@ public class TestUtils {
         recommendedTerms.add(getTermDTO());
         dto.setRecommendedTerms(recommendedTerms);
 
+        var synonym1 = new TermDTO();
+        var synonym2 = new TermDTO();
+        synonym1.setLanguage("en");
+        synonym1.setLabel("Synonym 1");
+        synonym1.setStatus(Status.DRAFT);
+        synonym2.setLanguage("en");
+        synonym2.setLabel("Synonym 2");
+        synonym2.setStatus(Status.DRAFT);
+        dto.setSynonyms(List.of(synonym1, synonym2));
+
         return dto;
     }
 

--- a/src/test/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapperTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapperTest.java
@@ -16,8 +16,6 @@ import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
-import org.apache.jena.riot.Lang;
-import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.sparql.vocabulary.FOAF;
 import org.apache.jena.vocabulary.*;
 import org.junit.jupiter.api.Test;
@@ -43,7 +41,6 @@ class ConceptMapperTest {
 
         var conceptResource = model.getResourceById(concept.getIdentifier());
 
-        RDFDataMgr.write(System.out, model, Lang.TURTLE);
         assertEquals(graphURI + concept.getIdentifier(), conceptResource.getURI());
         assertEquals(concept.getConceptClass(), conceptResource.getProperty(Term.conceptClass).getString());
         assertEquals(concept.getDefinition(), Map.of("en", "definition"));
@@ -336,14 +333,16 @@ class ConceptMapperTest {
     }
 
     private static List<String> getList(Resource conceptResource, Property property) {
-        return conceptResource.getProperty(property).getList()
+        var orderProperty = ConceptMapper.orderProperties.get(property.getLocalName());
+        return conceptResource.getProperty(orderProperty).getList()
                 .asJavaList().stream()
                 .map(r -> r.asLiteral().getString())
                 .toList();
     }
 
     private static List<LocalizedValueDTO> getLocalizedList(Resource conceptResource, Property property) {
-        return conceptResource.getProperty(property).getList()
+        var orderProperty = ConceptMapper.orderProperties.get(property.getLocalName());
+        return conceptResource.getProperty(orderProperty).getList()
                 .asJavaList().stream()
                 .map(r -> new LocalizedValueDTO(r.asLiteral().getLanguage(), r.asLiteral().getString()))
                 .toList();

--- a/src/test/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapperTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapperTest.java
@@ -309,8 +309,8 @@ class ConceptMapperTest {
         assertEquals("Suositettava termi", dto.getLabel().get("fi"));
         assertEquals("def", dto.getDefinition().get("fi"));
         assertTrue(dto.getAltLabel().containsAll(List.of("synonyymi 1", "synonyymi 2")));
-        assertTrue(dto.getNotRecommendedSynonym().containsAll(List.of("ei suositettava")));
-        assertTrue(dto.getSearchTerm().containsAll(List.of("hakutermi")));
+        assertTrue(dto.getNotRecommendedSynonym().contains("ei suositettava"));
+        assertTrue(dto.getSearchTerm().contains("hakutermi"));
         assertEquals("2024-05-06T05:00:00.000Z", dto.getCreated());
         assertEquals("2024-05-07T04:00:00.000Z", dto.getModified());
     }
@@ -331,7 +331,6 @@ class ConceptMapperTest {
         ConceptMapper.dtoToModel(model, dto, mockUser);
         ConceptMapper.mapDeleteConcept(model, dto.getIdentifier());
 
-        RDFDataMgr.write(System.out, model, Lang.TURTLE);
         // all triples related to removed concept should be removed
         assertEquals(initialSize, model.size());
     }

--- a/src/test/java/fi/vm/yti/terminology/api/v2/mapper/NTRFMapperTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/mapper/NTRFMapperTest.java
@@ -73,8 +73,6 @@ class NTRFMapperTest {
 
         // synonym EN
         assertEquals(2, synonymEN.size());
-        // TODO: not working -> add terms to RDF list per type
-        // assertEquals(TermEquivalency.NARROWER.name(), MapperUtils.propertyToString(synonymEN.get(0), Term.termEquivalency));
 
         assertEquals(1, getTerm(concept, SKOS.hiddenLabel, "en").size());
         assertEquals(2, getTerm(concept, Term.notRecommendedSynonym, "en").size());
@@ -209,7 +207,7 @@ class NTRFMapperTest {
         var orderProperty = ConceptMapper.orderProperties.get(property.getLocalName());
 
         var list = orderProperty != null
-            ? MapperUtils.getResourceList(concept, property)
+            ? MapperUtils.getResourceList(concept, orderProperty)
             : concept.listProperties(property).toList().stream()
                 .map(Statement::getResource)
                 .toList();

--- a/src/test/java/fi/vm/yti/terminology/api/v2/mapper/NTRFMapperTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/mapper/NTRFMapperTest.java
@@ -221,10 +221,11 @@ class NTRFMapperTest {
     }
 
     private static List<String> getLocalizedList(Resource concept, Property property, String language) {
-        if (!concept.hasProperty(property)) {
+        var orderProperty = ConceptMapper.orderProperties.get(property.getLocalName());
+        if (!concept.hasProperty(orderProperty)) {
             return new ArrayList<>();
         }
-        return concept.getProperty(property).getList().asJavaList().stream()
+        return concept.getProperty(orderProperty).getList().asJavaList().stream()
                 .map(RDFNode::asLiteral)
                 .filter(n -> n.getLanguage().equals(language))
                 .map(Literal::getString)
@@ -232,10 +233,11 @@ class NTRFMapperTest {
     }
 
     private static List<String> getListValues(Resource resource, Property property) {
-        if (!resource.hasProperty(property)) {
+        var orderProperty = ConceptMapper.orderProperties.get(property.getLocalName());
+        if (!resource.hasProperty(orderProperty)) {
             return new ArrayList<>();
         }
-        return resource.getProperty(property)
+        return resource.getProperty(orderProperty)
                 .getList().asJavaList().stream()
                 .map(s -> s.asLiteral().getString())
                 .toList();

--- a/src/test/java/fi/vm/yti/terminology/api/v2/migration/RDFListConversionTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/migration/RDFListConversionTest.java
@@ -2,18 +2,14 @@ package fi.vm.yti.terminology.api.v2.migration;
 
 import fi.vm.yti.common.util.MapperUtils;
 import fi.vm.yti.terminology.api.v2.TestUtils;
-import fi.vm.yti.terminology.api.v2.mapper.ConceptMapper;
 import fi.vm.yti.terminology.api.v2.migration.task.V3_RDFListConversion;
 import fi.vm.yti.terminology.api.v2.property.Term;
 import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
-import fi.vm.yti.terminology.api.v2.service.UriResolveService;
 import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
-import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.query.Query;
 import org.apache.jena.query.QuerySolution;
-import org.apache.jena.rdf.model.*;
-import org.apache.jena.riot.Lang;
-import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.SKOS;
 import org.apache.jena.vocabulary.SKOSXL;
@@ -26,12 +22,11 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
-import java.util.UUID;
 import java.util.function.Consumer;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(SpringExtension.class)
 @Import({

--- a/src/test/java/fi/vm/yti/terminology/api/v2/migration/RDFListConversionTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/migration/RDFListConversionTest.java
@@ -1,0 +1,111 @@
+package fi.vm.yti.terminology.api.v2.migration;
+
+import fi.vm.yti.common.util.MapperUtils;
+import fi.vm.yti.terminology.api.v2.TestUtils;
+import fi.vm.yti.terminology.api.v2.mapper.ConceptMapper;
+import fi.vm.yti.terminology.api.v2.migration.task.V3_RDFListConversion;
+import fi.vm.yti.terminology.api.v2.property.Term;
+import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
+import fi.vm.yti.terminology.api.v2.service.UriResolveService;
+import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.rdf.model.*;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.SKOS;
+import org.apache.jena.vocabulary.SKOSXL;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@Import({
+        V3_RDFListConversion.class
+})
+class RDFListConversionTest {
+
+    @MockBean
+    TerminologyRepository repository;
+
+    @Autowired
+    private V3_RDFListConversion migration;
+
+    @Test
+    void testConvertRDFLists() {
+        var uri = TerminologyURI.createTerminologyURI("order-test");
+        var model = TestUtils.getModelFromFile("/rdf-list-conversion.ttl", uri.getGraphURI());
+
+        var qs = mock(QuerySolution.class);
+
+        when(qs.get(anyString())).thenReturn(ResourceFactory.createResource(uri.getGraphURI()));
+
+        doAnswer(ans -> {
+            Consumer<QuerySolution> cons = ans.getArgument(1, Consumer.class);
+            cons.accept(qs);
+            return null;
+        }).when(repository).querySelect(anyString(), any(Consumer.class));
+
+        when(repository.fetch(anyString())).thenReturn(model);
+
+        migration.migrate();
+
+        var modelCaptor = ArgumentCaptor.forClass(Model.class);
+        verify(repository).put(eq(uri.getGraphURI()), modelCaptor.capture());
+
+        var result = modelCaptor.getValue();
+
+        result.listSubjectsWithProperty(RDF.type, SKOS.Concept).forEach(c -> {
+            var prefLabels = c.listProperties(SKOS.prefLabel).toList();
+            assertFalse(prefLabels.isEmpty());
+
+            prefLabels.forEach(label -> {
+                var labelResource = result.getResource(label.getResource().getURI());
+                assertTrue(labelResource.hasProperty(SKOSXL.literalForm));
+            });
+        });
+
+        var concept = result.getResource(uri.getGraphURI() + "order-1");
+
+        var synonyms = concept.getProperty(Term.orderedSynonym)
+                .getList().asJavaList().stream()
+                .map(s -> s.asResource().getProperty(SKOSXL.literalForm).getString())
+                .toList();
+
+        List<String> expectedSynonyms = List.of("synonyymi1", "synonyymi2", "synonyymi3");
+
+        assertTrue(expectedSynonyms.containsAll(concept.listProperties(SKOS.altLabel)
+                .toList().stream()
+                .map(s -> s.getResource().getProperty(SKOSXL.literalForm).getString())
+                .toList()));
+
+        assertEquals(expectedSynonyms, synonyms);
+
+        var collection = result.getResource(uri.getGraphURI() + "collection-2000");
+
+        var expectedMembers = List.of(
+                "https://iri.suomi.fi/terminology/order-test/c340",
+                "https://iri.suomi.fi/terminology/order-test/concept-3",
+                "https://iri.suomi.fi/terminology/order-test/order-1");
+
+        assertTrue(expectedMembers.containsAll(collection.listProperties(SKOS.member)
+                .mapWith(s -> s.getResource().getURI()).toList()));
+        assertEquals(expectedMembers, MapperUtils.getResourceList(collection, Term.orderedMember).stream()
+                .map(Resource::getURI)
+                .toList());
+    }
+}

--- a/src/test/java/fi/vm/yti/terminology/api/v2/service/ConceptCollectionServiceTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/service/ConceptCollectionServiceTest.java
@@ -7,6 +7,7 @@ import fi.vm.yti.common.util.ModelWrapper;
 import fi.vm.yti.security.AuthorizationException;
 import fi.vm.yti.terminology.api.v2.TestUtils;
 import fi.vm.yti.terminology.api.v2.dto.ConceptCollectionDTO;
+import fi.vm.yti.terminology.api.v2.dto.ConceptReferenceInfoDTO;
 import fi.vm.yti.terminology.api.v2.opensearch.IndexConcept;
 import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
 import fi.vm.yti.terminology.api.v2.security.TerminologyAuthorizationManager;
@@ -26,6 +27,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
 
 import java.net.URISyntaxException;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -37,7 +39,7 @@ import static org.mockito.Mockito.*;
 @Import({
         ConceptCollectionService.class,
 })
-public class ConceptCollectionServiceTest {
+class ConceptCollectionServiceTest {
     @MockBean
     TerminologyRepository repository;
 
@@ -110,6 +112,11 @@ public class ConceptCollectionServiceTest {
 
         assertFalse(dto.getLabel().isEmpty());
         assertFalse(dto.getDescription().isEmpty());
+
+        var members = dto.getMembers().stream()
+                .map(ConceptReferenceInfoDTO::getIdentifier)
+                .toList();
+        assertEquals(List.of("concept-1", "concept-2"), members);
 
         // only authenticated user should see this information
         assertNull(dto.getCreator().getName());

--- a/src/test/resources/ntrf/term-and-concept-info.xml
+++ b/src/test/resources/ntrf/term-and-concept-info.xml
@@ -30,10 +30,10 @@
                 <TERM>Not recommended term 2</TERM>
             </DTEA>
             <DEF>Concept definition</DEF>
-            <NOTE>Note 1</NOTE>
             <NOTE>Note 2</NOTE>
-            <EXAMP>Example 1</EXAMP>
+            <NOTE>Note 1</NOTE>
             <EXAMP>Example 2</EXAMP>
+            <EXAMP>Example 1</EXAMP>
             <STE>
                 <TERM>Search term</TERM>
             </STE>
@@ -43,10 +43,10 @@
                 <TERM>Test term recommended FI</TERM>
             </TE>
             <DEF>Definition FI</DEF>
-            <NOTE>Note 1 FI</NOTE>
             <NOTE>Note 2 FI</NOTE>
-            <EXAMP>Example 1 FI</EXAMP>
+            <NOTE>Note 1 FI</NOTE>
             <EXAMP>Example 2 FI</EXAMP>
+            <EXAMP>Example 1 FI</EXAMP>
         </LANG>
         <REMK>Editorial note 1</REMK>
         <REMK>Editorial note 2</REMK>

--- a/src/test/resources/rdf-list-conversion.ttl
+++ b/src/test/resources/rdf-list-conversion.ttl
@@ -41,6 +41,11 @@ order-test:collection-2000
         skos:member          ( order-test:c340 order-test:concept-3 order-test:order-1 );
         skos:prefLabel       "test"@sv , "test"@fi , "test"@en .
 
+order-test:collection-0
+        rdf:type             skos:Collection;
+        skos:inScheme        order-test:;
+        skos:prefLabel       "test empty"@sv , "test empty"@fi , "test empty"@en .
+
 order-test:  rdf:type                   skos:ConceptScheme;
         rdfs:comment                  "test en"@en , "test"@fi;
         dcterms:contributor           <urn:uuid:7d3a3c00-5a6b-489b-a3ed-63bb58c26a63>;
@@ -134,3 +139,81 @@ order-test:order-1  rdf:type            skos:Concept;
                                       );
         suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT" .
 
+_:b0 rdf:first _:b1; rdf:rest () .
+
+_:b2 rdf:first _:b3; rdf:rest () .
+
+_:b4 rdf:first _:b5; rdf:rest () .
+
+_:b6 rdf:first _:b7; rdf:rest () .
+
+_:b8 rdf:first _:b9; rdf:rest () .
+
+_:b10 rdf:first _:b11; rdf:rest () .
+
+_:b12 rdf:first _:b13; rdf:rest () .
+
+_:b14 rdf:first _:b15; rdf:rest () .
+
+_:b16 rdf:first _:b17; rdf:rest () .
+
+_:b18 rdf:first _:b19; rdf:rest () .
+
+_:b20 rdf:first _:b21; rdf:rest () .
+
+_:b22 rdf:first _:b23; rdf:rest () .
+
+_:b24 rdf:first _:b25; rdf:rest () .
+
+_:b26 rdf:first order-test:concept-3; rdf:rest () .
+
+_:b27 rdf:first _:b28; rdf:rest () .
+
+_:b29 rdf:first "editorial"; rdf:rest () .
+
+_:b30 rdf:first _:b31; rdf:rest () .
+
+_:b12   rdf:first  _:b13;
+        rdf:rest   () .
+
+_:b6    rdf:first  _:b7;
+        rdf:rest   () .
+
+_:b8    rdf:first  _:b9;
+        rdf:rest   () .
+
+_:b10   rdf:first  _:b11;
+        rdf:rest   () .
+
+_:b30   rdf:first  _:b31;
+        rdf:rest   () .
+
+_:b0    rdf:first  _:b1;
+        rdf:rest   () .
+
+_:b20   rdf:first  _:b21;
+        rdf:rest   () .
+
+_:b24   rdf:first  _:b25;
+        rdf:rest   () .
+
+_:b18   rdf:first  _:b19;
+        rdf:rest   () .
+
+_:b16   rdf:first  _:b17;
+        rdf:rest   () .
+
+_:b22   rdf:first  _:b23;
+        rdf:rest   () .
+
+_:b2    rdf:first  _:b3;
+        rdf:rest   () .
+
+_:b27   rdf:first  _:b28;
+        rdf:rest   () .
+
+_:b14   rdf:first  _:b15;
+        rdf:rest   () .
+
+_:b4    rdf:first  _:b5;
+        rdf:rest   () .

--- a/src/test/resources/rdf-list-conversion.ttl
+++ b/src/test/resources/rdf-list-conversion.ttl
@@ -1,0 +1,136 @@
+@prefix a59457c39:  <https://iri.suomi.fi/terminology/a59457c39/> .
+@prefix dcap:       <http://purl.org/ws-mmi-dc/terms/> .
+@prefix dcterms:    <http://purl.org/dc/terms/> .
+@prefix foaf:       <http://xmlns.com/foaf/0.1/> .
+@prefix order-test:   <https://iri.suomi.fi/terminology/order-test/> .
+@prefix owl:        <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:       <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh:         <http://www.w3.org/ns/shacl#> .
+@prefix skos:       <http://www.w3.org/2004/02/skos/core#> .
+@prefix skos-xl:    <http://www.w3.org/2008/05/skos-xl#> .
+@prefix suomi-meta: <https://iri.suomi.fi/model/suomi-meta/> .
+@prefix term:       <https://iri.suomi.fi/model/term/> .
+@prefix xsd:        <http://www.w3.org/2001/XMLSchema#> .
+
+order-test:c340  rdf:type               skos:Concept;
+        skos:inScheme                 order-test:;
+        skos:prefLabel                ( [ rdf:type                      skos-xl:Label;
+                                          skos-xl:literalForm           "test 1"@fi;
+                                          suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID"
+                                        ]
+                                      );
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID";
+        term:notRecommendedSynonym    ( [ rdf:type                      skos-xl:Label;
+                                          skos-xl:literalForm           "lapsen hoitotuki"@fi;
+                                          suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID";
+                                          term:termInfo                 "vanhentunut/föråldrad"
+                                        ]
+                                        [ rdf:type                      skos-xl:Label;
+                                          skos-xl:literalForm           "hoitotuki"@fi;
+                                          suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID";
+                                          term:homographNumber          "2"^^xsd:int;
+                                          term:termInfo                 "vanhentunut/föråldrad"
+                                        ]
+                                      ) .
+
+order-test:collection-2000
+        rdf:type             skos:Collection;
+        rdfs:comment         "kuvaus käsitekokoelma"@fi;
+        skos:inScheme        order-test:;
+        skos:member          ( order-test:c340 order-test:concept-3 order-test:order-1 );
+        skos:prefLabel       "test"@sv , "test"@fi , "test"@en .
+
+order-test:  rdf:type                   skos:ConceptScheme;
+        rdfs:comment                  "test en"@en , "test"@fi;
+        dcterms:contributor           <urn:uuid:7d3a3c00-5a6b-489b-a3ed-63bb58c26a63>;
+        dcterms:isPartOf              <http://urn.fi/URN:NBN:fi:au:ptvl:v1090>;
+        dcterms:language              "fi" , "sv" , "en";
+        dcap:preferredXMLNamespace    "https://iri.suomi.fi/terminology/order-test/";
+        dcap:preferredXMLNamespacePrefix
+                "order-test";
+        skos:prefLabel                "kallek test 20221014"@fi , "test sv"@sv , "test en"@en;
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/VALID";
+        term:terminologyType          "OTHER_VOCABULARY" .
+
+order-test:concept-3  rdf:type          skos:Concept;
+        skos:altLabel                 ( [ rdf:type                      skos-xl:Label;
+                                          skos-xl:literalForm           "hakusynonyymi"@fi;
+                                          suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT"
+                                        ]
+                                        [ rdf:type                      skos-xl:Label;
+                                          skos-xl:literalForm           "svenskasynonyymi"@sv;
+                                          suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT"
+                                        ]
+                                        [ rdf:type                      skos-xl:Label;
+                                          skos-xl:literalForm           "enkkusynonyymi"@en;
+                                          suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT"
+                                        ]
+                                      );
+        skos:definition               "test"@fi;
+        skos:inScheme                 order-test:;
+        skos:prefLabel                ( [ rdf:type                      skos-xl:Label;
+                                          skos-xl:literalForm           "hakutesti"@fi;
+                                          suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT"
+                                        ]
+                                        [ rdf:type                      skos-xl:Label;
+                                          skos-xl:literalForm           "sök test"@sv;
+                                          suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT"
+                                        ]
+                                        [ rdf:type                      skos-xl:Label;
+                                          skos-xl:literalForm           "search test"@en;
+                                          suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT"
+                                        ]
+                                      );
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT" .
+
+order-test:concept-5000
+        rdf:type                      skos:Concept;
+        skos:inScheme                 order-test:;
+        skos:prefLabel                ( [ rdf:type                      skos-xl:Label;
+                                          skos-xl:literalForm           "test ref"@fi;
+                                          suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT"
+                                        ]
+                                        [ rdf:type                      skos-xl:Label;
+                                          skos-xl:literalForm           "test ref sv"@sv;
+                                          suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT"
+                                        ]
+                                        [ rdf:type                      skos-xl:Label;
+                                          skos-xl:literalForm           "test ref en"@en;
+                                          suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT"
+                                        ]
+                                      );
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT" .
+
+order-test:order-1  rdf:type            skos:Concept;
+        skos:altLabel                 ( [ rdf:type                      skos-xl:Label;
+                                          skos-xl:literalForm           "synonyymi1"@fi;
+                                          suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT"
+                                        ]
+                                        [ rdf:type                      skos-xl:Label;
+                                          skos-xl:literalForm           "synonyymi2"@fi;
+                                          suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT"
+                                        ]
+                                        [ rdf:type                      skos-xl:Label;
+                                          skos-xl:literalForm           "synonyymi3"@fi;
+                                          suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT"
+                                        ]
+                                      );
+        skos:broader                  ( order-test:c340 order-test:concept-3 );
+        skos:inScheme                 order-test:;
+        skos:note                     ( "Ensimmäinen huomautus"@fi "Uusi huomautus"@fi );
+        skos:prefLabel                ( [ rdf:type                      skos-xl:Label;
+                                          skos-xl:literalForm           "Järjestystesti"@fi;
+                                          suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT"
+                                        ]
+                                        [ rdf:type                      skos-xl:Label;
+                                          skos-xl:literalForm           "Järjestystesti"@sv;
+                                          suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT"
+                                        ]
+                                        [ rdf:type                      skos-xl:Label;
+                                          skos-xl:literalForm           "Järjestystesti"@en;
+                                          suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT"
+                                        ]
+                                      );
+        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT" .
+

--- a/src/test/resources/terminology-with-concept-collections.ttl
+++ b/src/test/resources/terminology-with-concept-collections.ttl
@@ -28,7 +28,9 @@ test:   rdf:type                      skos:ConceptScheme;
 # Concept collection containing concept-1 and concept-2
 
 test:collection-1   rdf:type    skos:Collection;
-                    skos:member test:concept-1, test:concept-2;
+        term:orderedMember            ( test:concept-1 test:concept-2 );
+        skos:member                   test:concept-1;
+        skos:member                   test:concept-2;
         skos:prefLabel                "Testikokoelma 1"@fi , "Test collection 1"@en;
         rdfs:comment                  "Test collection description 1"@en , "Testikokoelman kuvaus 1"@fi;
         dcterms:created               "2024-05-15T05:00:00.000Z"^^xsd:dateTime;

--- a/src/test/resources/terminology-with-concepts.ttl
+++ b/src/test/resources/terminology-with-concepts.ttl
@@ -34,33 +34,37 @@ test:concept-1  rdfs:seeAlso          ( [
                                       ] );
         dcterms:created               "2024-05-06T05:00:00.000Z"^^xsd:dateTime;
         dcterms:modified              "2024-05-07T04:00:00.000Z"^^xsd:dateTime;
-        skos:altLabel                 <40b1e74c-766f-4fe2-9679-a1388e5c96ab> , <c0a7af17-4857-4446-965f-e9f304145170>;
-        term:orderedSynonym           ( <40b1e74c-766f-4fe2-9679-a1388e5c96ab> <c0a7af17-4857-4446-965f-e9f304145170> );
+        skos:altLabel                 <urn:uuid:40b1e74c-766f-4fe2-9679-a1388e5c96ab> , <urn:uuid:c0a7af17-4857-4446-965f-e9f304145170>;
+        term:orderedSynonym           ( <urn:uuid:40b1e74c-766f-4fe2-9679-a1388e5c96ab> <urn:uuid:c0a7af17-4857-4446-965f-e9f304145170> );
         term:orderedBroader           ( test:concept-2 test:concept-20 );
         skos:broader                  test:concept-2;
         skos:broader                  test:concept-20;
         skos:changeNote               "change";
         skos:definition               "def"@fi;
-        skos:editorialNote            ( "editorial" );
-        skos:example                  ( "example"@fi );
-        skos:hiddenLabel              <bf40a18b-fcce-4176-a6b0-b2209c1fca8f>;
+        term:orderedEditorialNote     ( "editorial" );
+        skos:editorialNote            "editorial";
+        skos:example                  "example"@fi;
+        term:orderedExample           ( "example"@fi );
+        skos:hiddenLabel              <urn:uuid:bf40a18b-fcce-4176-a6b0-b2209c1fca8f>;
         skos:historyNote              "history";
         skos:inScheme                 test:;
-        skos:note                     ( "note"@fi );
-        skos:prefLabel                <0a0c1bca-4a20-4c33-ab8b-d8f2abaa03ab>;
+        skos:note                     "note"@fi;
+        term:orderedNote              ( "note"@fi );
+        skos:prefLabel                <urn:uuid:0a0c1bca-4a20-4c33-ab8b-d8f2abaa03ab>;
         suomi-meta:creator            "23006bf4-4c09-4438-8224-785fdf108812";
         suomi-meta:modifier           "23006bf4-4c09-4438-8224-785fdf108812";
         suomi-meta:publicationStatus  <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT>;
         term:conceptClass             "concept class";
-        term:notRecommendedSynonym    <fa59a67e-e1ce-48c2-ac8c-effcbfa934a5> ;
+        term:notRecommendedSynonym    <urn:uuid:fa59a67e-e1ce-48c2-ac8c-effcbfa934a5> ;
         term:orderedNotRecommendedSynonym
-            ( <fa59a67e-e1ce-48c2-ac8c-effcbfa934a5> );
-        term:source                   ( "source" );
+            ( <urn:uuid:fa59a67e-e1ce-48c2-ac8c-effcbfa934a5> );
+        term:orderedSource            ( "source" );
+        dcterms:source                 "source";
         skos:narrowMatch              <https://iri.suomi.fi/terminology/ext/concept-1> ;
         term:orderedNarrowMatch       ( <https://iri.suomi.fi/terminology/ext/concept-1> ) ;
         term:subjectArea              "subject area" .
 
-<0a0c1bca-4a20-4c33-ab8b-d8f2abaa03ab>
+<urn:uuid:0a0c1bca-4a20-4c33-ab8b-d8f2abaa03ab>
         rdf:type                      skos-xl:Label;
         skos:changeNote               "term change";
         skos:historyNote              "term history";
@@ -75,22 +79,22 @@ test:concept-1  rdfs:seeAlso          ( [
         term:termStyle                "term style";
         term:wordClass                "ADJECTIVE" .
 
-<40b1e74c-766f-4fe2-9679-a1388e5c96ab>
+<urn:uuid:40b1e74c-766f-4fe2-9679-a1388e5c96ab>
         rdf:type            skos-xl:Label;
         skos-xl:literalForm           "synonyymi 1"@fi;
         suomi-meta:publicationStatus  <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> .
 
-<c0a7af17-4857-4446-965f-e9f304145170>
+<urn:uuid:c0a7af17-4857-4446-965f-e9f304145170>
         rdf:type                      skos-xl:Label;
         skos-xl:literalForm           "synonyymi 2"@fi;
         suomi-meta:publicationStatus  <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> .
 
-<fa59a67e-e1ce-48c2-ac8c-effcbfa934a5>
+<urn:uuid:fa59a67e-e1ce-48c2-ac8c-effcbfa934a5>
         rdf:type                      skos-xl:Label;
         skos-xl:literalForm           "ei suositettava"@fi;
         suomi-meta:publicationStatus  <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> .
 
-<bf40a18b-fcce-4176-a6b0-b2209c1fca8f>
+<urn:uuid:bf40a18b-fcce-4176-a6b0-b2209c1fca8f>
         rdf:type                      skos-xl:Label;
         skos-xl:literalForm           "hakutermi"@fi;
         suomi-meta:publicationStatus  <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> .
@@ -99,10 +103,10 @@ test:concept-1  rdfs:seeAlso          ( [
 
 test:concept-2
         skos:inScheme                 test:;
-        skos:prefLabel                <c1a77136-dc9e-4858-bb38-fab195c1bd0f>;
+        skos:prefLabel                <urn:uuid:c1a77136-dc9e-4858-bb38-fab195c1bd0f>;
         suomi-meta:publicationStatus  <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> .
 
-<c1a77136-dc9e-4858-bb38-fab195c1bd0f>
+<urn:uuid:c1a77136-dc9e-4858-bb38-fab195c1bd0f>
         rdf:type                      skos-xl:Label;
         skos-xl:literalForm           "Suositettava termi"@fi;
         suomi-meta:publicationStatus  <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> .

--- a/src/test/resources/terminology-with-concepts.ttl
+++ b/src/test/resources/terminology-with-concepts.ttl
@@ -34,64 +34,75 @@ test:concept-1  rdfs:seeAlso          ( [
                                       ] );
         dcterms:created               "2024-05-06T05:00:00.000Z"^^xsd:dateTime;
         dcterms:modified              "2024-05-07T04:00:00.000Z"^^xsd:dateTime;
-        skos:altLabel                 ( [
-                                            rdf:type                      skos-xl:Label;
-                                            skos-xl:literalForm           "synonyymi 1"@fi;
-                                            suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT"
-                                        ]
-                                        [
-                                            rdf:type                      skos-xl:Label;
-                                            skos-xl:literalForm           "synonyymi 2"@fi;
-                                            suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT"
-                                      ] );
-        skos:broader                  ( test:concept-2 test:concept-20 );
+        skos:altLabel                 <40b1e74c-766f-4fe2-9679-a1388e5c96ab> , <c0a7af17-4857-4446-965f-e9f304145170>;
+        term:orderedSynonym           ( <40b1e74c-766f-4fe2-9679-a1388e5c96ab> <c0a7af17-4857-4446-965f-e9f304145170> );
+        term:orderedBroader           ( test:concept-2 test:concept-20 );
+        skos:broader                  test:concept-2;
+        skos:broader                  test:concept-20;
         skos:changeNote               "change";
         skos:definition               "def"@fi;
         skos:editorialNote            ( "editorial" );
         skos:example                  ( "example"@fi );
-        skos:hiddenLabel              ( [
-                                              rdf:type                      skos-xl:Label;
-                                              skos-xl:literalForm           "hakutermi"@fi;
-                                              suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT"
-                                      ] ) ;
+        skos:hiddenLabel              <bf40a18b-fcce-4176-a6b0-b2209c1fca8f>;
         skos:historyNote              "history";
         skos:inScheme                 test:;
         skos:note                     ( "note"@fi );
-        skos:prefLabel                ( [
-                                             rdf:type                      skos-xl:Label;
-                                             skos:changeNote               "term change";
-                                             skos:historyNote              "term history";
-                                             skos-xl:literalForm           "Suositettava termi"@fi;
-                                             suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT";
-                                             term:homographNumber          2;
-                                             term:scope                    "scope";
-                                             term:termConjugation          "SINGULAR";
-                                             term:termEquivalency          "BROADER";
-                                             term:termFamily               "NEUTER";
-                                             term:termInfo                 "info";
-                                             term:termStyle                "term style";
-                                             term:wordClass                "ADJECTIVE"
-                                      ] );
+        skos:prefLabel                <0a0c1bca-4a20-4c33-ab8b-d8f2abaa03ab>;
         suomi-meta:creator            "23006bf4-4c09-4438-8224-785fdf108812";
         suomi-meta:modifier           "23006bf4-4c09-4438-8224-785fdf108812";
-        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT";
+        suomi-meta:publicationStatus  <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT>;
         term:conceptClass             "concept class";
-        term:notRecommendedSynonym    ( [
-                                              rdf:type                      skos-xl:Label;
-                                              skos-xl:literalForm           "ei suositettava"@fi;
-                                              suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT"
-                                      ] ) ;
+        term:notRecommendedSynonym    <fa59a67e-e1ce-48c2-ac8c-effcbfa934a5> ;
+        term:orderedNotRecommendedSynonym
+            ( <fa59a67e-e1ce-48c2-ac8c-effcbfa934a5> );
         term:source                   ( "source" );
-        skos:narrowMatch              ( <https://iri.suomi.fi/terminology/ext/concept-1> ) ;
+        skos:narrowMatch              <https://iri.suomi.fi/terminology/ext/concept-1> ;
+        term:orderedNarrowMatch       ( <https://iri.suomi.fi/terminology/ext/concept-1> ) ;
         term:subjectArea              "subject area" .
+
+<0a0c1bca-4a20-4c33-ab8b-d8f2abaa03ab>
+        rdf:type                      skos-xl:Label;
+        skos:changeNote               "term change";
+        skos:historyNote              "term history";
+        skos-xl:literalForm           "Suositettava termi"@fi;
+        suomi-meta:publicationStatus  <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT>;
+        term:homographNumber          2;
+        term:scope                    "scope";
+        term:termConjugation          "SINGULAR";
+        term:termEquivalency          "BROADER";
+        term:termFamily               "NEUTER";
+        term:termInfo                 "info";
+        term:termStyle                "term style";
+        term:wordClass                "ADJECTIVE" .
+
+<40b1e74c-766f-4fe2-9679-a1388e5c96ab>
+        rdf:type            skos-xl:Label;
+        skos-xl:literalForm           "synonyymi 1"@fi;
+        suomi-meta:publicationStatus  <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> .
+
+<c0a7af17-4857-4446-965f-e9f304145170>
+        rdf:type                      skos-xl:Label;
+        skos-xl:literalForm           "synonyymi 2"@fi;
+        suomi-meta:publicationStatus  <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> .
+
+<fa59a67e-e1ce-48c2-ac8c-effcbfa934a5>
+        rdf:type                      skos-xl:Label;
+        skos-xl:literalForm           "ei suositettava"@fi;
+        suomi-meta:publicationStatus  <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> .
+
+<bf40a18b-fcce-4176-a6b0-b2209c1fca8f>
+        rdf:type                      skos-xl:Label;
+        skos-xl:literalForm           "hakutermi"@fi;
+        suomi-meta:publicationStatus  <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> .
 
 # Concept 2 with term
 
 test:concept-2
         skos:inScheme                 test:;
-        skos:prefLabel                ( [
-                                            rdf:type                      skos-xl:Label;
-                                            skos-xl:literalForm           "Suositettava termi"@fi;
-                                            suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT"
-                                       ] ) ;
-        suomi-meta:publicationStatus  "http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT" .
+        skos:prefLabel                <c1a77136-dc9e-4858-bb38-fab195c1bd0f>;
+        suomi-meta:publicationStatus  <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> .
+
+<c1a77136-dc9e-4858-bb38-fab195c1bd0f>
+        rdf:type                      skos-xl:Label;
+        skos-xl:literalForm           "Suositettava termi"@fi;
+        suomi-meta:publicationStatus  <http://uri.suomi.fi/codelist/interoperabilityplatform/interoperabilityplatform_status/code/DRAFT> .


### PR DESCRIPTION
Store order of the data in separate property

```
test:concept-1;
          skos:note                   "Test note 1"@en , "Test note 2"@en ;
          term:orderedNote.    ( "Test note 2"@en  "Test note 1"@en ) .
```

Create terms as a resource with an identifier

```
test:concept-1;
         skos:prefLabel          <urn:uuid:b9dd6178-57e4-45bc-841d-13cdc6057bb9> .

<urn:uuid:b9dd6178-57e4-45bc-841d-13cdc6057bb9>
        rdf:type                      skos-xl:Label;
        skos-xl:literalForm    "Test term"@en .
```

Other fixes
- Fix saving notes' and examples' order in NTRF import
- Save term's homograph number only if > 0
- Change status to resource (previously stored as a literal)