### PR TITLE
YTI-4284 search fixes

### DIFF
--- a/src/test/java/fi/vm/yti/terminology/api/v2/service/TerminologyServiceTest.java
+++ b/src/test/java/fi/vm/yti/terminology/api/v2/service/TerminologyServiceTest.java
@@ -52,6 +52,9 @@ class TerminologyServiceTest {
 
     @MockBean
     private GroupManagementService groupManagementService;
+
+    @MockBean
+    private UriResolveService uriResolveService;
     
     @Autowired
     TerminologyService terminologyService;

--- a/src/test/resources/opensearch/terminology-deep-request.json
+++ b/src/test/resources/opensearch/terminology-deep-request.json
@@ -12,12 +12,38 @@
       "should": [
         {
           "bool": {
-            "minimum_should_match": "1",
-            "should": [
+            "must": [
               {
                 "terms": {
                   "uri": [
                     "https://iri.test/terminology/terminology1/"
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "minimum_should_match": "1",
+                  "should": [
+                    {
+                      "terms": {
+                        "organizations": [
+                          "d1f9f5fc-3aca-11ef-8006-7ef97ea86967"
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "must_not": [
+                          {
+                            "term": {
+                              "status": {
+                                "value": "INCOMPLETE"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
                   ]
                 }
               }

--- a/src/test/resources/opensearch/terminology-deep-superuser-request.json
+++ b/src/test/resources/opensearch/terminology-deep-superuser-request.json
@@ -1,6 +1,5 @@
 {
   "from": 0,
-  "size": 100,
   "highlight": {
     "fields": {
       "label.*": {}
@@ -11,16 +10,9 @@
       "minimum_should_match": "1",
       "should": [
         {
-          "bool": {
-            "minimum_should_match": "1",
-            "should": [
-              {
-                "terms": {
-                  "uri": [
-                    "https://iri.test/terminology/terminology1/"
-                  ]
-                }
-              }
+          "terms": {
+            "uri": [
+              "https://iri.test/terminology/terminology1/"
             ]
           }
         },
@@ -66,5 +58,6 @@
         }
       ]
     }
-  }
+  },
+  "size": 100
 }


### PR DESCRIPTION
Add incomplete check also to additional terminologies query, because concept search might find e.g. draft concepts from incomplete terminology. Add also same query string handling implemented in [datamodel application](https://github.com/VRK-YTI/yti-datamodel-api/pull/332).

Other change: when fetching terminology, check if the prefix is in UUID format. If so, check whether it is a termed graph id.