### PR TITLE
YTI-4260 support multiple namespaces in concept search

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptQueryFactory.java
@@ -95,6 +95,14 @@ public class ConceptQueryFactory {
                             .field("namespace")
                             .value(FieldValue.of(request.getNamespace())))
                     .toQuery());
+        } else if (!request.getNamespaces().isEmpty()) {
+            allQueries.add(TermsQuery.of(q -> q
+                            .field("namespace")
+                            .terms(t -> t.value(request.getNamespaces()
+                                    .stream()
+                                    .map(FieldValue::of)
+                                    .toList())))
+                    .toQuery());
         }
 
         if (request.getExcludeNamespace() != null) {

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptSearchRequest.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptSearchRequest.java
@@ -2,8 +2,11 @@ package fi.vm.yti.terminology.api.v2.opensearch;
 
 import fi.vm.yti.common.opensearch.BaseSearchRequest;
 
+import java.util.Set;
+
 public class ConceptSearchRequest extends BaseSearchRequest {
     private String namespace;
+    private Set<String> namespaces = Set.of();
     private String excludeNamespace;
     private boolean extendTerminologies;
 
@@ -13,6 +16,14 @@ public class ConceptSearchRequest extends BaseSearchRequest {
 
     public void setNamespace(String namespace) {
         this.namespace = namespace;
+    }
+
+    public Set<String> getNamespaces() {
+        return namespaces;
+    }
+
+    public void setNamespaces(Set<String> namespaces) {
+        this.namespaces = namespaces;
     }
 
     public String getExcludeNamespace() {


### PR DESCRIPTION
This is needed in datamodel application when searching concepts from all linked terminologies.