### PR TITLE
YTI-4226 count queries

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/v2/dto/CountDTO.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/dto/CountDTO.java
@@ -30,7 +30,15 @@ public class CountDTO {
         this.groups = groups;
     }
 
-
+    public CountDTO(
+            final Map<String, Long> statuses,
+            final Map<String, Long> types
+    ) {
+        this.statuses = statuses;
+        this.types = types;
+        this.languages = Map.of();
+        this.groups = Map.of();
+    }
 
     public Map<String, Long> getStatuses() {
         return statuses;

--- a/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/FrontendController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/endpoint/FrontendController.java
@@ -13,6 +13,8 @@ import fi.vm.yti.terminology.api.v2.dto.TerminologySearchResultDTO;
 import fi.vm.yti.terminology.api.v2.opensearch.ConceptSearchRequest;
 import fi.vm.yti.terminology.api.v2.opensearch.TerminologySearchRequest;
 import fi.vm.yti.terminology.api.v2.service.SearchIndexService;
+import fi.vm.yti.terminology.api.v2.service.TerminologyService;
+import fi.vm.yti.terminology.api.v2.util.TerminologyURI;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -38,13 +40,17 @@ public class FrontendController {
 
     private final AuthenticatedUserProvider userProvider;
 
+    private final TerminologyService terminologyService;
+
     public FrontendController(
             SearchIndexService searchIndexService,
             FrontendService frontendService,
-            AuthenticatedUserProvider userProvider) {
+            AuthenticatedUserProvider userProvider,
+            TerminologyService terminologyService) {
         this.frontendService = frontendService;
         this.searchIndexService = searchIndexService;
         this.userProvider = userProvider;
+        this.terminologyService = terminologyService;
     }
 
     @Operation(summary = "Get organizations", description = "List of organizations sorted by name")
@@ -88,24 +94,26 @@ public class FrontendController {
     @Operation(summary = "Get frontpage counts")
     @ApiResponse(responseCode = "200", description = "")
     @GetMapping(value = "/counts", produces = APPLICATION_JSON_VALUE)
-    public CountSearchResponse getCounts() {
-        // TODO: placeholder
-        return new CountSearchResponse();
+    public CountSearchResponse getCounts(
+            @Parameter(description = "Terminology search parameters") TerminologySearchRequest request) {
+        return searchIndexService.getTerminologyCounts(request, userProvider.getUser());
     }
 
     @Operation(summary = "Get concept counts")
     @ApiResponse(responseCode = "200", description = "")
     @GetMapping(value = "/concept-counts", produces = APPLICATION_JSON_VALUE)
     public CountSearchResponse getConceptCounts(@RequestParam String prefix) {
-        // TODO: placeholder
-        return new CountSearchResponse();
+        var request = new ConceptSearchRequest();
+        request.setNamespace(TerminologyURI.createTerminologyURI(prefix).getGraphURI());
+        request.setQuery("");
+        return searchIndexService.getConceptCounts(request, userProvider.getUser());
     }
 
     @Operation(summary = "Get status counts")
     @ApiResponse(responseCode = "200", description = "")
     @GetMapping(value = "/status-counts", produces = APPLICATION_JSON_VALUE)
     public StatusCountResponse getStatusCounts(@RequestParam String prefix) {
-        // TODO: placeholder
-        return new StatusCountResponse();
+        return terminologyService.getCountsByStatus(
+                TerminologyURI.createTerminologyURI(prefix).getGraphURI());
     }
 }

--- a/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapper.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/mapper/ConceptMapper.java
@@ -317,10 +317,16 @@ public class ConceptMapper {
     }
 
     private static void handleTerms(ModelWrapper model, ConceptDTO dto, Resource conceptResource) {
-        conceptResource.removeAll(SKOS.prefLabel);
-        conceptResource.removeAll(SKOS.altLabel);
-        conceptResource.removeAll(Term.notRecommendedSynonym);
-        conceptResource.removeAll(SKOS.hiddenLabel);
+        // remove old terms from model and concept's properties
+        termProperties.forEach(term -> {
+                conceptResource.listProperties(term)
+                        .mapWith(Statement::getResource)
+                        .forEach(termResource -> {
+                            MapperUtils.removeAllLists(termResource);
+                            model.removeAll(termResource, null, null);
+                        });
+                conceptResource.removeAll(term);
+        });
 
         // Preferred terms don't need to be ordered, since there's only one preferred term / language
         dto.getRecommendedTerms().stream()

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptQueryFactory.java
@@ -48,7 +48,7 @@ public class ConceptQueryFactory {
         return sr;
     }
 
-    private static Query getConceptBaseQuery(
+    public static Query getConceptBaseQuery(
             ConceptSearchRequest request,
             boolean isSuperUser,
             Set<String> incompleteFromTerminologies) {

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/CountQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/CountQueryFactory.java
@@ -1,0 +1,66 @@
+package fi.vm.yti.terminology.api.v2.opensearch;
+
+import fi.vm.yti.security.YtiUser;
+import fi.vm.yti.terminology.api.v2.service.IndexService;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.AggregationBuilders;
+import org.opensearch.client.opensearch.core.SearchRequest;
+
+import java.util.Set;
+import java.util.UUID;
+
+import static fi.vm.yti.common.opensearch.OpenSearchUtil.logPayload;
+
+public class CountQueryFactory {
+
+    private CountQueryFactory() {
+        // only static methods
+    }
+
+    public static SearchRequest createTerminologyCountQuery(TerminologySearchRequest request,
+                                                            YtiUser user,
+                                                            Set<String> matchingConcepts,
+                                                            Set<UUID> privilegedOrganizations) {
+        var terminologyQuery = TerminologyQueryFactory.getTerminologyBaseQuery(request,
+                user.isSuperuser(),
+                matchingConcepts,
+                privilegedOrganizations);
+
+        var sr = new SearchRequest.Builder()
+                .index(IndexService.TERMINOLOGY_INDEX)
+                .size(0)
+                .query(terminologyQuery)
+                .aggregations("statuses", getAggregation("status"))
+                .aggregations("groups", getAggregation("groups"))
+                .aggregations("languages", getAggregation("languages"))
+                .build();
+
+        logPayload(sr, IndexService.TERMINOLOGY_INDEX);
+        return sr;
+    }
+
+    public static SearchRequest createConceptCountQuery(ConceptSearchRequest request,
+                                                        boolean isSuperUser,
+                                                        Set<String> incompleteFromTerminologies) {
+        var query = ConceptQueryFactory.getConceptBaseQuery(request,
+                isSuperUser,
+                incompleteFromTerminologies);
+
+        var sr = new SearchRequest.Builder()
+                .index(IndexService.CONCEPT_INDEX)
+                .query(query)
+                .aggregations("statuses", getAggregation("status"))
+                .build();
+
+        logPayload(sr, IndexService.CONCEPT_INDEX);
+        return sr;
+    }
+
+    private static Aggregation getAggregation(String fieldName) {
+        return AggregationBuilders.terms()
+                .field(fieldName)
+                .size(100)
+                .build().
+                _toAggregation();
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologyQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologyQueryFactory.java
@@ -1,8 +1,8 @@
 package fi.vm.yti.terminology.api.v2.opensearch;
 
 import fi.vm.yti.common.enums.Status;
-import fi.vm.yti.common.opensearch.SearchResponseDTO;
 import fi.vm.yti.common.opensearch.QueryFactoryUtils;
+import fi.vm.yti.common.opensearch.SearchResponseDTO;
 import fi.vm.yti.terminology.api.v2.dto.ConceptSearchResultDTO;
 import fi.vm.yti.terminology.api.v2.service.IndexService;
 import org.opensearch.client.opensearch._types.FieldValue;
@@ -76,7 +76,7 @@ public class TerminologyQueryFactory {
         return sr;
     }
 
-    private static Query getTerminologyBaseQuery(
+    public static Query getTerminologyBaseQuery(
             TerminologySearchRequest request,
             boolean isSuperUser,
             Set<String> additionalTerminologyUris,

--- a/src/main/java/fi/vm/yti/terminology/api/v2/service/SearchIndexService.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/service/SearchIndexService.java
@@ -1,13 +1,15 @@
 package fi.vm.yti.terminology.api.v2.service;
 
+import fi.vm.yti.common.enums.Status;
+import fi.vm.yti.common.opensearch.IndexBase;
 import fi.vm.yti.common.opensearch.OpenSearchClientWrapper;
 import fi.vm.yti.common.opensearch.SearchResponseDTO;
 import fi.vm.yti.common.service.GroupManagementService;
 import fi.vm.yti.security.YtiUser;
-import fi.vm.yti.terminology.api.v2.dto.ConceptSearchResultDTO;
-import fi.vm.yti.terminology.api.v2.dto.SimpleTerminologyDTO;
-import fi.vm.yti.terminology.api.v2.dto.TerminologySearchResultDTO;
+import fi.vm.yti.terminology.api.v2.dto.*;
 import fi.vm.yti.terminology.api.v2.opensearch.*;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
+import org.opensearch.client.opensearch.core.SearchResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -28,45 +30,24 @@ public class SearchIndexService {
 
     private final TerminologyService terminologyService;
 
-    private final ConceptService conceptService;
-
-    private final ConceptCollectionService conceptCollectionService;
 
     public SearchIndexService(OpenSearchClientWrapper client,
                               GroupManagementService groupManagementService,
-                              TerminologyService terminologyService,
-                              ConceptService conceptService,
-                              ConceptCollectionService conceptCollectionService) {
+                              TerminologyService terminologyService) {
         this.client = client;
         this.groupManagementService = groupManagementService;
         this.terminologyService = terminologyService;
-        this.conceptService = conceptService;
-        this.conceptCollectionService = conceptCollectionService;
     }
 
     public SearchResponseDTO<TerminologySearchResultDTO> searchTerminologies(
             TerminologySearchRequest request,
             YtiUser user) {
         // list of organizations that the user belongs to
-        Set<java.util.UUID> privilegedOrganizations = user.isSuperuser() ?
+        Set<UUID> privilegedOrganizations = user.isSuperuser() ?
                 Collections.emptySet() :
                 this.groupManagementService.getOrganizationsForUser(user);
 
-        SearchResponseDTO<ConceptSearchResultDTO> matchingConcepts = null;
-        if (request.isSearchConcepts() && !request.getQuery().isEmpty()) {
-            // list of terminologies that the user has access to
-            Set<String> incompleteFromTerminologies = user.isSuperuser() ?
-                    Collections.emptySet() :
-                    terminologiesMatchingOrganizations(privilegedOrganizations);
-
-            var conceptRequest = new ConceptSearchRequest();
-            conceptRequest.setQuery(request.getQuery());
-            var query = ConceptQueryFactory.createConceptQuery(
-                    conceptRequest,
-                    user.isSuperuser(),
-                    incompleteFromTerminologies);
-            matchingConcepts = client.search(query, ConceptSearchResultDTO.class);
-        }
+        var matchingConcepts = getMatchingConcepts(request, user, privilegedOrganizations);
 
         var query = TerminologyQueryFactory.createTerminologyQuery(
                 request,
@@ -90,7 +71,7 @@ public class SearchIndexService {
     public SearchResponseDTO<ConceptSearchResultDTO> searchConcepts(
             ConceptSearchRequest request,
             YtiUser user) {
-        Set<java.util.UUID> privilegedOrganizations = user.isSuperuser() ?
+        Set<UUID> privilegedOrganizations = user.isSuperuser() ?
                 Collections.emptySet() :
                 this.groupManagementService.getOrganizationsForUser(user);
         Set<String> incompleteFromTerminologies = user.isSuperuser() ?
@@ -141,5 +122,107 @@ public class SearchIndexService {
             logger.error("Failed to resolve terminologies based on contributors", e);
             throw new RuntimeException(e);
         }
+    }
+
+    public CountSearchResponse getTerminologyCounts(TerminologySearchRequest request, YtiUser user) {
+        request.setSearchConcepts(true);
+        // add all statuses to the search because only particular statuses are included to the search by default
+        if (request.getStatus() == null || request.getStatus().isEmpty()) {
+            request.setStatus(Arrays.stream(Status.values()).collect(Collectors.toSet()));
+        }
+        if (request.getQuery() == null) {
+            request.setQuery("");
+        }
+
+        Set<UUID> privilegedOrganizations = user.isSuperuser() ?
+                Collections.emptySet() :
+                this.groupManagementService.getOrganizationsForUser(user);
+
+        var matchingConcepts = getMatchingConcepts(request, user, privilegedOrganizations);
+
+        Set<String> additionalTerminologies = new HashSet<>();
+        if (matchingConcepts != null) {
+            additionalTerminologies = matchingConcepts.getResponseObjects().stream()
+                    .map(IndexConcept::getNamespace)
+                    .collect(Collectors.toSet());
+        }
+        var countRequest = CountQueryFactory.createTerminologyCountQuery(request, user,
+                additionalTerminologies,
+                privilegedOrganizations);
+
+        var response = client.searchResponse(countRequest, IndexTerminology.class);
+
+        var countResponse = new CountSearchResponse();
+        var counts = new CountDTO(
+                getBucketValues(response, "statuses"),
+                getBucketValues(response, "languages"),
+                getBucketValues(response, "types"),
+                getBucketValues(response, "groups")
+        );
+        countResponse.setTotalHitCount(response.hits().total().value());
+        countResponse.setCounts(counts);
+        return countResponse;
+    }
+
+    public CountSearchResponse getConceptCounts(ConceptSearchRequest request, YtiUser user) {
+
+        Set<UUID> privilegedOrganizations = user.isSuperuser() ?
+                Collections.emptySet() :
+                this.groupManagementService.getOrganizationsForUser(user);
+
+        Set<String> incompleteFromTerminologies = user.isSuperuser() ?
+                Collections.emptySet() :
+                terminologiesMatchingOrganizations(privilegedOrganizations);
+
+        var searchRequest = CountQueryFactory.createConceptCountQuery(request, user.isSuperuser(), incompleteFromTerminologies);
+
+        var countSearchResponse = client.searchResponse(searchRequest, IndexConcept.class);
+
+        // find concept collection count by type with sparql query, because they are not indexed.
+        var collectionCount = terminologyService.getConceptCollectionCount(request.getNamespace());
+
+        var countDTO = new CountDTO(
+                getBucketValues(countSearchResponse, "statuses"),
+                Map.of(
+                        "Concept", countSearchResponse.hits().total().value(),
+                        "Collection", collectionCount)
+        );
+        var response = new CountSearchResponse();
+        response.setCounts(countDTO);
+        response.setTotalHitCount(0);
+
+        return response;
+    }
+
+    private SearchResponseDTO<ConceptSearchResultDTO> getMatchingConcepts(TerminologySearchRequest request, YtiUser user, Set<UUID> privilegedOrganizations) {
+        if (request.isSearchConcepts() && !request.getQuery().isEmpty()) {
+            // list of terminologies that the user has access to
+            Set<String> incompleteFromTerminologies = user.isSuperuser() ?
+                    Collections.emptySet() :
+                    terminologiesMatchingOrganizations(privilegedOrganizations);
+
+            var conceptRequest = new ConceptSearchRequest();
+            conceptRequest.setQuery(request.getQuery());
+            var query = ConceptQueryFactory.createConceptQuery(
+                    conceptRequest,
+                    user.isSuperuser(),
+                    incompleteFromTerminologies);
+            return client.search(query, ConceptSearchResultDTO.class);
+        }
+        return null;
+    }
+
+    private static Map<String, Long> getBucketValues(SearchResponse<? extends IndexBase> response, String aggregateName) {
+        var aggregation = response.aggregations().get(aggregateName);
+
+        if (aggregation == null) {
+            return Collections.emptyMap();
+        }
+        return aggregation
+                .sterms()
+                .buckets()
+                .array()
+                .stream()
+                .collect(Collectors.toMap(StringTermsBucket::key, StringTermsBucket::docCount));
     }
 }

--- a/src/test/java/fi/vm/yti/terminology/api/v2/opensearch/CountQueryFactoryTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/opensearch/CountQueryFactoryTest.java
@@ -1,0 +1,31 @@
+package fi.vm.yti.terminology.api.v2.opensearch;
+
+import fi.vm.yti.terminology.api.v2.TestUtils;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.util.Set;
+
+import static fi.vm.yti.common.opensearch.OpenSearchUtil.getPayload;
+
+class CountQueryFactoryTest {
+
+    @Test
+    void testTerminologyCounts() throws Exception {
+        var request = new TerminologySearchRequest();
+        var query = CountQueryFactory.createTerminologyCountQuery(request, TestUtils.mockUser, Set.of(), Set.of());
+
+        var expected = TestUtils.getJsonString("/opensearch/terminology-count-query.json");
+        JSONAssert.assertEquals(expected, getPayload(query), JSONCompareMode.LENIENT);
+    }
+
+    @Test
+    void testConceptCountQuery() throws Exception {
+        var request = new ConceptSearchRequest();
+        var query = CountQueryFactory.createConceptCountQuery(request, false, Set.of());
+
+        var expected = TestUtils.getJsonString("/opensearch/concept-count-query.json");
+        JSONAssert.assertEquals(expected, getPayload(query), JSONCompareMode.LENIENT);
+    }
+}

--- a/src/test/resources/opensearch/concept-count-query.json
+++ b/src/test/resources/opensearch/concept-count-query.json
@@ -1,0 +1,38 @@
+{
+  "aggregations": {
+    "statuses": {
+      "terms": {
+        "field": "status",
+        "size": 100
+      }
+    }
+  },
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "terms": {
+            "status": [
+              "DRAFT",
+              "VALID",
+              "INCOMPLETE"
+            ]
+          }
+        },
+        {
+          "bool": {
+            "must_not": [
+              {
+                "terms": {
+                  "status": [
+                    "INCOMPLETE"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/opensearch/terminology-count-query.json
+++ b/src/test/resources/opensearch/terminology-count-query.json
@@ -1,0 +1,52 @@
+{
+  "aggregations": {
+    "languages": {
+      "terms": {
+        "field": "languages",
+        "size": 100
+      }
+    },
+    "statuses": {
+      "terms": {
+        "field": "status",
+        "size": 100
+      }
+    },
+    "groups": {
+      "terms": {
+        "field": "groups",
+        "size": 100
+      }
+    }
+  },
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "bool": {
+            "must_not": [
+              {
+                "term": {
+                  "status": {
+                    "value": "INCOMPLETE"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "terms": {
+            "status": [
+              "DRAFT",
+              "INCOMPLETE",
+              "SUGGESTED",
+              "VALID"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "size": 0
+}


### PR DESCRIPTION
Implement count queries:
- GET /terminology-api/v2/frontend/counts
- GET /terminology-api/v2/frontend/concept-counts
- GET /terminology-api/v2/frontend/status-counts

Other fix: remove old terms from the model, when updating concept