### PR TITLE
add custom health checks for fuseki/opensearch connection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
 
     implementation "fi.vm.yti:yti-spring-security:0.4.0"
     implementation "fi.vm.yti:yti-spring-migration:0.3.0"
-    implementation "fi.vm.yti:yti-common-backend:0.3.0"
+    implementation "fi.vm.yti:yti-common-backend:0.4.0"
 
     implementation "org.springframework.cloud:spring-cloud-starter-config"
 

--- a/src/main/java/fi/vm/yti/terminology/api/v2/health/FusekiHealthChecker.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/health/FusekiHealthChecker.java
@@ -1,0 +1,31 @@
+package fi.vm.yti.terminology.api.v2.health;
+
+import fi.vm.yti.terminology.api.v2.repository.TerminologyRepository;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "health.fuseki.enabled", havingValue = "true", matchIfMissing = true)
+public class FusekiHealthChecker implements HealthIndicator {
+    private final TerminologyRepository repository;
+
+    public FusekiHealthChecker(TerminologyRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Health health() {
+        try {
+            return repository.isHealthy() ?
+                    Health.up().withDetail("fuseki_connection", "OK").build() :
+                    Health.down().withDetail("fuseki_connection", "NOT OK").build();
+        } catch (Exception e) {
+            return Health.down()
+                    .withDetail("fuseki_connection", "NOT OK")
+                    .withDetail("exception", e.getMessage())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/fi/vm/yti/terminology/api/v2/health/OpenSearchHealthChecker.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/health/OpenSearchHealthChecker.java
@@ -1,0 +1,25 @@
+package fi.vm.yti.terminology.api.v2.health;
+
+import fi.vm.yti.common.opensearch.OpenSearchClientWrapper;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "health.opensearch.enabled", havingValue = "true", matchIfMissing = true)
+public class OpenSearchHealthChecker implements HealthIndicator {
+    private final OpenSearchClientWrapper openSearchClient;
+
+    public OpenSearchHealthChecker(OpenSearchClientWrapper openSearchClient) {
+        this.openSearchClient = openSearchClient;
+    }
+
+    @Override
+    public Health health() {
+        if (openSearchClient.isHealthy()) {
+            return Health.up().withDetail("opensearch_connection", "OK").build();
+        }
+        return Health.down().withDetail("opensearch_connection", "NOT OK").build();
+    }
+}

--- a/src/main/resources/config/application-template.properties
+++ b/src/main/resources/config/application-template.properties
@@ -13,3 +13,13 @@ openSearch.initOnStartUp=true
 openSearch.bulkMaxSize=300
 
 fake.login.allowed=true
+
+# custom health indicators are enabled by default
+health.opensearch.enabled=false
+health.fuseki.enabled=false
+
+#management.endpoint.health.show-details=always
+
+# add health indicators to appropriate groups for use with readiness/liveness checks
+management.endpoint.health.group.readiness.include=ping,openSearchHealthChecker,fusekiHealthChecker
+management.endpoint.health.group.liveness.include=ping


### PR DESCRIPTION
This will allow having readiness probes in kubernetes to stop traffic if the backend services are down.