### PR TITLE
Terminology api release fixes

### DIFF
--- a/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedMigrationController.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/migration/v1/TermedMigrationController.java
@@ -26,7 +26,12 @@ public class TermedMigrationController {
         migrationService.migrate(terminologyId);
     }
 
-    @PostMapping("/all")
+    @PostMapping("/termed-id-update")
+    void updateTermedId() {
+        migrationService.updateTermedIds();
+    }
+
+    // @PostMapping("/all")
     void migrateAll() throws URISyntaxException {
         migrationService.migrateAll();
     }


### PR DESCRIPTION
- update termed ids for terminologies. Previously termed node's id was added to terminology metadata, correct id is termed graph id
- fix query for getting resource type during resolving (add graph to where condition, otherwise uses default graph)
- fix resolving resources which id starts with digit (add prefix 'a' to id)
- disable migrateAll endpoint