### PR TITLE
YTI-4385 - Improve label search and fix special character handling in search queries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 
     implementation "fi.vm.yti:yti-spring-security:0.5.0"
     implementation "fi.vm.yti:yti-spring-migration:0.3.0"
-    implementation "fi.vm.yti:yti-common-backend:0.8.0-SNAPSHOT"
+    implementation "fi.vm.yti:yti-common-backend:0.8.0"
 
     implementation "org.springframework.cloud:spring-cloud-starter-config"
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 
     implementation "fi.vm.yti:yti-spring-security:0.5.0"
     implementation "fi.vm.yti:yti-spring-migration:0.3.0"
-    implementation "fi.vm.yti:yti-common-backend:0.7.0"
+    implementation "fi.vm.yti:yti-common-backend:0.8.0"
 
     implementation "org.springframework.cloud:spring-cloud-starter-config"
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 
     implementation "fi.vm.yti:yti-spring-security:0.5.0"
     implementation "fi.vm.yti:yti-spring-migration:0.3.0"
-    implementation "fi.vm.yti:yti-common-backend:0.8.0"
+    implementation "fi.vm.yti:yti-common-backend:0.8.0-SNAPSHOT"
 
     implementation "org.springframework.cloud:spring-cloud-starter-config"
 

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptQueryFactory.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static fi.vm.yti.common.opensearch.OpenSearchUtil.logPayload;
+import static fi.vm.yti.common.opensearch.QueryFactoryUtils.escapeWildcard;
 
 public class ConceptQueryFactory {
     private ConceptQueryFactory() {
@@ -65,9 +66,9 @@ public class ConceptQueryFactory {
             // In case of a single word, search exact match (with fuzzy) or with wild cards. Exact match will be ranked higher.
             final var query = qs.contains(" ")
                     ? Arrays.stream(qs.split("\\s+"))
-                        .map(q -> String.format("*%s*", q))
+                        .map(q -> String.format("*%s*", escapeWildcard(q)))
                         .collect(Collectors.joining(" "))
-                    : String.format("%s~1 *%s*", qs, qs);
+                    : String.format("%s~1 *%s*", escapeWildcard(qs), escapeWildcard(qs));
 
             var definitionQuery = QueryStringQuery.of(q -> q
                     .query(query)

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/ConceptQueryFactory.java
@@ -63,12 +63,12 @@ public class ConceptQueryFactory {
             var qs = queryString.trim();
 
             // If there are spaces in the query, add quotations to search with an exact phrase.
-            // In case of a single word, search exact match (with fuzzy) or with wild cards. Exact match will be ranked higher.
+            // In case of a single word, search exact match or with wild cards. Exact match will be ranked higher.
             final var query = qs.contains(" ")
                     ? Arrays.stream(qs.split("\\s+"))
                         .map(q -> String.format("*%s*", escapeWildcard(q)))
                         .collect(Collectors.joining(" "))
-                    : String.format("%s~1 *%s*", escapeWildcard(qs), escapeWildcard(qs));
+                    : String.format("*%s*", escapeWildcard(qs));
 
             var definitionQuery = QueryStringQuery.of(q -> q
                     .query(query)

--- a/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologyQueryFactory.java
+++ b/src/main/java/fi/vm/yti/terminology/api/v2/opensearch/TerminologyQueryFactory.java
@@ -16,6 +16,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static fi.vm.yti.common.opensearch.OpenSearchUtil.logPayload;
+import static fi.vm.yti.common.opensearch.QueryFactoryUtils.labelQuery;
 
 public class TerminologyQueryFactory {
 
@@ -126,11 +127,7 @@ public class TerminologyQueryFactory {
         //
         var queryString = request.getQuery();
         if (queryString != null && !queryString.isBlank()) {
-            mustQueries.add(QueryBuilders.bool()
-                    .should(QueryFactoryUtils.labelQuery(queryString))
-                    .minimumShouldMatch("1")
-                    .build()
-                    .toQuery());
+            mustQueries.add(labelQuery(queryString));
         }
 
         //

--- a/src/test/resources/integration/resource-search-request.json
+++ b/src/test/resources/integration/resource-search-request.json
@@ -3,11 +3,7 @@
     "bool": {
       "must": [
         {
-          "terms": {
-            "namespace": [
-              "https://iri.suomi.fi/terminology/test/"
-            ]
-          }
+          "terms": { "namespace": ["https://iri.suomi.fi/terminology/test/"] }
         },
         {
           "range": {
@@ -18,21 +14,36 @@
           }
         },
         {
-          "query_string": {
-            "default_operator": "or",
-            "fields": [
-              "label.*"
-            ],
-            "query": "Search~1 *Search*"
+          "bool": {
+            "minimum_should_match": "1",
+            "should": [
+              {
+                "multi_match": {
+                  "boost": 3.0,
+                  "fields": ["label.*"],
+                  "operator": "and",
+                  "query": "Search"
+                }
+              },
+              {
+                "multi_match": {
+                  "boost": 2.0,
+                  "fields": ["label.*.edge"],
+                  "operator": "and",
+                  "query": "Search"
+                }
+              },
+              {
+                "multi_match": {
+                  "fields": ["label.*.ngram"],
+                  "operator": "or",
+                  "query": "Search"
+                }
+              }
+            ]
           }
         },
-        {
-          "term": {
-            "status": {
-              "value": "DRAFT"
-            }
-          }
-        }
+        { "term": { "status": { "value": "DRAFT" } } }
       ]
     }
   },

--- a/src/test/resources/integration/resource-search-request.json
+++ b/src/test/resources/integration/resource-search-request.json
@@ -36,7 +36,7 @@
               {
                 "multi_match": {
                   "fields": ["label.*.ngram"],
-                  "operator": "or",
+                  "operator": "and",
                   "query": "Search"
                 }
               }

--- a/src/test/resources/opensearch/concept-exceptions-request.json
+++ b/src/test/resources/opensearch/concept-exceptions-request.json
@@ -18,7 +18,7 @@
               "definition.*^3.0",
               "notRecommendedSynonym"
             ],
-            "query": "test~1 *test*"
+            "query": "*test*"
           }
         },
         {

--- a/src/test/resources/opensearch/concept-request.json
+++ b/src/test/resources/opensearch/concept-request.json
@@ -17,7 +17,7 @@
               "definition.*^3.0",
               "notRecommendedSynonym"
             ],
-            "query": "test~1 *test*"
+            "query": "*test*"
           }
         },
         {

--- a/src/test/resources/opensearch/concept-superuser-request.json
+++ b/src/test/resources/opensearch/concept-superuser-request.json
@@ -18,7 +18,7 @@
               "definition.*^3.0",
               "notRecommendedSynonym"
             ],
-            "query": "test~1 *test*"
+            "query": "*test*"
           }
         },
         {

--- a/src/test/resources/opensearch/terminology-deep-request.json
+++ b/src/test/resources/opensearch/terminology-deep-request.json
@@ -3,20 +3,34 @@
   "highlight": { "fields": { "label.*": {} } },
   "query": {
     "bool": {
-      "must": [
+      "minimum_should_match": "1",
+      "should": [
         {
           "bool": {
-            "minimum_should_match": "1",
-            "should": [
+            "must": [
               {
                 "terms": {
-                  "organizations": ["d1f9f5fc-3aca-11ef-8006-7ef97ea86967"]
+                  "uri": ["https://iri.test/terminology/terminology1/"]
                 }
               },
               {
                 "bool": {
-                  "must_not": [
-                    { "term": { "status": { "value": "INCOMPLETE" } } }
+                  "minimum_should_match": "1",
+                  "should": [
+                    {
+                      "terms": {
+                        "organizations": [
+                          "d1f9f5fc-3aca-11ef-8006-7ef97ea86967"
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "must_not": [
+                          { "term": { "status": { "value": "INCOMPLETE" } } }
+                        ]
+                      }
+                    }
                   ]
                 }
               }
@@ -24,13 +38,29 @@
           }
         },
         {
-          "terms": { "status": ["DRAFT", "INCOMPLETE", "SUGGESTED", "VALID"] }
-        },
-        { "terms": { "groups": ["P11", "P1"] } },
-        {
           "bool": {
-            "minimum_should_match": "1",
-            "should": [
+            "must": [
+              {
+                "bool": {
+                  "minimum_should_match": "1",
+                  "should": [
+                    {
+                      "terms": {
+                        "organizations": [
+                          "d1f9f5fc-3aca-11ef-8006-7ef97ea86967"
+                        ]
+                      }
+                    },
+                    {
+                      "bool": {
+                        "must_not": [
+                          { "term": { "status": { "value": "INCOMPLETE" } } }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
               {
                 "bool": {
                   "minimum_should_match": "1",
@@ -54,7 +84,7 @@
                     {
                       "multi_match": {
                         "fields": ["label.*.ngram"],
-                        "operator": "or",
+                        "operator": "and",
                         "query": "test"
                       }
                     }
@@ -63,9 +93,10 @@
               },
               {
                 "terms": {
-                  "uri": ["https://iri.test/terminology/terminology1/"]
+                  "status": ["DRAFT", "INCOMPLETE", "SUGGESTED", "VALID"]
                 }
-              }
+              },
+              { "terms": { "groups": ["P1", "P11"] } }
             ]
           }
         }

--- a/src/test/resources/opensearch/terminology-deep-request.json
+++ b/src/test/resources/opensearch/terminology-deep-request.json
@@ -1,49 +1,22 @@
 {
   "from": 0,
-  "size": 100,
-  "highlight": {
-    "fields": {
-      "label.*": {}
-    }
-  },
+  "highlight": { "fields": { "label.*": {} } },
   "query": {
     "bool": {
-      "minimum_should_match": "1",
-      "should": [
+      "must": [
         {
           "bool": {
-            "must": [
+            "minimum_should_match": "1",
+            "should": [
               {
                 "terms": {
-                  "uri": [
-                    "https://iri.test/terminology/terminology1/"
-                  ]
+                  "organizations": ["d1f9f5fc-3aca-11ef-8006-7ef97ea86967"]
                 }
               },
               {
                 "bool": {
-                  "minimum_should_match": "1",
-                  "should": [
-                    {
-                      "terms": {
-                        "organizations": [
-                          "d1f9f5fc-3aca-11ef-8006-7ef97ea86967"
-                        ]
-                      }
-                    },
-                    {
-                      "bool": {
-                        "must_not": [
-                          {
-                            "term": {
-                              "status": {
-                                "value": "INCOMPLETE"
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    }
+                  "must_not": [
+                    { "term": { "status": { "value": "INCOMPLETE" } } }
                   ]
                 }
               }
@@ -51,46 +24,38 @@
           }
         },
         {
+          "terms": { "status": ["DRAFT", "INCOMPLETE", "SUGGESTED", "VALID"] }
+        },
+        { "terms": { "groups": ["P11", "P1"] } },
+        {
           "bool": {
-            "must": [
+            "minimum_should_match": "1",
+            "should": [
               {
                 "bool": {
                   "minimum_should_match": "1",
                   "should": [
                     {
-                      "terms": {
-                        "organizations": [
-                          "d1f9f5fc-3aca-11ef-8006-7ef97ea86967"
-                        ]
+                      "multi_match": {
+                        "boost": 3.0,
+                        "fields": ["label.*"],
+                        "operator": "and",
+                        "query": "test"
                       }
                     },
                     {
-                      "bool": {
-                        "must_not": [
-                          {
-                            "term": {
-                              "status": {
-                                "value": "INCOMPLETE"
-                              }
-                            }
-                          }
-                        ]
+                      "multi_match": {
+                        "boost": 2.0,
+                        "fields": ["label.*.edge"],
+                        "operator": "and",
+                        "query": "test"
                       }
-                    }
-                  ]
-                }
-              },
-              {
-                "bool": {
-                  "minimum_should_match": "1",
-                  "should": [
+                    },
                     {
-                      "query_string": {
-                        "default_operator": "or",
-                        "fields": [
-                          "label.*"
-                        ],
-                        "query": "test~1 *test*"
+                      "multi_match": {
+                        "fields": ["label.*.ngram"],
+                        "operator": "or",
+                        "query": "test"
                       }
                     }
                   ]
@@ -98,20 +63,7 @@
               },
               {
                 "terms": {
-                  "status": [
-                    "DRAFT",
-                    "INCOMPLETE",
-                    "SUGGESTED",
-                    "VALID"
-                  ]
-                }
-              },
-              {
-                "terms": {
-                  "groups": [
-                    "P11",
-                    "P1"
-                  ]
+                  "uri": ["https://iri.test/terminology/terminology1/"]
                 }
               }
             ]
@@ -119,5 +71,6 @@
         }
       ]
     }
-  }
+  },
+  "size": 100
 }

--- a/src/test/resources/opensearch/terminology-deep-superuser-request.json
+++ b/src/test/resources/opensearch/terminology-deep-superuser-request.json
@@ -1,35 +1,42 @@
 {
   "from": 0,
-  "highlight": {
-    "fields": {
-      "label.*": {}
-    }
-  },
+  "highlight": { "fields": { "label.*": {} } },
   "query": {
     "bool": {
-      "minimum_should_match": "1",
-      "should": [
+      "must": [
         {
-          "terms": {
-            "uri": [
-              "https://iri.test/terminology/terminology1/"
-            ]
-          }
+          "terms": { "status": ["DRAFT", "INCOMPLETE", "SUGGESTED", "VALID"] }
         },
+        { "terms": { "groups": ["P1", "P11"] } },
         {
           "bool": {
-            "must": [
+            "minimum_should_match": "1",
+            "should": [
               {
                 "bool": {
                   "minimum_should_match": "1",
                   "should": [
                     {
-                      "query_string": {
-                        "default_operator": "or",
-                        "fields": [
-                          "label.*"
-                        ],
-                        "query": "test~1 *test*"
+                      "multi_match": {
+                        "boost": 3.0,
+                        "fields": ["label.*"],
+                        "operator": "and",
+                        "query": "test"
+                      }
+                    },
+                    {
+                      "multi_match": {
+                        "boost": 2.0,
+                        "fields": ["label.*.edge"],
+                        "operator": "and",
+                        "query": "test"
+                      }
+                    },
+                    {
+                      "multi_match": {
+                        "fields": ["label.*.ngram"],
+                        "operator": "or",
+                        "query": "test"
                       }
                     }
                   ]
@@ -37,20 +44,7 @@
               },
               {
                 "terms": {
-                  "status": [
-                    "DRAFT",
-                    "INCOMPLETE",
-                    "SUGGESTED",
-                    "VALID"
-                  ]
-                }
-              },
-              {
-                "terms": {
-                  "groups": [
-                    "P1",
-                    "P11"
-                  ]
+                  "uri": ["https://iri.test/terminology/terminology1/"]
                 }
               }
             ]

--- a/src/test/resources/opensearch/terminology-deep-superuser-request.json
+++ b/src/test/resources/opensearch/terminology-deep-superuser-request.json
@@ -3,15 +3,12 @@
   "highlight": { "fields": { "label.*": {} } },
   "query": {
     "bool": {
-      "must": [
-        {
-          "terms": { "status": ["DRAFT", "INCOMPLETE", "SUGGESTED", "VALID"] }
-        },
-        { "terms": { "groups": ["P1", "P11"] } },
+      "minimum_should_match": "1",
+      "should": [
+        { "terms": { "uri": ["https://iri.test/terminology/terminology1/"] } },
         {
           "bool": {
-            "minimum_should_match": "1",
-            "should": [
+            "must": [
               {
                 "bool": {
                   "minimum_should_match": "1",
@@ -35,7 +32,7 @@
                     {
                       "multi_match": {
                         "fields": ["label.*.ngram"],
-                        "operator": "or",
+                        "operator": "and",
                         "query": "test"
                       }
                     }
@@ -44,9 +41,10 @@
               },
               {
                 "terms": {
-                  "uri": ["https://iri.test/terminology/terminology1/"]
+                  "status": ["DRAFT", "INCOMPLETE", "SUGGESTED", "VALID"]
                 }
-              }
+              },
+              { "terms": { "groups": ["P1", "P11"] } }
             ]
           }
         }

--- a/src/test/resources/opensearch/terminology-request.json
+++ b/src/test/resources/opensearch/terminology-request.json
@@ -1,59 +1,48 @@
 {
   "from": 0,
-  "size": 100,
-  "highlight": {
-    "fields": {
-      "label.*": {}
-    }
-  },
+  "highlight": { "fields": { "label.*": {} } },
   "query": {
     "bool": {
       "must": [
         {
           "bool": {
-            "must_not": [
-              {
-                "term": {
-                  "status": {
-                    "value": "INCOMPLETE"
-                  }
-                }
-              }
-            ]
+            "must_not": [{ "term": { "status": { "value": "INCOMPLETE" } } }]
           }
         },
+        { "terms": { "status": ["VALID"] } },
+        { "terms": { "groups": ["P1", "P11"] } },
         {
           "bool": {
             "minimum_should_match": "1",
             "should": [
               {
-                "query_string": {
-                  "default_operator": "or",
-                  "fields": [
-                    "label.*"
-                  ],
-                  "query": "test~1 *test*"
+                "multi_match": {
+                  "boost": 3.0,
+                  "fields": ["label.*"],
+                  "operator": "and",
+                  "query": "test"
+                }
+              },
+              {
+                "multi_match": {
+                  "boost": 2.0,
+                  "fields": ["label.*.edge"],
+                  "operator": "and",
+                  "query": "test"
+                }
+              },
+              {
+                "multi_match": {
+                  "fields": ["label.*.ngram"],
+                  "operator": "or",
+                  "query": "test"
                 }
               }
-            ]
-          }
-        },
-        {
-          "terms": {
-            "status": [
-              "VALID"
-            ]
-          }
-        },
-        {
-          "terms": {
-            "groups": [
-              "P11",
-              "P1"
             ]
           }
         }
       ]
     }
-  }
+  },
+  "size": 100
 }

--- a/src/test/resources/opensearch/terminology-request.json
+++ b/src/test/resources/opensearch/terminology-request.json
@@ -9,8 +9,6 @@
             "must_not": [{ "term": { "status": { "value": "INCOMPLETE" } } }]
           }
         },
-        { "terms": { "status": ["VALID"] } },
-        { "terms": { "groups": ["P1", "P11"] } },
         {
           "bool": {
             "minimum_should_match": "1",
@@ -34,13 +32,15 @@
               {
                 "multi_match": {
                   "fields": ["label.*.ngram"],
-                  "operator": "or",
+                  "operator": "and",
                   "query": "test"
                 }
               }
             ]
           }
-        }
+        },
+        { "terms": { "status": ["VALID"] } },
+        { "terms": { "groups": ["P11", "P1"] } }
       ]
     }
   },


### PR DESCRIPTION
This PR updates `common-backend` to 0.8.0 and utilizes the updated `labelQuery` as well as a newly added `escapeWildcard` from there. With these changes special characters should now be escaped correctly in queries and search should use ngrams for short query strings and wildcard search for longer ones. Fuzziness is also removed from term queries in order to reduce noise in search results.