### PR TITLE
YTI-4260 improve concept search

### DIFF
--- a/src/test/resources/opensearch/concept-exceptions-request.json
+++ b/src/test/resources/opensearch/concept-exceptions-request.json
@@ -18,7 +18,7 @@
               "definition.*^3.0",
               "notRecommendedSynonym"
             ],
-            "query": "*test*"
+            "query": "test~1 *test*"
           }
         },
         {

--- a/src/test/resources/opensearch/concept-request.json
+++ b/src/test/resources/opensearch/concept-request.json
@@ -17,7 +17,7 @@
               "definition.*^3.0",
               "notRecommendedSynonym"
             ],
-            "query": "*test*"
+            "query": "test~1 *test*"
           }
         },
         {

--- a/src/test/resources/opensearch/concept-superuser-request.json
+++ b/src/test/resources/opensearch/concept-superuser-request.json
@@ -18,7 +18,7 @@
               "definition.*^3.0",
               "notRecommendedSynonym"
             ],
-            "query": "*test*"
+            "query": "test~1 *test*"
           }
         },
         {


### PR DESCRIPTION
For more relevant search result, build query string with exact match and wildcards, e.g. `test~1 *test*`.  That is: search documents matching `test` (with fuzziness 1) OR `*test*`. Exact matches will get better score, so they will be ranked higher in the results. If the query string contains space, search for exact phrase, e.g.  query string `test something` => `"test something"`.

If no status is given, use predefined status list to filter out concepts with status SUPERSEDED or RETIRED. 

See also: https://github.com/VRK-YTI/yti-common-backend/pull/8